### PR TITLE
Dependency cleanup and Edition 2024 migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/coryzibell/mx"
 clap = { version = "4", features = ["derive"] }
 
 # SQLite
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -21,7 +21,6 @@ serde_yaml = "0.9"
 
 # File system
 walkdir = "2"
-notify = "6"
 
 # Error handling
 anyhow = "1"
@@ -30,17 +29,14 @@ thiserror = "2"
 # Time
 chrono = { version = "0.4", features = ["serde"] }
 
-# Markdown parsing
-pulldown-cmark = "0.12"
-
 # Paths
-dirs = "5"
+dirs = "6"
 
 # Random
 rand = "0.9"
 
 # base-d library
-base-d = "2"
+base-d = "3"
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }
@@ -48,7 +44,8 @@ urlencoding = "2"
 regex = "1.12.2"
 
 # JWT for GitHub App auth
-jsonwebtoken = "9"
+jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto"] }
+pem = "3"
 lazy_static = "1"
 
 # Temporary directories

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -8,7 +8,7 @@
 //! Dejavu detection: When both title and body randomly get the same
 //! dictionary, we add "whoa." to the footer.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use base_d::prelude::*;
 use std::process::Command;
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::sync::yaml::schema::{slugify, SyncYaml};
+use crate::sync::yaml::schema::{SyncYaml, slugify};
 
 /// Parse markdown file to YAML structure
 pub fn parse_markdown(content: &str) -> Result<SyncYaml> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 use std::path::Path;
 
 use crate::knowledge::KnowledgeEntry;

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use base_d::{encode, hash, DictionaryRegistry, HashAlgorithm};
+use base_d::{DictionaryRegistry, HashAlgorithm, encode, hash};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use clap::{Parser, Subcommand};
 
 use crate::db::Database;
 use crate::index::{
-    export_csv, export_jsonl, export_markdown, import_jsonl, rebuild_index, IndexConfig,
+    IndexConfig, export_csv, export_jsonl, export_markdown, import_jsonl, rebuild_index,
 };
 
 #[derive(Parser)]
@@ -948,10 +948,10 @@ fn handle_agents(cmd: AgentsCommands, config: &IndexConfig) -> Result<()> {
                 }
 
                 // Skip files starting with _
-                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    if name.starts_with('_') {
-                        continue;
-                    }
+                if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                    && name.starts_with('_')
+                {
+                    continue;
                 }
 
                 // Read file
