### PR TITLE
fix: wake cascade bridge layer never returns results due to kn- prefix strip

### DIFF
--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1497,7 +1497,7 @@ impl SurrealDatabase {
         let mut anchor_ids: Vec<String> = core
             .iter()
             .chain(recent.iter())
-            .map(|e| e.id.strip_prefix("kn-").unwrap_or(&e.id).to_string())
+            .map(|e| e.id.clone())
             .collect();
 
         // Deduplicate anchor IDs


### PR DESCRIPTION
## What's broken

The Layer 3 (bridge blooms) step of the wake cascade has never returned results.

**Root cause:** In `src/surreal_db.rs`, the code that builds the `anchor_ids` list for the bridge query strips the `kn-` prefix from entry IDs before passing them to `query_bridge_blooms`:

```rust
// Before (broken)
.map(|e| e.id.strip_prefix("kn-").unwrap_or(&e.id).to_string())
```

The bridge query then does:

```sql
WHERE array::len(array::intersect(anchors, $anchor_ids)) > 0
```

But the `anchors` field on knowledge entries stores IDs **with** the `kn-` prefix (e.g. `"kn-f30be669"`). So `array::intersect` is comparing `"f30be669"` against `"kn-f30be669"` — zero intersection, every time, for every entry.

## The fix

Stop stripping the prefix. Pass `e.id.clone()` directly so the IDs passed to the query match the format anchors actually use:

```rust
// After (fixed)
.map(|e| e.id.clone())
```

One line changed. The bridge query itself is untouched.

## Verification

- `cargo build` passes cleanly
- Pre-commit hooks (fmt + clippy) pass