### PR TITLE
fix: Use central cache directory for fastembed

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use std::path::PathBuf;
 
 /// Trait for embedding providers
 pub trait EmbeddingProvider: Send + Sync {
@@ -25,8 +26,15 @@ pub struct FastEmbedProvider {
 
 impl FastEmbedProvider {
     pub fn new() -> Result<Self> {
+        // Use ~/.cache/fastembed instead of polluting working directories
+        let cache_dir = dirs::cache_dir()
+            .map(|d| d.join("fastembed"))
+            .unwrap_or_else(|| PathBuf::from(".fastembed_cache"));
+
         let model = TextEmbedding::try_new(
-            InitOptions::new(EmbeddingModel::BGEBaseENV15).with_show_download_progress(true),
+            InitOptions::new(EmbeddingModel::BGEBaseENV15)
+                .with_cache_dir(cache_dir)
+                .with_show_download_progress(true),
         )
         .context("Failed to initialize FastEmbed model")?;
 


### PR DESCRIPTION
## Summary

Fix fastembed cache pollution by using a central cache directory instead of the current working directory.

## Problem

fastembed was creating `.fastembed_cache/` (258MB+) in whatever directory `mx` was run from, polluting repos and nearly getting committed.

## Solution

Configure fastembed to use the XDG cache directory:
- Linux: `~/.cache/fastembed/`
- macOS: `~/Library/Caches/fastembed/`
- Fallback: `.fastembed_cache` (if cache_dir unavailable)

## Cleanup

After deploying, clean up existing scattered caches:
```bash
find ~/ -name ".fastembed_cache" -type d -exec rm -rf {} + 2>/dev/null
```

Closes #104