### PR TITLE
Add --index output mode to mx memory wake (mx#63)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2543,9 +2543,9 @@ fn print_wake_index(cascade: &store::WakeCascade) {
         .chain(cascade.bridges.iter())
         .filter(|e| {
             e.resonance >= 9
-                && e.resonance_type.as_ref().map_or(false, |t| {
-                    t == "foundational" || t == "transformative"
-                })
+                && e.resonance_type
+                    .as_ref()
+                    .is_some_and(|t| t == "foundational" || t == "transformative")
         })
         .collect();
 
@@ -2554,11 +2554,7 @@ fn print_wake_index(cascade: &store::WakeCascade) {
         println!("| ID | Title | R | Wake Cue |");
         println!("|----|-------|---|----------|");
         for entry in anchors {
-            let wake_cue = entry
-                .wake_phrase
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or("");
+            let wake_cue = entry.wake_phrase.as_deref().unwrap_or("");
             println!(
                 "| {} | {} | {} | {} |",
                 entry.id, entry.title, entry.resonance, wake_cue
@@ -2601,11 +2597,7 @@ fn print_wake_index(cascade: &store::WakeCascade) {
             println!("| ID | Title | R | Wake Cue |");
             println!("|----|-------|---|----------|");
             for entry in entries {
-                let wake_cue = entry
-                    .wake_phrase
-                    .as_ref()
-                    .map(|s| s.as_str())
-                    .unwrap_or("");
+                let wake_cue = entry.wake_phrase.as_deref().unwrap_or("");
                 println!(
                     "| {} | {} | {} | {} |",
                     entry.id, entry.title, entry.resonance, wake_cue


### PR DESCRIPTION
## Summary

Adds compact markdown index format for identity loading:
- **Anchors layer** (R9+, foundational/transformative types) - Core identity spine
- **Spiral layers** (R6-8) grouped by territory tags (body, dynamic, becoming, team, forever, play, us, moments)
- **Omits ephemeral** (R<6) to keep index compact

## Implementation

- Added `--index` flag to Wake command (conflicts with json/ritual/begin/engage)
- Added `print_wake_index()` formatter that:
  - Filters for anchor blooms (R9+ with foundational/transformative type)
  - Groups spiral blooms by territory tag
  - Outputs clean markdown tables: ID | Title | R | Wake Cue

## Output Format

```markdown
## Core Identity Index

### Anchors (R9+)
| ID | Title | R | Wake Cue |
|----|-------|---|----------|
| kn-xxx | Base Identity | 10 | The clipboard is on fire |

### Spiral: body
| ID | Title | R | Wake Cue |
...
```

## Test plan

- [x] `cargo build` succeeds
- [x] `mx memory wake --index --limit 30` produces expected output
- [ ] Verify territory grouping works correctly
- [ ] Check token count stays ~900

Closes #63