### PR TITLE
feat: auto-backup memory content before update/delete

### DIFF
--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -227,6 +227,8 @@ DEFINE INDEX IF NOT EXISTS relates_to_unique ON relates_to FIELDS in, out, relat
 -- =============================================================================
 
 DEFINE TABLE IF NOT EXISTS memory_backup SCHEMAFULL;
+-- entry_id is a plain string (not record<knowledge>) because backups must
+-- survive entry deletion — a deleted entry has no record to reference.
 DEFINE FIELD IF NOT EXISTS entry_id     ON memory_backup TYPE string;
 DEFINE FIELD IF NOT EXISTS title        ON memory_backup TYPE string;
 DEFINE FIELD IF NOT EXISTS body         ON memory_backup TYPE option<string>;

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -223,6 +223,24 @@ DEFINE FIELD IF NOT EXISTS created_at ON relates_to TYPE datetime DEFAULT time::
 DEFINE INDEX IF NOT EXISTS relates_to_unique ON relates_to FIELDS in, out, relationship_type UNIQUE;
 
 -- =============================================================================
+-- MEMORY BACKUPS (Issue #206 - pre-mutation content snapshots)
+-- =============================================================================
+
+DEFINE TABLE IF NOT EXISTS memory_backup SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS entry_id     ON memory_backup TYPE string;
+DEFINE FIELD IF NOT EXISTS title        ON memory_backup TYPE string;
+DEFINE FIELD IF NOT EXISTS body         ON memory_backup TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS content_hash ON memory_backup TYPE string;
+DEFINE FIELD IF NOT EXISTS operation    ON memory_backup TYPE string
+  ASSERT $value IN ['update', 'delete', 'edit', 'append', 'prepend'];
+DEFINE FIELD IF NOT EXISTS source_agent ON memory_backup TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS created_at   ON memory_backup TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS backup_entry_id   ON memory_backup FIELDS entry_id;
+DEFINE INDEX IF NOT EXISTS backup_created    ON memory_backup FIELDS created_at;
+DEFINE INDEX IF NOT EXISTS backup_entry_time ON memory_backup FIELDS entry_id, created_at;
+
+-- =============================================================================
 -- METADATA TABLES
 -- =============================================================================
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -873,6 +873,20 @@ enum MemoryCommands {
         json: bool,
     },
 
+    /// Restore entry content from a backup
+    Restore {
+        /// Entry ID to restore
+        id: String,
+
+        /// List available backups instead of restoring
+        #[arg(long)]
+        list: bool,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Generate embedding for a knowledge entry
     Embed {
         /// Entry ID to embed (not used with --all)
@@ -2525,6 +2539,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 _ => store::AgentContext::public_only(),
             };
 
+            // Backup before delete (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "delete", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             if db.delete(&id, &ctx)? {
                 if json {
                     println!(
@@ -3033,6 +3055,22 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             let mut changes = Vec::new();
 
+            // Backup before body mutation (Issue #206)
+            let will_change_body = content.is_some()
+                || file.is_some()
+                || append_content.is_some()
+                || append_file.is_some()
+                || prepend_content.is_some()
+                || prepend_file.is_some()
+                || find.is_some();
+
+            if will_change_body {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "update", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             // Update title if provided
             if let Some(new_title) = title {
                 changes.push(format!("title: {} -> {}", entry.title, new_title));
@@ -3435,6 +3473,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 _ => store::AgentContext::public_only(),
             };
 
+            // Backup before edit (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "edit", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             let result = db.edit_content(&id, &ctx, &find, &replace, replace_all, nth)?;
 
             // Auto-generate embedding if in network SurrealDB mode
@@ -3496,6 +3542,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 bail!("No content provided");
             }
 
+            // Backup before append (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "append", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             db.append_content(&id, &ctx, &text)?;
 
             // Auto-generate embedding if in network SurrealDB mode
@@ -3553,6 +3607,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 bail!("No content provided");
             }
 
+            // Backup before prepend (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "prepend", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             db.prepend_content(&id, &ctx, &text)?;
 
             // Auto-generate embedding if in network SurrealDB mode
@@ -3572,6 +3634,84 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             } else {
                 println!("Prepended to entry: {}", id);
                 println!("  {} bytes added", text.len());
+            }
+        }
+
+        MemoryCommands::Restore { id, list, json } => {
+            let db = store::create_store_with_verbose(&config.db_path, verbose)?;
+            let id = normalize_id(&id);
+
+            if list {
+                // List available backups
+                let backups = db.list_backups(&id)?;
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&backups)?);
+                } else if backups.is_empty() {
+                    println!("No backups found for {}", id);
+                } else {
+                    println!("Backups for {}:", id);
+                    for b in &backups {
+                        let body_len = b.body.as_ref().map(|s| s.len()).unwrap_or(0);
+                        println!(
+                            "  {} | {} | {} | {} bytes",
+                            b.id,
+                            b.created_at.as_deref().unwrap_or("unknown"),
+                            b.operation,
+                            body_len,
+                        );
+                    }
+                }
+            } else {
+                // Restore from latest backup
+                let ctx = match std::env::var("MX_CURRENT_AGENT") {
+                    Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
+                    _ => store::AgentContext::public_only(),
+                };
+
+                let backup = db
+                    .latest_backup(&id)?
+                    .ok_or_else(|| anyhow::anyhow!("No backups found for {}", id))?;
+
+                // Fetch current entry and backup it before restoring
+                if let Some(current) = db.get(&id, &ctx)? {
+                    let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                    if let Err(e) = db.backup_content(&current, "update", agent.as_deref()) {
+                        eprintln!("Warning: failed to backup current state before restore: {}", e);
+                    }
+                }
+
+                // Restore: update the entry's body with the backup content
+                let mut entry = db
+                    .get(&id, &ctx)?
+                    .ok_or_else(|| anyhow::anyhow!("Entry not found: {}", id))?;
+                entry.body = backup.body.clone();
+
+                // Recompute content hash
+                let hash_body = entry.body.as_deref().unwrap_or("").to_string();
+                entry.content_hash = Some(knowledge::KnowledgeEntry::compute_hash(&hash_body));
+
+                db.upsert_knowledge(&entry)?;
+
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "restored": true,
+                            "id": id,
+                            "from_backup": backup.id,
+                            "backup_created": backup.created_at,
+                            "operation": backup.operation,
+                        }))?
+                    );
+                } else {
+                    println!("Restored entry: {}", id);
+                    println!("  from backup: {}", backup.id);
+                    println!(
+                        "  backup created: {}",
+                        backup.created_at.as_deref().unwrap_or("unknown")
+                    );
+                    println!("  original operation: {}", backup.operation);
+                }
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3036,9 +3036,13 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // For Update, use current agent context to allow updating own private entries
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            // #10: read MX_CURRENT_AGENT once, reuse for both ctx and backup
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Fetch existing entry
@@ -3065,8 +3069,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 || find.is_some();
 
             if will_change_body {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "update", agent.as_deref()) {
+                if let Err(e) = db.backup_content(&entry, "update", current_agent.as_deref()) {
                     eprintln!("Warning: failed to create backup: {}", e);
                 }
             }
