### PR TITLE
feat: Add mx memory reinforce command (Phase 1 of #119)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -81,6 +81,25 @@ pub struct EditResult {
     pub new_content: String,
 }
 
+/// Result of a reinforce operation
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ReinforcementResult {
+    /// Entry ID that was reinforced
+    pub id: String,
+    /// Previous resonance value
+    pub old_resonance: i32,
+    /// New resonance value (after increment and cap)
+    pub new_resonance: i32,
+    /// Amount added (before cap)
+    pub amount_added: i32,
+    /// Whether the cap was hit
+    pub capped: bool,
+    /// New last_activated timestamp
+    pub last_activated: String,
+    /// New activation count
+    pub activation_count: i32,
+}
+
 /// Abstract interface for knowledge storage backends (SQLite, SurrealDB, etc)
 pub trait KnowledgeStore {
     // =========================================================================
@@ -141,6 +160,17 @@ pub trait KnowledgeStore {
 
     /// Query recent ephemeral facts with decay computation
     fn query_recent_facts(&self, days: i32) -> Result<Vec<KnowledgeEntry>>;
+
+    /// Reinforce a knowledge entry (increment resonance, update last_activated, increment activation_count)
+    ///
+    /// # Arguments
+    /// * `id` - Entry ID to reinforce
+    /// * `amount` - Amount to increase resonance by
+    /// * `cap` - Maximum resonance value (None = no cap)
+    ///
+    /// # Returns
+    /// Result containing the old/new values and whether cap was hit
+    fn reinforce(&self, id: &str, amount: i32, cap: Option<i32>) -> Result<ReinforcementResult>;
 
     // =========================================================================
     // CONTENT PATCH OPERATIONS


### PR DESCRIPTION
## Summary

Implements the "inhale" part of the breathing metaphor from #119 - actively reinforcing memories through use.

This PR adds `mx memory reinforce <id>` which:
- Increments resonance by a specified amount (default: 1)
- Respects a configurable cap (default: 10)
- Updates `last_activated` timestamp
- Increments `activation_count`
- Returns detailed before/after values

## Changes

- **CLI**: Add `mx memory reinforce` subcommand with `--amount` and `--cap` flags
- **Store trait**: New `reinforce()` method interface
- **SurrealDB**: Full implementation with atomic updates and cap enforcement
- **SQLite**: Graceful degradation with basic reinforce support
- **Types**: New `ReinforcementResult` struct for operation results
- **Tests**: 5 new tests covering basic operation, capping, ID normalization, and error cases

## Test Coverage

All 157 tests pass, including new tests for:
- Basic reinforcement (increment + activation)
- Cap enforcement (prevents exceeding max)
- ID normalization (handles with/without kn- prefix)
- Nonexistent entry handling (proper error)

## Related Issues

Closes first half of #119 (breathing in/reinforcement).

Phase 2 (decay/breathing out) will be implemented separately.

## Test Plan

- [ ] CI passes (tests + clippy + format)
- [ ] Manual test: `mx memory reinforce kn-xxx --amount 2 --cap 8`
- [ ] Verify JSON output: `mx memory reinforce kn-xxx --format json`
- [ ] Verify cap enforcement works correctly
- [ ] Check activation_count increments properly