@@ -959,19 +959,19 @@ fn handle_agents(cmd: AgentsCommands, config: &IndexConfig) -> Result<()> {
                     .with_context(|| format!("Failed to read file: {:?}", path))?;
 
                 // Parse frontmatter
-                if let Some((frontmatter, _body)) = parse_frontmatter(&content) {
-                    if let Ok(agent_data) = serde_yaml::from_str::<AgentFrontmatter>(&frontmatter) {
-                        let agent = db::Agent {
-                            id: agent_data.name.clone(),
-                            description: Some(agent_data.description.clone()),
-                            domain: agent_data.domain,
-                            created_at: Some(now.clone()),
-                            updated_at: Some(now.clone()),
-                        };
+                if let Some((frontmatter, _body)) = parse_frontmatter(&content)
+                    && let Ok(agent_data) = serde_yaml::from_str::<AgentFrontmatter>(&frontmatter)
+                {
+                    let agent = db::Agent {
+                        id: agent_data.name.clone(),
+                        description: Some(agent_data.description.clone()),
+                        domain: agent_data.domain,
+                        created_at: Some(now.clone()),
+                        updated_at: Some(now.clone()),
+                    };
 
-                        db.upsert_agent(&agent)?;
-                        seeded.push(agent_data.name);
-                    }
+                    db.upsert_agent(&agent)?;
+                    seeded.push(agent_data.name);
                 }
             }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -167,17 +167,17 @@ fn find_most_recent_session() -> Result<PathBuf> {
             }
 
             // Skip agent sessions
-            if let Some(name) = file_path.file_name().and_then(|n| n.to_str()) {
-                if name.starts_with("agent-") {
-                    continue;
-                }
+            if let Some(name) = file_path.file_name().and_then(|n| n.to_str())
+                && name.starts_with("agent-")
+            {
+                continue;
             }
 
             // Get modification time
-            if let Ok(metadata) = file_entry.metadata() {
-                if let Ok(modified) = metadata.modified() {
-                    sessions.push((file_path, modified));
-                }
+            if let Ok(metadata) = file_entry.metadata()
+                && let Ok(modified) = metadata.modified()
+            {
+                sessions.push((file_path, modified));
             }
         }
     }

--- a/src/sync/commands/pull.rs
+++ b/src/sync/commands/pull.rs
@@ -7,7 +7,7 @@ use crate::sync::default_sync_dir;
 use crate::sync::github::auth::get_github_token;
 use crate::sync::github::graphql::GraphQLClient;
 use crate::sync::github::rest::RestClient;
-use crate::sync::yaml::schema::{yaml_filename, Comment, LastSynced, Metadata, SyncYaml};
+use crate::sync::yaml::schema::{Comment, LastSynced, Metadata, SyncYaml, yaml_filename};
 use crate::sync::yaml::store::YamlStore;
 
 /// Run the pull command

--- a/src/sync/commands/push.rs
+++ b/src/sync/commands/push.rs
@@ -12,7 +12,7 @@ use crate::sync::github::auth::get_github_token;
 use crate::sync::github::graphql::GraphQLClient;
 use crate::sync::github::rest::{CreateIssueRequest, RestClient, UpdateIssueRequest};
 use crate::sync::merge::resolve::merge_fields;
-use crate::sync::yaml::schema::{yaml_filename, ItemType, LastSynced};
+use crate::sync::yaml::schema::{ItemType, LastSynced, yaml_filename};
 use crate::sync::yaml::store::YamlStore;
 
 /// Run the push command

--- a/src/sync/github/app_auth.rs
+++ b/src/sync/github/app_auth.rs
@@ -6,7 +6,7 @@
 //! - DOTMATRIX_PRIVATE_KEY: Full PEM private key content
 
 use anyhow::{Context, Result};
-use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::sync::{Arc, Mutex};
@@ -80,9 +80,8 @@ pub fn generate_jwt(app_id: &str, private_key: &str) -> Result<String> {
     let header = Header::new(Algorithm::RS256);
 
     // Parse PEM to DER for jsonwebtoken v10
-    let pem = pem::parse(private_key.as_bytes())
-        .context("Failed to parse PEM format")?;
-    let encoding_key = EncodingKey::from_rsa_der(&pem.contents());
+    let pem = pem::parse(private_key.as_bytes()).context("Failed to parse PEM format")?;
+    let encoding_key = EncodingKey::from_rsa_der(pem.contents());
 
     encode(&header, &claims, &encoding_key).context("Failed to encode JWT")
 }

--- a/src/sync/github/auth.rs
+++ b/src/sync/github/auth.rs
@@ -56,12 +56,11 @@ pub fn get_github_token() -> Result<String> {
 
     // Search through all projects for a GitHub token
     for project_config in config.projects.values() {
-        if let Some(github_server) = project_config.mcp_servers.get("github") {
-            if let Some(token) = github_server.env.get("GITHUB_PERSONAL_ACCESS_TOKEN") {
-                if !token.is_empty() {
-                    return Ok(token.clone());
-                }
-            }
+        if let Some(github_server) = project_config.mcp_servers.get("github")
+            && let Some(token) = github_server.env.get("GITHUB_PERSONAL_ACCESS_TOKEN")
+            && !token.is_empty()
+        {
+            return Ok(token.clone());
         }
     }
 

--- a/src/sync/github/graphql.rs
+++ b/src/sync/github/graphql.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use reqwest::blocking::Client;
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue, USER_AGENT};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -66,11 +66,11 @@ impl GraphQLClient {
         let result: GraphQLResponse<T> = serde_json::from_str(&text)
             .with_context(|| format!("Failed to parse GraphQL response: {}", text))?;
 
-        if let Some(errors) = result.errors {
-            if !errors.is_empty() {
-                let messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
-                anyhow::bail!("GraphQL errors: {}", messages.join(", "));
-            }
+        if let Some(errors) = result.errors
+            && !errors.is_empty()
+        {
+            let messages: Vec<_> = errors.iter().map(|e| e.message.as_str()).collect();
+            anyhow::bail!("GraphQL errors: {}", messages.join(", "));
         }
 
         result.data.context("No data in GraphQL response")

--- a/src/sync/github/rest.rs
+++ b/src/sync/github/rest.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use reqwest::blocking::Client;
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
 
 const GITHUB_API_BASE: &str = "https://api.github.com";

--- a/src/sync/merge/diff.rs
+++ b/src/sync/merge/diff.rs
@@ -92,25 +92,25 @@ impl DiffResult {
     pub fn summary(&self) -> Vec<String> {
         let mut changes = Vec::new();
 
-        if let Some(ref c) = self.title {
-            if c.has_changes() {
-                changes.push(format!("title: {}", change_type_str(c)));
-            }
+        if let Some(ref c) = self.title
+            && c.has_changes()
+        {
+            changes.push(format!("title: {}", change_type_str(c)));
         }
-        if let Some(ref c) = self.body {
-            if c.has_changes() {
-                changes.push(format!("body: {}", change_type_str(c)));
-            }
+        if let Some(ref c) = self.body
+            && c.has_changes()
+        {
+            changes.push(format!("body: {}", change_type_str(c)));
         }
-        if let Some(ref c) = self.labels {
-            if c.has_changes() {
-                changes.push(format!("labels: {}", change_type_str(c)));
-            }
+        if let Some(ref c) = self.labels
+            && c.has_changes()
+        {
+            changes.push(format!("labels: {}", change_type_str(c)));
         }
-        if let Some(ref c) = self.assignees {
-            if c.has_changes() {
-                changes.push(format!("assignees: {}", change_type_str(c)));
-            }
+        if let Some(ref c) = self.assignees
+            && c.has_changes()
+        {
+            changes.push(format!("assignees: {}", change_type_str(c)));
         }
 
         changes

--- a/src/sync/yaml/store.rs
+++ b/src/sync/yaml/store.rs
@@ -44,10 +44,10 @@ impl YamlStore {
             let entry = entry?;
             let path = entry.path();
 
-            if let Some(ext) = path.extension() {
-                if ext == "yaml" || ext == "yml" {
-                    files.push(path);
-                }
+            if let Some(ext) = path.extension()
+                && (ext == "yaml" || ext == "yml")
+            {
+                files.push(path);
             }
         }
 
@@ -99,10 +99,10 @@ impl YamlStore {
     /// Find a YAML file by GitHub issue number
     pub fn find_by_issue_number(&self, number: u64) -> Result<Option<(PathBuf, SyncYaml)>> {
         for path in self.list_files()? {
-            if let Ok(yaml) = self.read(&path) {
-                if yaml.metadata.github_issue_number == Some(number) {
-                    return Ok(Some((path, yaml)));
-                }
+            if let Ok(yaml) = self.read(&path)
+                && yaml.metadata.github_issue_number == Some(number)
+            {
+                return Ok(Some((path, yaml)));
             }
         }
         Ok(None)
@@ -111,10 +111,10 @@ impl YamlStore {
     /// Find a YAML file by GitHub discussion ID
     pub fn find_by_discussion_id(&self, id: &str) -> Result<Option<(PathBuf, SyncYaml)>> {
         for path in self.list_files()? {
-            if let Ok(yaml) = self.read(&path) {
-                if yaml.metadata.github_discussion_id.as_deref() == Some(id) {
-                    return Ok(Some((path, yaml)));
-                }
+            if let Ok(yaml) = self.read(&path)
+                && yaml.metadata.github_discussion_id.as_deref() == Some(id)
+            {
+                return Ok(Some((path, yaml)));
             }
         }
         Ok(None)
@@ -123,10 +123,10 @@ impl YamlStore {
     /// Find a YAML file by title (exact match)
     pub fn find_by_title(&self, title: &str) -> Result<Option<(PathBuf, SyncYaml)>> {
         for path in self.list_files()? {
-            if let Ok(yaml) = self.read(&path) {
-                if yaml.title() == title {
-                    return Ok(Some((path, yaml)));
-                }
+            if let Ok(yaml) = self.read(&path)
+                && yaml.title() == title
+            {
+                return Ok(Some((path, yaml)));
             }
         }
         Ok(None)


### PR DESCRIPTION
## Summary

Cleans up unused dependencies, upgrades outdated packages, and migrates to Rust Edition 2024.

## Changes

### Dependencies Removed
- `notify` - file watcher, unused
- `pulldown-cmark` - markdown parser, unused

### Dependencies Upgraded
- `dirs` 5.0.1 → 6.0.0 (API unchanged)
- `rusqlite` 0.32 → 0.37.0 (no breaking changes)
- `jsonwebtoken` 9 → 10.2.0 (breaking: added `pem` crate for PEM→DER conversion)

### Edition 2024 Migration
- Updated `edition = "2021"` → `edition = "2024"` in Cargo.toml
- Wrapped `env::remove_var` calls in `unsafe {}` block with SAFETY comment (required in Edition 2024)

## Test Plan

- [x] `cargo check` passes
- [x] All 63 tests pass (60 executed, 3 ignored integration tests)
- [x] No clippy warnings introduced

Closes #47