### PR TITLE
feat: Add dejavu detection to upload commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "mx"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "blake3",


### PR DESCRIPTION
## Summary
- Detect when both title and body randomly receive the same dictionary
- Add decode hint to footer only on dejavu
- Observation, not forcing - watching the system for coincidence

Closes #2