### PR TITLE
fix: update base-d and add defensive validation for encoded commit output

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -262,7 +262,11 @@ fn validate_encoded_output(encoded: &str, context: &str) -> Result<()> {
              This suggests an unsafe dictionary was selected. Encoded preview: {:?}",
             context,
             pos,
-            &encoded[..encoded.char_indices().take(40).last().map_or(0, |(i, c)| i + c.len_utf8())]
+            &encoded[..encoded
+                .char_indices()
+                .take(40)
+                .last()
+                .map_or(0, |(i, c)| i + c.len_utf8())]
         );
     }
     // Check for C0 controls (except newline, tab) and C1 controls
@@ -275,7 +279,11 @@ fn validate_encoded_output(encoded: &str, context: &str) -> Result<()> {
                 context,
                 cp,
                 i,
-                &encoded[..encoded.char_indices().take(40).last().map_or(0, |(i, c)| i + c.len_utf8())]
+                &encoded[..encoded
+                    .char_indices()
+                    .take(40)
+                    .last()
+                    .map_or(0, |(i, c)| i + c.len_utf8())]
             );
         }
     }
@@ -499,6 +507,12 @@ mod tests {
     #[test]
     fn test_validate_encoded_multibyte_unicode() {
         // Valid multi-byte chars should pass -- no false positives
-        assert!(validate_encoded_output("\u{1f711}\u{1f754}\u{1f72e}\u{1f716}\u{1f723}\u{1f75c}", "test").is_ok());
+        assert!(
+            validate_encoded_output(
+                "\u{1f711}\u{1f754}\u{1f72e}\u{1f716}\u{1f723}\u{1f75c}",
+                "test"
+            )
+            .is_ok()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Update base-d dependency to 3.0.32 (picks up ByteRange safety fix from base-d PR #162)
- Add `validate_encoded_output()` in `commit.rs` that checks encoded title, body, and footer for:
  - NUL bytes (would silently truncate C-string arguments to git/gh)
  - C0 control characters (except \n and \t)
  - C1 control characters (U+0080-U+009F, which caused garbled commit messages per base-d #125)
- Validation called in both `upload_commit()` and `pr_merge()` paths, after encoding but before passing to external commands
- 8 unit tests covering all validation cases

Addresses the defensive side of coryzibell/base-d#125 and the `mx pr merge` nul byte error from #141.

## Test plan

- [x] `cargo test` -- 201 pass, 0 fail
- [x] `cargo clippy` -- zero warnings
- [x] Tests cover: clean ASCII, NUL, C0, C1, allowed \n and \t, empty string, multi-byte Unicode