### PR TITLE
Quiet default stdout for mx commit; add --show-encoded opt-in

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -364,8 +364,51 @@ pub fn encode_commit_message(title_text: &str, body_text: &str) -> Result<String
     Ok(encode_commit(title_text, body_text)?.message())
 }
 
-/// Perform the full upload commit
-pub fn upload_commit(message: &str, stage_all_flag: bool, push: bool) -> Result<()> {
+/// Format an `EncodedCommit` for human-facing stdout display.
+///
+/// - `show_encoded == false` (default): returns only the `Footer:` line.
+///   The title and body are random-glyph noise with a freshly-rolled
+///   dictionary per commit, so they are useless to a human at stdout.
+///   The footer identifies the hash/compression/dictionary combo, which
+///   IS meaningful confirmation that encoding succeeded.
+///
+/// - `show_encoded == true`: returns the full dump (`Title:`, `Body:`,
+///   `Dejavu:` when applicable, `Footer:`), matching the historical
+///   behavior of `upload_commit` verbatim.
+///
+/// The returned string does NOT include a trailing newline or the
+/// `Committed.` / `Pushed.` status lines — those are the caller's
+/// responsibility. Kept as a pure function so tests can assert on the
+/// exact output without spawning a subprocess.
+pub fn format_encoded_commit(encoded: &EncodedCommit, show_encoded: bool) -> String {
+    let mut out = String::new();
+    if show_encoded {
+        out.push_str(&format!("Title:  {}\n", encoded.title));
+        out.push_str(&format!("Body:   {}\n", encoded.body));
+        if encoded.dejavu {
+            out.push_str(&format!(
+                "Dejavu: true (both used {})\n",
+                encoded.title_dict
+            ));
+        }
+    }
+    out.push_str(&format!("Footer: {}", encoded.footer));
+    out
+}
+
+/// Perform the full upload commit.
+///
+/// `show_encoded` controls stdout verbosity:
+/// - `false` (default): prints only the footer line and `Committed.`
+///   (plus `Pushed.` if `push` is set).
+/// - `true`: prints the full `Title:` / `Body:` / `Dejavu:` / `Footer:`
+///   block — historical behavior, opt-in via `mx commit --show-encoded`.
+pub fn upload_commit(
+    message: &str,
+    stage_all_flag: bool,
+    push: bool,
+    show_encoded: bool,
+) -> Result<()> {
     // Stage if requested
     if stage_all_flag {
         stage_all()?;
@@ -382,12 +425,7 @@ pub fn upload_commit(message: &str, stage_all_flag: bool, push: bool) -> Result<
     // Encode with retry: title from diff hash, body from compressed message
     let encoded = encode_commit(&diff, message)?;
 
-    println!("Title:  {}", encoded.title);
-    println!("Body:   {}", encoded.body);
-    if encoded.dejavu {
-        println!("Dejavu: true (both used {})", encoded.title_dict);
-    }
-    println!("Footer: {}", encoded.footer);
+    println!("{}", format_encoded_commit(&encoded, show_encoded));
 
     // Commit
     git_commit(&encoded.title, &encoded.body, &encoded.footer)?;
@@ -537,5 +575,120 @@ mod tests {
             )
             .is_ok()
         );
+    }
+
+    // --- format_encoded_commit ---
+
+    fn sample_encoded_no_dejavu() -> EncodedCommit {
+        EncodedCommit {
+            title: "TTTT-title-glyphs".to_string(),
+            body: "BBBB-body-glyphs".to_string(),
+            footer: "[sha384:base62|lzma:uuencode]".to_string(),
+            dejavu: false,
+            title_dict: "base62".to_string(),
+            body_dict: "uuencode".to_string(),
+        }
+    }
+
+    fn sample_encoded_with_dejavu() -> EncodedCommit {
+        EncodedCommit {
+            title: "TTTT-title-glyphs".to_string(),
+            body: "BBBB-body-glyphs".to_string(),
+            footer: "[sha384:base62|lzma:base62]\nwhoa.".to_string(),
+            dejavu: true,
+            title_dict: "base62".to_string(),
+            body_dict: "base62".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_format_default_omits_title_and_body() {
+        let encoded = sample_encoded_no_dejavu();
+        let out = format_encoded_commit(&encoded, false);
+        assert!(
+            !out.contains("Title:"),
+            "default output must not contain Title: -- got {:?}",
+            out
+        );
+        assert!(
+            !out.contains("Body:"),
+            "default output must not contain Body: -- got {:?}",
+            out
+        );
+        assert!(
+            !out.contains("Dejavu:"),
+            "default output must not contain Dejavu: -- got {:?}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_format_default_contains_footer() {
+        let encoded = sample_encoded_no_dejavu();
+        let out = format_encoded_commit(&encoded, false);
+        assert!(
+            out.contains("Footer: [sha384:base62|lzma:uuencode]"),
+            "default output must contain the footer line -- got {:?}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_format_default_dejavu_still_hidden() {
+        // Even when dejavu is true, default mode hides everything but footer.
+        let encoded = sample_encoded_with_dejavu();
+        let out = format_encoded_commit(&encoded, false);
+        assert!(!out.contains("Dejavu:"));
+        assert!(!out.contains("Title:"));
+        assert!(!out.contains("Body:"));
+        assert!(out.contains("Footer:"));
+    }
+
+    #[test]
+    fn test_format_verbose_contains_all_fields() {
+        let encoded = sample_encoded_no_dejavu();
+        let out = format_encoded_commit(&encoded, true);
+        assert!(out.contains("Title:  TTTT-title-glyphs"));
+        assert!(out.contains("Body:   BBBB-body-glyphs"));
+        assert!(out.contains("Footer: [sha384:base62|lzma:uuencode]"));
+        // No dejavu on this sample, so the line should NOT appear.
+        assert!(!out.contains("Dejavu:"));
+    }
+
+    #[test]
+    fn test_format_verbose_shows_dejavu_when_true() {
+        let encoded = sample_encoded_with_dejavu();
+        let out = format_encoded_commit(&encoded, true);
+        assert!(out.contains("Title:  TTTT-title-glyphs"));
+        assert!(out.contains("Body:   BBBB-body-glyphs"));
+        assert!(out.contains("Dejavu: true (both used base62)"));
+        assert!(out.contains("Footer: [sha384:base62|lzma:base62]"));
+    }
+
+    #[test]
+    fn test_format_verbose_matches_historical_field_order() {
+        // Historical order (before this change) was Title, Body,
+        // optional Dejavu, Footer. Keep that order exact so `--show-encoded`
+        // is a byte-for-byte match of pre-refactor stdout.
+        let encoded = sample_encoded_with_dejavu();
+        let out = format_encoded_commit(&encoded, true);
+        let title_pos = out.find("Title:").unwrap();
+        let body_pos = out.find("Body:").unwrap();
+        let dejavu_pos = out.find("Dejavu:").unwrap();
+        let footer_pos = out.find("Footer:").unwrap();
+        assert!(title_pos < body_pos);
+        assert!(body_pos < dejavu_pos);
+        assert!(dejavu_pos < footer_pos);
+    }
+
+    #[test]
+    fn test_format_no_trailing_newline() {
+        // Caller adds its own newline via println!; the formatter must not
+        // double-space the output.
+        let encoded = sample_encoded_no_dejavu();
+        let out = format_encoded_commit(&encoded, false);
+        assert!(!out.ends_with('\n'));
+        let out_v = format_encoded_commit(&encoded, true);
+        assert!(!out_v.ends_with('\n'));
     }
 }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -666,19 +666,21 @@ mod tests {
     }
 
     #[test]
-    fn test_format_verbose_matches_historical_field_order() {
+    fn test_format_verbose_exact_bytes_match_historical_output() {
         // Historical order (before this change) was Title, Body,
         // optional Dejavu, Footer. Keep that order exact so `--show-encoded`
-        // is a byte-for-byte match of pre-refactor stdout.
+        // is a byte-for-byte match of pre-refactor stdout. Asserting on the
+        // full string (not just substring order) catches any drift in
+        // spacing, field labels, or separators -- two formatters that
+        // happened to interleave the fields in the right order but with
+        // different whitespace would have passed the old substring check.
         let encoded = sample_encoded_with_dejavu();
         let out = format_encoded_commit(&encoded, true);
-        let title_pos = out.find("Title:").unwrap();
-        let body_pos = out.find("Body:").unwrap();
-        let dejavu_pos = out.find("Dejavu:").unwrap();
-        let footer_pos = out.find("Footer:").unwrap();
-        assert!(title_pos < body_pos);
-        assert!(body_pos < dejavu_pos);
-        assert!(dejavu_pos < footer_pos);
+        let expected = "Title:  TTTT-title-glyphs\n\
+                        Body:   BBBB-body-glyphs\n\
+                        Dejavu: true (both used base62)\n\
+                        Footer: [sha384:base62|lzma:base62]\nwhoa.";
+        assert_eq!(out, expected);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,11 @@ enum Commands {
         /// Body text for PR-style encoding (requires --encode-only)
         #[arg(short, long, requires = "encode_only", requires = "title")]
         body: Option<String>,
+
+        /// Show the full encoded commit fields (Title/Body/Dejavu/Footer).
+        /// Default output is just the footer line and `Committed.`
+        #[arg(long, conflicts_with = "encode_only")]
+        show_encoded: bool,
     },
 
     /// Pull request operations
@@ -1566,9 +1571,12 @@ fn main() -> Result<()> {
             encode_only,
             title,
             body,
+            show_encoded,
         } => {
             if encode_only {
-                // PR-style encoding: encode title and body, print to stdout
+                // PR-style encoding: encode title and body, print to stdout.
+                // `--encode-only` is its own print path and is deliberately
+                // left alone — its entire purpose is to emit encoded output.
                 if let (Some(t), Some(b)) = (title, body) {
                     let encoded_message = commit::encode_commit_message(&t, &b)?;
                     println!("{}", encoded_message);
@@ -1580,7 +1588,7 @@ fn main() -> Result<()> {
                 // Normal commit workflow
                 let msg =
                     message.ok_or_else(|| anyhow::anyhow!("message is required for commit"))?;
-                commit::upload_commit(&msg, all, push)?;
+                commit::upload_commit(&msg, all, push, show_encoded)?;
             }
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ enum Commands {
 
         /// Show the full encoded commit fields (Title/Body/Dejavu/Footer).
         /// Default output is just the footer line and `Committed.`
-        #[arg(long, conflicts_with = "encode_only")]
+        #[arg(long, conflicts_with = "encode_only", conflicts_with_all = ["title", "body"])]
         show_encoded: bool,
     },
 


### PR DESCRIPTION
## Summary

Three changes, one focused PR:

1. **`mx commit` is now quiet by default.** It prints the `Footer:` line and `Committed.` (plus `Pushed.` if `-p`). The Title/Body are random-glyph noise with a freshly-rolled dictionary per commit -- they are useless to a human reading stdout -- and we drop them.
2. **Opt back in with `--show-encoded`.** This preserves the historical output verbatim (`Title:` / `Body:` / `Dejavu:` / `Footer:`) for anyone who actually wanted to see it.
3. **Extracted `commit::format_encoded_commit`**, a pure function that owns the display contract, so tests can assert on the exact output without spawning a subprocess.

The footer stays because it genuinely matters: it identifies the hash/compression/dictionary combo (e.g. `[sha384:base62|lzma:uuencode]`) and confirms encoding succeeded.

### Behavior

```
# Default (new)
$ mx commit "fix widget"
Footer: [sha384:base62|lzma:uuencode]
Committed.

# Opt-in (preserves pre-PR behavior)
$ mx commit --show-encoded "fix widget"
Title:  <encoded title>
Body:   <encoded body>
Dejavu: true (both used <dict>)   # only when both rolled the same dict
Footer: [sha384:base62|lzma:uuencode]
Committed.
```

## Flag name: `--show-encoded`, not `-v`/`--verbose`

Picked `--show-encoded` over repurposing the global `-v/--verbose` for two reasons:

1. The global `--verbose` on root `Cli` (main.rs:35-37) already has documented semantics: *"Enable verbose output (show connection logs)"*, and it's currently wired into `handle_memory`. Overloading it with "also show encoded commit fields" muddles the meaning and invites future confusion.
2. `--show-encoded` is self-documenting at the `mx commit` level and leaves the global flag free to keep meaning what it says. Zero short-flag conflict, zero ambiguity in help output.

The new flag is scoped to the `Commit` subcommand and carries `conflicts_with = "encode_only"` because `--encode-only` is already its own print path (it emits the raw concatenated encoded message for capture) and mixing the two would be nonsense.

## Consolidation: honest finding

The spec asked me to look for duplication in the commit display path and consolidate it. **The duplication was smaller than the recon suggested.** Concretely:

- The `Title:`/`Body:`/`Dejavu:`/`Footer:` print block only lived in ONE place: `upload_commit()` at `src/commit.rs:385-390`. Nowhere else formats an `EncodedCommit` for human display.
- `--encode-only` has a structurally different output (single multi-line string via `encode_commit_message`) for downstream capture and is deliberately untouched.
- `pr_merge()` at `src/commit.rs:423-489` has a similar "chatty success message" shape but does NOT print the encoded fields -- just `Merged PR #N (<method>)` plus `gh`'s stdout. It's a different concern and folding it in would be scope creep. Leaving it as a follow-up candidate.
- `handle_log`'s decode path (`main.rs:5094-5190`) uses `commit::decode_body` and formats for display, but it's solving the inverse problem (decoded plaintext, not encoded fields) and has nothing to share with `format_encoded_commit`.

So: I extracted `commit::format_encoded_commit(&EncodedCommit, show_encoded: bool) -> String` anyway, because separating display from I/O is still worthwhile -- it makes the display contract unit-testable as a pure function and gives a single obvious home for future variants. But I didn't manufacture extra refactoring to hit a duplication quota.

## Tests

Added 7 unit tests in `src/commit.rs::tests` that assert on the new helper directly (no subprocess):

- `test_format_default_omits_title_and_body` -- default output has no Title/Body/Dejavu lines
- `test_format_default_contains_footer` -- default output has the footer line
- `test_format_default_dejavu_still_hidden` -- even when `dejavu == true`, default mode hides everything but footer
- `test_format_verbose_contains_all_fields` -- `show_encoded=true` emits Title/Body/Footer, and no Dejavu line when dejavu is false
- `test_format_verbose_shows_dejavu_when_true` -- dejavu line appears only when the flag is set
- `test_format_verbose_matches_historical_field_order` -- field order is Title -> Body -> Dejavu -> Footer, byte-for-byte matching pre-refactor stdout
- `test_format_no_trailing_newline` -- the pure function leaves trailing-newline responsibility to `println!`

Manual CLI smoke checks:
- `mx commit --help` renders the new flag with correct description.
- `mx commit --encode-only --title foo --body bar --show-encoded` correctly errors with the clap conflict message.
- `mx commit --encode-only --title foo --body bar` emits unchanged encoded output (verified against a sample run).

## Test suite

```
cargo test
...
test result: FAILED. 264 passed; 1 failed; 3 ignored; 0 measured; 0 filtered out
```

- **+7 passing** (257 -> 264): the new `format_encoded_commit` tests.
- **1 failure, pre-existing and unrelated:** `surreal_db::tests::test_open_with_path` fails on `assertion failed: db_path.exists()` at `src/surreal_db.rs:3781`. Same failure exists on `main` at HEAD; nothing in this PR touches `surreal_db`. Noted so the Savorist doesn't chase it on account of this PR.
- **3 ignored:** unchanged from baseline.
- `cargo clippy --all-targets --all-features -- -D warnings` is clean (pre-push hook enforced it).
- `cargo fmt --check` is clean (pre-push hook enforced it).

## Files touched

- `src/commit.rs` (+161, -8): new `format_encoded_commit` helper, `upload_commit` signature gains `show_encoded: bool`, 7 new unit tests.
- `src/main.rs` (+10, -2): new `show_encoded: bool` field on `Commands::Commit`, threaded into `upload_commit` call site; expanded comment on the untouched `--encode-only` branch.

## Follow-ups (not in this PR)

- `commit::pr_merge` has a similar chatty-output shape. Not touched here to keep the PR focused. Worth a separate pass if the Savorist wants `mx pr merge` to also go quiet by default.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --bin mx commit::` -- 15/15 green
- [x] `cargo test` -- 264/265 green (1 unrelated pre-existing failure noted above)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `mx commit --help` renders new flag correctly
- [x] `--encode-only` output unchanged
- [x] `--show-encoded` conflicts with `--encode-only` as expected