### PR TITLE
Unify mx memory CLI surface (fixes #123, addresses #126)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2132,10 +2132,10 @@ fn auto_anchor(
         // Skip anchors that the user explicitly removed via --anchors replacement.
         // auto_anchor is a safety net for missed connections, not an override of
         // explicit user intent.
-        if let Some(removed) = explicitly_removed {
-            if removed.contains(&candidate.id) {
-                continue;
-            }
+        if let Some(removed) = explicitly_removed
+            && removed.contains(&candidate.id)
+        {
+            continue;
         }
 
         // Privacy check


### PR DESCRIPTION
## Summary

Major refactor of the `mx memory` command surface, addressing Schemnya's full audit (#126) and fixing the `--private` persistence bug (#123).

Fixes #123
Addresses #126

## Changes

### Bug Fix: `--private` persistence (#123)
- Owner field now correctly falls back to `MX_CURRENT_AGENT` when `--source-agent` is not provided
- Ensures owner format matches what the visibility filter expects during reads
- Both `--private` (sugar) and `--visibility private` are supported on `add` and `update`

### Shared Filter Extraction (#126 inconsistency 5)
- Extracted `EntryFilter` struct with `#[command(flatten)]` -- search and list share identical filter flags
- Added `apply_entry_filters()` helper for in-memory field presence filtering
- Eliminated ~60 lines of duplicated filter definitions

### Content Ops Absorbed into Update (#126 phase 2)
- `update --append-content` replaces standalone `append` (kept as shortcut)
- `update --prepend-content` replaces standalone `prepend` (kept as shortcut)
- `update --find/--replace` replaces standalone `edit` (kept as shortcut)
- `--replace-all` and `--nth` work with `--find/--replace` on update

### Add/Remove Ops for Tags and Anchors (#126 inconsistency 8)
- `--add-tag`, `--remove-tag` on update (like wake phrases already had)
- `--add-anchor`, `--remove-anchor` on update (normalizes IDs)

### `--source-agent` Now Optional (#126 inconsistency 3)
- Falls back to `MX_CURRENT_AGENT` env var (required if neither provided)
- Reduces boilerplate for the common case

### Unified `--json` Output (#126 inconsistency 7)
- All mutation commands accept `--json`: add, update, delete, edit, append, prepend, reinforce
- `--format json` still works (hidden, deprecated) for recent, for-session, fact-session, reinforce

### `--category` Multi-Value on List (#126 inconsistency 6)
- `--category` on list now accepts comma-delimited multiple values, matching search

### New: `--content-only` on Show
- `mx memory show <id> --content-only` outputs only the body (for piping to other tools)

### ID Normalization
- `normalize_id()` helper accepts both `kn-abc` and `abc` formats everywhere
- Applied to: show, update, delete, edit, append, prepend, reinforce, for-session, fact-session

### Enhanced `print_entry_full`
- Now shows: wake_phrases, anchors, visibility (for private entries), owner

## What's Left (from Schemnya's 4-phase plan)

Phase 3-4 items deferred to follow-up PRs:
- `--mine-only` filter on search (currently only `--mine` on list)
- Rename `fact-session`/`for-session` to `fact session`/`session facts` (breaking change, needs migration)
- Extract `MutationResult` struct for unified JSON output schema
- Full deprecation warnings on `edit`/`append`/`prepend` standalone commands
- `--sort` and `--offset` for pagination on list

## Test Plan

- [x] `cargo test` -- 157 passed, 0 failed
- [x] `cargo clippy` -- no warnings
- [x] `cargo fmt --check` -- clean
- [x] CLI help verified for add, update, list, show
- [ ] Manual test: `mx memory add --private --content "test" --title "test" --category bloom` and verify readback with `mx memory show`