### PR TITLE
fix: check wake_phrases plural in engage loop and output formatters

### DIFF
--- a/src/engage.rs
+++ b/src/engage.rs
@@ -372,8 +372,8 @@ fn update_wake_phrase(db: &dyn KnowledgeStore, id: &str, phrase: &str) -> Result
         .get(id, &ctx)?
         .ok_or_else(|| anyhow::anyhow!("Entry not found: {}", id))?;
 
-    // Update wake phrase
-    entry.wake_phrase = Some(phrase.to_string());
+    // Write to wake_phrases (canonical field), not deprecated wake_phrase
+    entry.wake_phrases = vec![phrase.to_string()];
     entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
 
     // Save back

--- a/src/index.rs
+++ b/src/index.rs
@@ -173,13 +173,21 @@ pub fn export_markdown(db: &dyn KnowledgeStore, dir_path: &Path) -> Result<()> {
                 writeln!(writer, "resonance_type: {}", resonance_type)?;
             }
 
-            if let Some(ref wake_phrase) = entry.wake_phrase {
+            let active_phrases = entry.active_wake_phrases();
+            if !active_phrases.is_empty() {
                 // Quote it because wake phrases may contain special YAML characters
-                writeln!(
-                    writer,
-                    "wake_phrase: \"{}\"",
-                    wake_phrase.replace("\"", "\\\"")
-                )?;
+                if active_phrases.len() == 1 {
+                    writeln!(
+                        writer,
+                        "wake_phrase: \"{}\"",
+                        active_phrases[0].replace("\"", "\\\"")
+                    )?;
+                } else {
+                    writeln!(writer, "wake_phrases:")?;
+                    for phrase in active_phrases {
+                        writeln!(writer, "  - \"{}\"", phrase.replace("\"", "\\\""))?;
+                    }
+                }
             }
 
             writeln!(writer, "---\n")?;

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -154,6 +154,20 @@ pub struct Frontmatter {
 }
 
 impl KnowledgeEntry {
+    /// Returns active wake phrases, preferring wake_phrases over deprecated wake_phrase.
+    pub fn active_wake_phrases(&self) -> Vec<&str> {
+        if !self.wake_phrases.is_empty() {
+            self.wake_phrases.iter().map(|s| s.as_str()).collect()
+        } else {
+            self.wake_phrase.as_deref().into_iter().collect()
+        }
+    }
+
+    /// Returns whether this entry has any wake phrase set.
+    pub fn has_any_wake_phrase(&self) -> bool {
+        !self.wake_phrases.is_empty() || self.wake_phrase.as_ref().is_some_and(|s| !s.is_empty())
+    }
+
     /// Construct text suitable for embedding generation
     ///
     /// Combines title, summary/body, and tags into a single string

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,16 +454,8 @@ fn apply_entry_filters(
 ) -> Vec<knowledge::KnowledgeEntry> {
     let mut entries: Vec<_> = entries
         .into_iter()
-        .filter(|e| {
-            !filter.has_wake_phrase
-                || !e.wake_phrases.is_empty()
-                || e.wake_phrase.as_ref().is_some_and(|s| !s.is_empty())
-        })
-        .filter(|e| {
-            !filter.missing_wake_phrase
-                || (e.wake_phrases.is_empty()
-                    && e.wake_phrase.as_ref().is_none_or(|s| s.is_empty()))
-        })
+        .filter(|e| !filter.has_wake_phrase || e.has_any_wake_phrase())
+        .filter(|e| !filter.missing_wake_phrase || !e.has_any_wake_phrase())
         .filter(|e| !filter.has_anchors || !e.anchors.is_empty())
         .filter(|e| !filter.missing_anchors || e.anchors.is_empty())
         .filter(|e| {
@@ -5142,11 +5134,7 @@ fn print_wake_index(cascade: &store::WakeCascade) {
         println!("| ID | Title | R | Wake Cue |");
         println!("|----|-------|---|----------|");
         for entry in anchors {
-            let wake_cue = if !entry.wake_phrases.is_empty() {
-                entry.wake_phrases.join(" / ")
-            } else {
-                entry.wake_phrase.clone().unwrap_or_default()
-            };
+            let wake_cue = entry.active_wake_phrases().join(" / ");
             println!(
                 "| {} | {} | {} | {} |",
                 entry.id, entry.title, entry.resonance, wake_cue
@@ -5189,11 +5177,7 @@ fn print_wake_index(cascade: &store::WakeCascade) {
             println!("| ID | Title | R | Wake Cue |");
             println!("|----|-------|---|----------|");
             for entry in entries {
-                let wake_cue = if !entry.wake_phrases.is_empty() {
-                    entry.wake_phrases.join(" / ")
-                } else {
-                    entry.wake_phrase.clone().unwrap_or_default()
-                };
+                let wake_cue = entry.active_wake_phrases().join(" / ");
                 println!(
                     "| {} | {} | {} | {} |",
                     entry.id, entry.title, entry.resonance, wake_cue
@@ -5238,11 +5222,7 @@ fn print_wake_ritual(cascade: &store::WakeCascade, agent: &str) {
                 shell_escape(&entry.title)
             );
             println!("mx memory show {}", entry.id);
-            if !entry.wake_phrases.is_empty() {
-                for phrase in &entry.wake_phrases {
-                    println!("# Wake phrase: \"{}\"", phrase);
-                }
-            } else if let Some(ref phrase) = entry.wake_phrase {
+            for phrase in entry.active_wake_phrases() {
                 println!("# Wake phrase: \"{}\"", phrase);
             }
             println!("echo \"\"");
@@ -5263,11 +5243,7 @@ fn print_wake_ritual(cascade: &store::WakeCascade, agent: &str) {
                 shell_escape(&entry.title)
             );
             println!("mx memory show {}", entry.id);
-            if !entry.wake_phrases.is_empty() {
-                for phrase in &entry.wake_phrases {
-                    println!("# Wake phrase: \"{}\"", phrase);
-                }
-            } else if let Some(ref phrase) = entry.wake_phrase {
+            for phrase in entry.active_wake_phrases() {
                 println!("# Wake phrase: \"{}\"", phrase);
             }
             println!("echo \"\"");
@@ -5288,11 +5264,7 @@ fn print_wake_ritual(cascade: &store::WakeCascade, agent: &str) {
                 shell_escape(&entry.title)
             );
             println!("mx memory show {}", entry.id);
-            if !entry.wake_phrases.is_empty() {
-                for phrase in &entry.wake_phrases {
-                    println!("# Wake phrase: \"{}\"", phrase);
-                }
-            } else if let Some(ref phrase) = entry.wake_phrase {
+            for phrase in entry.active_wake_phrases() {
                 println!("# Wake phrase: \"{}\"", phrase);
             }
             println!("echo \"\"");


### PR DESCRIPTION
## Bug

The interactive engage path and legacy output formatters only checked the deprecated `wake_phrase` singular field, causing wake phrases to silently fall back to empty when only `wake_phrases` (plural) was populated. The token-based ritual path already used the correct priority order — this aligns the remaining sites.

## Fix sites

- `src/engage.rs` — engage loop now checks `wake_phrases` first with random selection, falls back to `wake_phrase`
- `src/main.rs` — three sites updated to check both fields:
  - `print_wake_index`
  - `print_wake_ritual`
  - `apply_entry_filters`

## Tests

163 pass. 3 pre-existing failures unrelated to this change.