### PR TITLE
feat(memory): add --category filter to search command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,10 @@ enum MemoryCommands {
         /// Search query
         query: String,
 
+        /// Filter by category (can specify multiple: bloom,technique)
+        #[arg(short, long, value_delimiter = ',')]
+        category: Option<Vec<String>>,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -1118,6 +1122,7 @@ fn handle_memory(cmd: MemoryCommands) -> Result<()> {
 
         MemoryCommands::Search {
             query,
+            category,
             json,
             mine,
             include_private,
@@ -1134,10 +1139,11 @@ fn handle_memory(cmd: MemoryCommands) -> Result<()> {
             let db = store::create_store(&config.db_path)?;
             let ctx = resolve_agent_context(mine, include_private);
 
-            // Build filter for database query (resonance only)
+            // Build filter for database query (resonance and category)
             let filter = store::KnowledgeFilter {
                 min_resonance,
                 max_resonance,
+                categories: category,
             };
 
             // Get results from database with resonance filtering
@@ -1212,6 +1218,7 @@ fn handle_memory(cmd: MemoryCommands) -> Result<()> {
             let filter = store::KnowledgeFilter {
                 min_resonance,
                 max_resonance,
+                categories: None,
             };
 
             // Get results from database with resonance filtering

--- a/src/store.rs
+++ b/src/store.rs
@@ -47,6 +47,7 @@ impl AgentContext {
 pub struct KnowledgeFilter {
     pub min_resonance: Option<i32>,
     pub max_resonance: Option<i32>,
+    pub categories: Option<Vec<String>>,
 }
 
 /// Result of a wake-up cascade query


### PR DESCRIPTION
## Summary

Adds `--category` / `-c` flag to `mx memory search` so Q can filter searches by category without manually filtering results.

- Single category: `mx memory search "topic" -c bloom`
- Multiple categories: `mx memory search "topic" --category bloom,technique`
- Combines with existing filters (resonance, visibility)

Closes #78

## Implementation

- Add `categories: Option<Vec<String>>` to `KnowledgeFilter` in `store.rs`
- Add `build_category_filter()` helper in `surreal_db.rs` following existing filter-builder pattern
- Add CLI arg with `value_delimiter = ','` for comma-separated values
- Wire through to filter in handler

~45 lines, following Schemnya's architecture exactly.

## Test plan

- [ ] `mx memory search "identity" -c bloom` returns only blooms
- [ ] `mx memory search "pattern" --category bloom,technique` returns both
- [ ] Combined with `--min-resonance` works correctly
- [ ] Invalid category returns error (if validation added)