### PR TITLE
Refactor auth_level from String to enum in SurrealConfig

### DIFF
--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -32,6 +32,48 @@ pub enum SurrealMode {
     Network,
 }
 
+/// Authentication level for SurrealDB signin
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum AuthLevel {
+    /// Root-level authentication (default)
+    #[default]
+    Root,
+    /// Namespace-level authentication
+    Namespace,
+    /// Database-level authentication
+    Database,
+}
+
+impl AuthLevel {
+    /// Parse an auth level from an environment variable string.
+    ///
+    /// Accepts lowercase aliases:
+    /// - "root" -> Root
+    /// - "namespace" or "ns" -> Namespace
+    /// - "database" or "db" -> Database
+    pub fn from_env_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "root" => Ok(Self::Root),
+            "namespace" | "ns" => Ok(Self::Namespace),
+            "database" | "db" => Ok(Self::Database),
+            other => anyhow::bail!(
+                "Unknown MX_SURREAL_AUTH_LEVEL '{}'. Valid values: root, namespace (ns), database (db)",
+                other
+            ),
+        }
+    }
+}
+
+impl std::fmt::Display for AuthLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Root => write!(f, "root"),
+            Self::Namespace => write!(f, "namespace"),
+            Self::Database => write!(f, "database"),
+        }
+    }
+}
+
 /// Configuration for SurrealDB connection
 ///
 /// Parsed from environment variables:
@@ -58,7 +100,7 @@ pub struct SurrealConfig {
     /// SurrealDB database name
     pub database: String,
     /// Auth level for signin (root, namespace, or database)
-    pub auth_level: String,
+    pub auth_level: AuthLevel,
 }
 
 impl Default for SurrealConfig {
@@ -70,7 +112,7 @@ impl Default for SurrealConfig {
             pass: None,
             namespace: "memory".to_string(),
             database: "knowledge".to_string(),
-            auth_level: "root".to_string(),
+            auth_level: AuthLevel::Root,
         }
     }
 }
@@ -108,9 +150,10 @@ impl SurrealConfig {
 
         let database = std::env::var("MX_SURREAL_DB").unwrap_or_else(|_| "knowledge".to_string());
 
-        let auth_level = std::env::var("MX_SURREAL_AUTH_LEVEL")
-            .unwrap_or_else(|_| "root".to_string())
-            .to_lowercase();
+        let auth_level_str = std::env::var("MX_SURREAL_AUTH_LEVEL")
+            .unwrap_or_else(|_| "root".to_string());
+        let auth_level = AuthLevel::from_env_str(&auth_level_str)
+            .expect("Invalid MX_SURREAL_AUTH_LEVEL value");
 
         Self {
             mode,
@@ -580,8 +623,8 @@ impl SurrealDatabase {
                     config.user, config.auth_level
                 );
             }
-            match config.auth_level.as_str() {
-                "namespace" | "ns" => {
+            match config.auth_level {
+                AuthLevel::Namespace => {
                     db.signin(Namespace {
                         namespace: &config.namespace,
                         username: &config.user,
@@ -595,7 +638,7 @@ impl SurrealDatabase {
                         )
                     })?;
                 }
-                "database" | "db" => {
+                AuthLevel::Database => {
                     db.signin(Database {
                         namespace: &config.namespace,
                         database: &config.database,
@@ -610,7 +653,7 @@ impl SurrealDatabase {
                         )
                     })?;
                 }
-                "root" => {
+                AuthLevel::Root => {
                     db.signin(Root {
                         username: &config.user,
                         password: pass,
@@ -622,12 +665,6 @@ impl SurrealDatabase {
                             config.url, config.user
                         )
                     })?;
-                }
-                other => {
-                    anyhow::bail!(
-                        "Unknown MX_SURREAL_AUTH_LEVEL '{}'. Valid values: root, namespace (ns), database (db)",
-                        other
-                    );
                 }
             }
         } else if verbose {

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -150,13 +150,12 @@ impl SurrealConfig {
 
         let database = std::env::var("MX_SURREAL_DB").unwrap_or_else(|_| "knowledge".to_string());
 
-        let auth_level_str = std::env::var("MX_SURREAL_AUTH_LEVEL")
-            .unwrap_or_else(|_| "root".to_string());
-        let auth_level = AuthLevel::from_env_str(&auth_level_str)
-            .unwrap_or_else(|e| {
-                eprintln!("[mx] WARNING: {e}, defaulting to root");
-                AuthLevel::Root
-            });
+        let auth_level_str =
+            std::env::var("MX_SURREAL_AUTH_LEVEL").unwrap_or_else(|_| "root".to_string());
+        let auth_level = AuthLevel::from_env_str(&auth_level_str).unwrap_or_else(|e| {
+            eprintln!("[mx] WARNING: {e}, defaulting to root");
+            AuthLevel::Root
+        });
 
         Self {
             mode,

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -33,7 +33,7 @@ pub enum SurrealMode {
 }
 
 /// Authentication level for SurrealDB signin
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum AuthLevel {
     /// Root-level authentication (default)
     #[default]
@@ -153,7 +153,10 @@ impl SurrealConfig {
         let auth_level_str = std::env::var("MX_SURREAL_AUTH_LEVEL")
             .unwrap_or_else(|_| "root".to_string());
         let auth_level = AuthLevel::from_env_str(&auth_level_str)
-            .expect("Invalid MX_SURREAL_AUTH_LEVEL value");
+            .unwrap_or_else(|e| {
+                eprintln!("[mx] WARNING: {e}, defaulting to root");
+                AuthLevel::Root
+            });
 
         Self {
             mode,


### PR DESCRIPTION
Closes #143

## Summary

- Introduces `AuthLevel` enum (`Root`, `Namespace`, `Database`) replacing the stringly-typed `auth_level` field on `SurrealConfig`
- Invalid values caught at config parse time with a warning and fallback to `Root`, instead of deep in connection logic
- Signin match is now exhaustive over enum variants -- compiler enforces completeness
- Accepts aliases: `namespace`/`ns`, `database`/`db`

## Changes

Single file: `src/surreal_db.rs` (~52 insertions, ~15 deletions)

- New `AuthLevel` enum with `Default`, `Display`, and `from_env_str()` parser
- `SurrealConfig.auth_level` type changed from `String` to `AuthLevel`
- `from_env()` parses through enum; invalid values warn and fall back to `Root`
- Signin match uses enum variants, wildcard arm removed

## Review Findings (Verdictia)

- **W1** (fixed): `.expect()` panic replaced with `unwrap_or_else` + warning + fallback
- **S1** (fixed): Derive order aligned with `SurrealMode`
- **N1** (no action): Serde derives omitted, consistent with `SurrealMode`

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` -- 257 passed, 1 pre-existing failure (unrelated `test_open_with_path`)