### PR TITLE
fix: apply denylist filter to remaining wake query functions

### DIFF
--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1453,9 +1453,7 @@ impl SurrealDatabase {
             "SELECT {}
             FROM knowledge
             WHERE resonance >= $threshold
-            -- Wake cascade surfaces identity-level entries only (foundational/transformative).
-            -- Ephemeral facts are excluded — they surface via `recent` and `for-session`, not wake.
-            AND resonance_type IN ['foundational', 'transformative']
+            AND (resonance_type IS NONE OR resonance_type != 'ephemeral')
             {}
             ORDER BY resonance DESC",
             Self::knowledge_select_fields(),
@@ -1545,9 +1543,7 @@ impl SurrealDatabase {
                 SELECT {}
                 FROM knowledge
                 WHERE last_activated > <datetime>$cutoff
-                -- Wake cascade surfaces identity-level entries only (foundational/transformative).
-                -- Ephemeral facts are excluded — they surface via `recent` and `for-session`, not wake.
-                AND resonance_type IN ['foundational', 'transformative']
+                AND (resonance_type IS NONE OR resonance_type != 'ephemeral')
                 {}
             )
             ORDER BY


### PR DESCRIPTION
## Summary

- PR #139 fixed the allowlist→denylist filter in `query_core_blooms` but missed two other functions with the same bug
- **`query_blooms_by_resonance`** (used when `--min-resonance` is passed) still had `resonance_type IN ['foundational', 'transformative']` — this is the direct cause of wake only returning 3/6 blooms
- **`query_recent_blooms`** (Layer 2 of normal wake cascade) had the same stale allowlist
- Both now use the same denylist: `AND (resonance_type IS NONE OR resonance_type != 'ephemeral')`

## Root cause

PR #133 introduced the allowlist in all three query functions. PR #139 fixed only `query_core_blooms`. The review missed that `--min-resonance` takes an early-return path through `query_blooms_by_resonance`, which was never patched.

## Test plan

- [ ] `mx memory wake --begin --min-resonance 9` returns 6 blooms (not 3)
- [ ] `mx memory wake --begin` returns all core + recent blooms including relational type
- [ ] Ephemeral entries still excluded from both paths

cc @GeoffBlay — completing the fix from #139