@@ -3641,59 +3644,87 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
             let id = normalize_id(&id);
 
+            // Shared agent context (#10: read MX_CURRENT_AGENT once)
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
+            };
+
             if list {
                 // List available backups
-                let backups = db.list_backups(&id)?;
-                if json {
-                    println!("{}", serde_json::to_string_pretty(&backups)?);
-                } else if backups.is_empty() {
-                    println!("No backups found for {}", id);
+                // #7: filter by visibility — only show backups for entries the agent can see
+                if db.get(&id, &ctx)?.is_none() {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&serde_json::json!([]))?);
+                    } else {
+                        println!("No entry or backups found for {}", id);
+                    }
                 } else {
-                    println!("Backups for {}:", id);
-                    for b in &backups {
-                        let body_len = b.body.as_ref().map(|s| s.len()).unwrap_or(0);
-                        println!(
-                            "  {} | {} | {} | {} bytes",
-                            b.id,
-                            b.created_at.as_deref().unwrap_or("unknown"),
-                            b.operation,
-                            body_len,
-                        );
+                    let backups = db.list_backups(&id)?;
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&backups)?);
+                    } else if backups.is_empty() {
+                        println!("No backups found for {}", id);
+                    } else {
+                        println!("Backups for {}:", id);
+                        for b in &backups {
+                            let body_len = b.body.as_ref().map(|s| s.len()).unwrap_or(0);
+                            println!(
+                                "  {} | {} | {} | {} bytes",
+                                b.id,
+                                b.created_at.as_deref().unwrap_or("unknown"),
+                                b.operation,
+                                body_len,
+                            );
+                        }
                     }
                 }
             } else {
-                // Restore from latest backup
-                let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                    Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                    _ => store::AgentContext::public_only(),
-                };
-
                 let backup = db
                     .latest_backup(&id)?
                     .ok_or_else(|| anyhow::anyhow!("No backups found for {}", id))?;
 
