### PR TITLE
drop openssl from dep tree via fastembed rustls swap

### DIFF
--- a/.github/workflows/follow-the-white-rabbit.yml
+++ b/.github/workflows/follow-the-white-rabbit.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     uses: coryzibell/nebuchadnezzar/.github/workflows/follow-the-white-rabbit.yml@main
     with:
-      needs-openssl: true
+      needs-openssl: false
       # ONNX Runtime doesn't provide prebuilt binaries for musl or FreeBSD targets
       # aarch64-unknown-linux-gnu: ort-sys static linking fails in cross-compilation (see issue)
       # x86_64-apple-darwin: ort dropped Intel Mac support upstream (ort 2.0+)

--- a/.github/workflows/wake-up.yml
+++ b/.github/workflows/wake-up.yml
@@ -15,6 +15,6 @@ jobs:
   ci:
     uses: coryzibell/nebuchadnezzar/.github/workflows/wake-up.yml@main
     with:
-      needs-openssl: true
+      needs-openssl: false
     secrets:
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ tempfile = "3"
 colored = "2"
 
 # Embeddings
-fastembed = { version = "5.6", default-features = false, features = ["hf-hub-rustls-tls", "image-models", "ort-download-binaries"] }
+fastembed = { version = "5.6", default-features = false, features = ["hf-hub-rustls-tls", "image-models", "ort-download-binaries-rustls-tls"] }
 
 [dev-dependencies.cargo-husky]
 version = "1"


### PR DESCRIPTION
## Summary

- Swap `fastembed` feature `ort-download-binaries` → `ort-download-binaries-rustls-tls`. This was the sole openssl pull-in: a silent alias that routed `ort-sys` through `ureq?/native-tls` → `openssl-sys`.
- Set `needs-openssl: false` in both `follow-the-white-rabbit.yml` and `wake-up.yml`. With openssl gone from the dep tree, the `install-deps` composite can skip the openssl install step on every platform.
- Fixes coryzibell/nebuchadnezzar#10 (recurring Windows CI failure when chocolatey → slproweb 404s on the OpenSSL installer).

## Why

`fastembed`'s `ort-download-binaries` feature is a silent alias for `ort-download-binaries-native-tls`. Everything else in the mx tree already spoke rustls (`reqwest` with `rustls-tls`, `hf-hub` with `hf-hub-rustls-tls`, `surrealdb` via `kv-surrealkv` + `protocol-ws`) — this one aliased feature was the last thread dragging the whole openssl chain in. A prior PR added `hf-hub-rustls-tls` but missed that the neighbor was also native-tls by default.

fastembed ships `ort-download-binaries-rustls-tls` as a drop-in replacement. Zero source changes required — mx has no direct openssl usage anywhere in `src/`.

## Evidence

**Dep tree, before:** `mx → fastembed → ort → ort-sys → ureq → native-tls → openssl-sys`

**Dep tree, after** (`cargo tree --target x86_64-pc-windows-msvc | grep -E "openssl|native-tls"`):
```
CLEAN: no openssl or native-tls in Windows target tree
```

Host (Linux) tree is equally clean. New TLS path: `ort-sys v2.0.0-rc.11 → ureq v3.2.0 → rustls v0.23.37`.

**Local checks:**
- `cargo check --release` → pass (34.83s)
- `cargo build --release` → pass (1m 32s), rustls/ring linked cleanly
- `cargo clippy --all-targets --all-features -- -D warnings` → pass (pre-push hook)
- `Cargo.lock` → untouched. `ureq v3.2.0` and `rustls v0.23.37` were already locked by reqwest and hf-hub, so the feature swap only re-routed which features activate on already-locked crates. No transitive version churn.

## Test plan

- [ ] Linux CI (`wake-up.yml`) green
- [ ] macOS CI green
- [ ] **Windows CI green** — the real oracle. Local Linux build is a strong signal (rustls/ring link cleanly), but pyke's ort binary CDN + rustls's default webpki root set is unverified until a Windows runner actually downloads at build time. Low risk, mainstream CDN.
- [ ] Post-merge: retrigger v0.1.105 release path. **Do NOT use `gh run rerun`** on the existing stalled run — per kn-abaec4ca, reruns cache the `@main` reusable-workflow pin resolution. Use `workflow_dispatch` or an empty-commit bump.

## Out of scope

`install-deps/action.yml` in nebuchadnezzar still has the chocolatey → slproweb trap for other consumers who genuinely need openssl. Hardening that (runner-bundled `C:\Program Files\OpenSSL` primary, vcpkg fallback) is a separate follow-up PR in the nebuchadnezzar repo.