### PR TITLE
Add MX_CODEX_PATH environment variable override

### DIFF
--- a/src/codex.rs
+++ b/src/codex.rs
@@ -575,6 +575,9 @@ struct ArchiveEntry {
 }
 
 fn get_codex_dir() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("MX_CODEX_PATH") {
+        return Ok(PathBuf::from(path));
+    }
     let home = dirs::home_dir().context("Could not determine home directory")?;
     Ok(home.join(".crewu-private/logs/codex"))
 }


### PR DESCRIPTION
## Summary
- Adds `MX_CODEX_PATH` environment variable support for custom codex directory
- Falls back to existing default `~/.crewu-private/logs/codex` when not set
- Fixes #111

## Changes
Modified `get_codex_dir()` in `src/codex.rs` to check for env var before using default path.

## Test plan
- [x] Verify code compiles with `cargo check`
- [ ] Test with `MX_CODEX_PATH` set to custom location
- [ ] Test without env var set (should use default)