-                // Fetch current entry and backup it before restoring
-                if let Some(current) = db.get(&id, &ctx)? {
-                    let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                    if let Err(e) = db.backup_content(&current, "update", agent.as_deref()) {
-                        eprintln!(
-                            "Warning: failed to backup current state before restore: {}",
-                            e
+                // #5: single fetch, #6: better error for deleted entries
+                let mut entry = match db.get(&id, &ctx)? {
+                    Some(entry) => {
+                        // Backup current state before restoring
+                        if let Err(e) =
+                            db.backup_content(&entry, "update", current_agent.as_deref())
+                        {
+                            eprintln!(
+                                "Warning: failed to backup current state before restore: {}",
+                                e
+                            );
+                        }
+                        entry
+                    }
+                    None => {
+                        bail!(
+                            "Entry '{}' not found (may have been deleted). \
+                             Restore from backup after deletion is not yet supported.",
+                            id
                         );
                     }
-                }
+                };
 
-                // Restore: update the entry's body with the backup content
-                let mut entry = db
-                    .get(&id, &ctx)?
-                    .ok_or_else(|| anyhow::anyhow!("Entry not found: {}", id))?;
+                // Restore body from backup
                 entry.body = backup.body.clone();
+
+                // #4: set updated_at
+                entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
 
                 // Recompute content hash
                 let hash_body = entry.body.as_deref().unwrap_or("").to_string();
                 entry.content_hash = Some(knowledge::KnowledgeEntry::compute_hash(&hash_body));
 
                 db.upsert_knowledge(&entry)?;
+
+                // #3: update embeddings and anchors like all other mutation paths
+                auto_embed(&id, db.as_ref())?;
+                auto_anchor(&id, db.as_ref(), None)?;
 
                 if json {
                     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2534,17 +2534,19 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Respect visibility: agents can only delete entries they can see
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Backup before delete (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "delete", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "delete", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             if db.delete(&id, &ctx)? {
@@ -3069,9 +3071,9 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 || find.is_some();
 
             if will_change_body {
-                if let Err(e) = db.backup_content(&entry, "update", current_agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "update", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             // Update title if provided
@@ -3471,17 +3473,19 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Use current agent context for private entry access
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Backup before edit (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "edit", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "edit", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             let result = db.edit_content(&id, &ctx, &find, &replace, replace_all, nth)?;
@@ -3522,9 +3526,12 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Use current agent context for private entry access
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Get content from argument, file, or stdin
@@ -3547,10 +3554,9 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Backup before append (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "append", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "append", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             db.append_content(&id, &ctx, &text)?;
@@ -3587,9 +3593,12 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Use current agent context for private entry access
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Get content from argument, file, or stdin
@@ -3612,10 +3621,9 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Backup before prepend (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "prepend", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "prepend", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             db.prepend_content(&id, &ctx, &text)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3676,7 +3676,10 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 if let Some(current) = db.get(&id, &ctx)? {
                     let agent = std::env::var("MX_CURRENT_AGENT").ok();
                     if let Err(e) = db.backup_content(&current, "update", agent.as_deref()) {
-                        eprintln!("Warning: failed to backup current state before restore: {}", e);
+                        eprintln!(
+                            "Warning: failed to backup current state before restore: {}",
+                            e
+                        );
                     }
                 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -263,7 +263,7 @@ pub trait KnowledgeStore {
     fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>>;
 
     /// Purge old backups, keeping the most recent `keep` per entry
-    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize>;
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<()>;
 
     // =========================================================================
     // TAG OPERATIONS

--- a/src/store.rs
+++ b/src/store.rs
@@ -245,6 +245,27 @@ pub trait KnowledgeStore {
     fn prepend_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()>;
 
     // =========================================================================
+    // BACKUP OPERATIONS (Issue #206)
+    // =========================================================================
+
+    /// Create a pre-mutation backup of entry content
+    fn backup_content(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String>;
+
+    /// List backups for a specific entry, newest first
+    fn list_backups(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>>;
+
+    /// Get the most recent backup for an entry
+    fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>>;
+
+    /// Purge old backups, keeping the most recent `keep` per entry
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize>;
+
+    // =========================================================================
     // TAG OPERATIONS
     // =========================================================================
 

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1274,10 +1274,7 @@ impl SurrealDatabase {
         Self::runtime().block_on(self.list_backups_async(entry_id))
     }
 
-    async fn list_backups_async(
-        &self,
-        entry_id: &str,
-    ) -> Result<Vec<crate::types::MemoryBackup>> {
+    async fn list_backups_async(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
         let mut response = with_db!(self, db, {
             db.query(
                 "SELECT meta::id(id) AS id, entry_id, title, body, content_hash,

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1237,7 +1237,7 @@ impl SurrealDatabase {
         let backup_id = format!(
             "{}_{}",
             entry_id.replace("kn-", ""),
-            Utc::now().format("%Y%m%dT%H%M%S")
+            Utc::now().format("%Y%m%dT%H%M%S%.3f")
         );
 
         let _response = with_db!(self, db, {
@@ -1323,11 +1323,11 @@ impl SurrealDatabase {
     }
 
     /// Purge old backups, keeping the most recent `keep` per entry
-    pub fn purge_backups_internal(&self, entry_id: &str, keep: usize) -> Result<usize> {
+    pub fn purge_backups_internal(&self, entry_id: &str, keep: usize) -> Result<()> {
         Self::runtime().block_on(self.purge_backups_async(entry_id, keep))
     }
 
-    async fn purge_backups_async(&self, entry_id: &str, keep: usize) -> Result<usize> {
+    async fn purge_backups_async(&self, entry_id: &str, keep: usize) -> Result<()> {
         // Delete backups older than the Nth newest
         let _response = with_db!(self, db, {
             db.query(
@@ -1346,7 +1346,7 @@ impl SurrealDatabase {
             .context("Failed to purge old backups")
         })?;
 
-        Ok(0)
+        Ok(())
     }
 
     /// Search knowledge using BM25 full-text indexes
@@ -3888,7 +3888,7 @@ impl KnowledgeStore for SurrealDatabase {
         self.latest_backup_internal(entry_id)
     }
 
-    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize> {
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<()> {
         self.purge_backups_internal(entry_id, keep)
     }
 

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1212,6 +1212,146 @@ impl SurrealDatabase {
         Ok(true)
     }
 
+    // =========================================================================
+    // BACKUP OPERATIONS (Issue #206)
+    // =========================================================================
+
+    /// Create a pre-mutation backup of entry content
+    pub fn backup_content_internal(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String> {
+        Self::runtime().block_on(self.backup_content_async(entry, operation, agent))
+    }
+
+    async fn backup_content_async(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String> {
+        let entry_id = entry.id.clone();
+        let content_hash = entry.content_hash.clone().unwrap_or_default();
+        let backup_id = format!(
+            "{}_{}",
+            entry_id.replace("kn-", ""),
+            Utc::now().format("%Y%m%dT%H%M%S")
+        );
+
+        let _response = with_db!(self, db, {
+            db.query(
+                "CREATE type::thing('memory_backup', $backup_id) SET
+                    entry_id = $entry_id,
+                    title = $title,
+                    body = $body,
+                    content_hash = $content_hash,
+                    operation = $operation,
+                    source_agent = $source_agent,
+                    created_at = time::now()
+                ",
+            )
+            .bind(("backup_id", backup_id.clone()))
+            .bind(("entry_id", entry_id.clone()))
+            .bind(("title", entry.title.clone()))
+            .bind(("body", entry.body.clone()))
+            .bind(("content_hash", content_hash))
+            .bind(("operation", operation.to_string()))
+            .bind(("source_agent", agent.map(|s| s.to_string())))
+            .await
+            .context("Failed to create memory backup")
+        })?;
+
+        // Purge old backups (keep 10 per entry) — non-fatal
+        let _ = self.purge_backups_async(&entry_id, 10).await;
+
+        Ok(backup_id)
+    }
+
+    /// List backups for an entry, newest first
+    pub fn list_backups_internal(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
+        Self::runtime().block_on(self.list_backups_async(entry_id))
+    }
+
+    async fn list_backups_async(
+        &self,
+        entry_id: &str,
+    ) -> Result<Vec<crate::types::MemoryBackup>> {
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(id) AS id, entry_id, title, body, content_hash,
+                        operation, source_agent, created_at
+                 FROM memory_backup
+                 WHERE entry_id = $entry_id
+                 ORDER BY created_at DESC",
+            )
+            .bind(("entry_id", entry_id.to_string()))
+            .await
+            .context("Failed to list memory backups")
+        })?;
+
+        let backups: Vec<crate::types::MemoryBackup> = response.take(0)?;
+        Ok(backups)
+    }
+
+    /// Get the most recent backup for an entry
+    pub fn latest_backup_internal(
+        &self,
+        entry_id: &str,
+    ) -> Result<Option<crate::types::MemoryBackup>> {
+        Self::runtime().block_on(self.latest_backup_async(entry_id))
+    }
+
+    async fn latest_backup_async(
+        &self,
+        entry_id: &str,
+    ) -> Result<Option<crate::types::MemoryBackup>> {
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(id) AS id, entry_id, title, body, content_hash,
+                        operation, source_agent, created_at
+                 FROM memory_backup
+                 WHERE entry_id = $entry_id
+                 ORDER BY created_at DESC
+                 LIMIT 1",
+            )
+            .bind(("entry_id", entry_id.to_string()))
+            .await
+            .context("Failed to get latest backup")
+        })?;
+
+        let backups: Vec<crate::types::MemoryBackup> = response.take(0)?;
+        Ok(backups.into_iter().next())
+    }
+
+    /// Purge old backups, keeping the most recent `keep` per entry
+    pub fn purge_backups_internal(&self, entry_id: &str, keep: usize) -> Result<usize> {
+        Self::runtime().block_on(self.purge_backups_async(entry_id, keep))
+    }
+
+    async fn purge_backups_async(&self, entry_id: &str, keep: usize) -> Result<usize> {
+        // Delete backups older than the Nth newest
+        let _response = with_db!(self, db, {
+            db.query(
+                "DELETE FROM memory_backup
+                    WHERE entry_id = $entry_id
+                    AND id NOT IN (
+                        SELECT VALUE id FROM memory_backup
+                        WHERE entry_id = $entry_id
+                        ORDER BY created_at DESC
+                        LIMIT $keep
+                    )",
+            )
+            .bind(("entry_id", entry_id.to_string()))
+            .bind(("keep", keep as i64))
+            .await
+            .context("Failed to purge old backups")
+        })?;
+
+        Ok(0)
+    }
+
     /// Search knowledge using BM25 full-text indexes
     pub fn search_knowledge(
         &self,
@@ -3732,6 +3872,27 @@ impl KnowledgeStore for SurrealDatabase {
         content: &str,
     ) -> Result<()> {
         self.prepend_content(id, ctx, content)
+    }
+
+    fn backup_content(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String> {
+        self.backup_content_internal(entry, operation, agent)
+    }
+
+    fn list_backups(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
+        self.list_backups_internal(entry_id)
+    }
+
+    fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>> {
+        self.latest_backup_internal(entry_id)
+    }
+
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize> {
+        self.purge_backups_internal(entry_id, keep)
     }
 
     fn create_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<String> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,6 +71,22 @@ pub struct RelationshipType {
     pub created_at: String,
 }
 
+/// Pre-mutation content backup (Issue #206)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryBackup {
+    pub id: String,
+    pub entry_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    pub content_hash: String,
+    pub operation: String,
+    #[serde(default)]
+    pub source_agent: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Relationship {
     pub id: String,


### PR DESCRIPTION
## Summary

Closes #206.

- Automatically creates a pre-mutation backup of memory content before any destructive operation (update, delete, edit, append, prepend)
- Adds `mx memory restore <id>` command to restore from the latest backup
- Adds `mx memory restore <id> --list` to view available backups
- Backups stored in a dedicated `memory_backup` SurrealDB table
- Rolling retention of 10 backups per entry
- Restore creates its own backup first (can never lose data by restoring)

## Changes

- **schema/surrealdb-schema.surql** — New `memory_backup` table with indexes
- **src/types.rs** — `MemoryBackup` struct
- **src/store.rs** — `backup_content`, `list_backups`, `latest_backup`, `purge_backups` trait methods
- **src/surreal_db.rs** — SurrealDB implementations for backup operations
- **src/main.rs** — Backup hooks in Update, Delete, Edit, Append, Prepend handlers + Restore subcommand

## Design

Architecture by Schemnya (see #206 comment). Key decisions:
- SurrealDB table over flat files (same transactional context, no second storage system)
- Hooks at CLI handler level, not store trait methods (avoids duplicate backups from shortcut commands)
- Only backs up on body mutations, not metadata-only changes
- Backup failures are warnings, not fatal errors (the mutation still proceeds)

## Test plan

- [x] `mx memory update --append-content` creates backup before mutating
- [x] `mx memory restore <id> --list` shows backup history
- [x] `mx memory restore <id>` restores content from latest backup
- [x] Restore creates its own backup before overwriting
- [ ] `mx memory delete` creates backup before deleting
- [ ] Purge keeps only 10 most recent backups per entry
- [ ] `mx memory edit` creates backup before find/replace