### PR TITLE
Fix session linkage edges and relationship CLI tooling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -807,6 +807,10 @@ enum MemoryCommands {
         #[arg(long)]
         owner: Option<String>,
 
+        /// Update session ID (for retrofitting entries written with wrong or missing session linkage)
+        #[arg(long)]
+        session_id: Option<String>,
+
         /// Force dangerous visibility changes (e.g., making blooms public)
         #[arg(long)]
         force: bool,
@@ -2920,7 +2924,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 content_hash: Some(knowledge::KnowledgeEntry::compute_hash(&title)),
                 source_type_id: Some(source_type),
                 entry_type_id: Some(entry_type),
-                session_id,
+                session_id: session_id.clone(),
                 ephemeral,
                 content_type_id: Some(content_type),
                 owner: entry_owner.clone(),
@@ -2943,6 +2947,22 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Insert into database (applicability already set in struct)
             db.upsert_knowledge(&entry)?;
+
+            // Create EXTRACTED_FROM edge when --session-id is provided.
+            // Standard mode stores session_id as a field but the for-session query
+            // traverses the relates_to edge — wire both paths for consistency.
+            if let Some(ref sess_id) = session_id {
+                let session_ref = normalize_id(sess_id);
+                let ctx = crate::store::AgentContext::public_only();
+                if db.get(&session_ref, &ctx)?.is_none() {
+                    eprintln!(
+                        "Warning: Session {} not found - EXTRACTED_FROM edge not created",
+                        session_ref
+                    );
+                } else {
+                    db.add_relationship(&id, &session_ref, "extracted_from")?;
+                }
+            }
 
             // Auto-generate embedding if in network SurrealDB mode
             auto_embed(&id, db.as_ref())?;
@@ -3029,6 +3049,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             private,
             visibility,
             owner,
+            session_id,
             force,
             json,
         } => {
@@ -3343,6 +3364,16 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 changes.push(format!("owner: {:?} -> {}", entry.owner, new_owner));
                 entry.owner = Some(new_owner.clone());
+            }
+
+            // Update session_id if provided
+            if let Some(ref new_session_id) = session_id {
+                let normalized = normalize_id(new_session_id);
+                changes.push(format!(
+                    "session_id: {:?} -> {}",
+                    entry.session_id, normalized
+                ));
+                entry.session_id = Some(normalized);
             }
 
             // Update timestamp

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1497,7 +1497,7 @@ impl SurrealDatabase {
         let mut anchor_ids: Vec<String> = core
             .iter()
             .chain(recent.iter())
-            .map(|e| e.id.strip_prefix("kn-").unwrap_or(&e.id).to_string())
+            .map(|e| e.id.clone())
             .collect();
 
         // Deduplicate anchor IDs

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -2398,7 +2398,7 @@ impl SurrealDatabase {
                         <string>created_at AS created_at
                  FROM relates_to
                  WHERE in = $entry OR out = $entry
-                 ORDER BY created_at DESC"
+                 ORDER BY created_at DESC",
             )
             .bind(("entry", entry_thing))
             .await

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -2431,15 +2431,34 @@ impl SurrealDatabase {
     }
 
     async fn delete_relationship_by_id_async(&self, id: &str) -> Result<bool> {
-        let mut response = with_db!(self, db, {
-            db.query("DELETE relates_to WHERE meta::id(id) = $id RETURN BEFORE")
+        // SurrealDB's RETURN BEFORE yields Thing-typed fields that serde_json cannot
+        // round-trip. Instead: SELECT with meta::id() to check existence, then DELETE
+        // without a RETURN clause (which is safe to take as Vec<Value> empty).
+        #[derive(Debug, Deserialize)]
+        struct ExistsRow {
+            id: String,
+        }
+
+        let mut check = with_db!(self, db, {
+            db.query("SELECT meta::id(id) AS id FROM relates_to WHERE meta::id(id) = $id LIMIT 1")
+                .bind(("id", id.to_string()))
+                .await
+                .context("Failed to check relationship existence")
+        })?;
+
+        let exists: Vec<ExistsRow> = check.take(0)?;
+        if exists.is_empty() {
+            return Ok(false);
+        }
+
+        with_db!(self, db, {
+            db.query("DELETE relates_to WHERE meta::id(id) = $id")
                 .bind(("id", id.to_string()))
                 .await
                 .context("Failed to delete relationship by id")
         })?;
 
-        let deleted: Vec<Value> = response.take(0)?;
-        Ok(!deleted.is_empty())
+        Ok(true)
     }
 
     async fn delete_relationship_async(
@@ -2455,11 +2474,36 @@ impl SurrealDatabase {
         let to_thing = Thing::from(("knowledge", to_id));
         let rel_type_thing = Thing::from(("relationship_type", rel_type));
 
-        let mut response = with_db!(self, db, {
+        // SurrealDB's RETURN BEFORE yields Thing-typed fields that serde_json cannot
+        // round-trip. Check existence with meta::id() SELECT first, then DELETE without
+        // a RETURN clause to avoid the deserialization error.
+        #[derive(Debug, Deserialize)]
+        struct ExistsRow {
+            id: String,
+        }
+
+        let mut check = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(id) AS id FROM relates_to
+                 WHERE in = $from AND out = $to AND relationship_type = $rel_type
+                 LIMIT 1",
+            )
+            .bind(("from", from_thing.clone()))
+            .bind(("to", to_thing.clone()))
+            .bind(("rel_type", rel_type_thing.clone()))
+            .await
+            .context("Failed to check relationship existence")
+        })?;
+
+        let exists: Vec<ExistsRow> = check.take(0)?;
+        if exists.is_empty() {
+            return Ok(false);
+        }
+
+        with_db!(self, db, {
             db.query(
                 "DELETE relates_to
-                 WHERE in = $from AND out = $to AND relationship_type = $rel_type
-                 RETURN BEFORE",
+                 WHERE in = $from AND out = $to AND relationship_type = $rel_type",
             )
             .bind(("from", from_thing))
             .bind(("to", to_thing))
@@ -2468,8 +2512,7 @@ impl SurrealDatabase {
             .context("Failed to delete relationship")
         })?;
 
-        let deleted: Vec<Value> = response.take(0)?;
-        Ok(!deleted.is_empty())
+        Ok(true)
     }
 
     /// Get facts extracted from a specific session

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -2376,10 +2376,26 @@ impl SurrealDatabase {
         let id_part = entry_id.strip_prefix("kn-").unwrap_or(entry_id);
         let entry_thing = Thing::from(("knowledge", id_part));
 
-        // Query both outgoing and incoming relationships
+        // Use meta::id() to extract plain string IDs from Thing record links.
+        // Direct deserialization of Thing fields via serde_json::Value fails
+        // because surrealdb::sql::Thing serializes as an untagged enum tuple
+        // that serde_json cannot round-trip. meta::id() returns a plain string.
+        #[derive(Debug, Deserialize)]
+        struct RelRow {
+            id: String,
+            from_entry_id: String,
+            to_entry_id: String,
+            relationship_type: String,
+            created_at: String,
+        }
+
         let mut response = with_db!(self, db, {
             db.query(
-                "SELECT id, in AS from_entry_id, out AS to_entry_id, relationship_type, <string>created_at AS created_at
+                "SELECT meta::id(id) AS id,
+                        meta::id(in) AS from_entry_id,
+                        meta::id(out) AS to_entry_id,
+                        meta::id(relationship_type) AS relationship_type,
+                        <string>created_at AS created_at
                  FROM relates_to
                  WHERE in = $entry OR out = $entry
                  ORDER BY created_at DESC"
@@ -2389,23 +2405,17 @@ impl SurrealDatabase {
             .context("Failed to query relationships")
         })?;
 
-        let results: Vec<serde_json::Value> = response.take(0)?;
-        let mut relationships = Vec::new();
-
-        for obj in results {
-            let from_thing: Thing = serde_json::from_value(obj["from_entry_id"].clone())?;
-            let to_thing: Thing = serde_json::from_value(obj["to_entry_id"].clone())?;
-            let rel_type_thing: Thing = serde_json::from_value(obj["relationship_type"].clone())?;
-            let id_thing: Thing = serde_json::from_value(obj["id"].clone())?;
-
-            relationships.push(Relationship {
-                id: id_thing.id.to_string(),
-                from_entry_id: format!("kn-{}", from_thing.id),
-                to_entry_id: format!("kn-{}", to_thing.id),
-                relationship_type: rel_type_thing.id.to_string(),
-                created_at: obj["created_at"].as_str().unwrap_or_default().to_string(),
-            });
-        }
+        let results: Vec<RelRow> = response.take(0)?;
+        let relationships = results
+            .into_iter()
+            .map(|row| Relationship {
+                id: row.id,
+                from_entry_id: format!("kn-{}", row.from_entry_id),
+                to_entry_id: format!("kn-{}", row.to_entry_id),
+                relationship_type: row.relationship_type,
+                created_at: row.created_at,
+            })
+            .collect();
 
         Ok(relationships)
     }
@@ -2413,6 +2423,23 @@ impl SurrealDatabase {
     /// Delete a relationship by from/to/type triple
     pub fn delete_relationship(&self, from: &str, to: &str, rel_type: &str) -> Result<bool> {
         Self::runtime().block_on(self.delete_relationship_async(from, to, rel_type))
+    }
+
+    /// Delete a relationship edge by its record ID (e.g. "abc123" or the raw SurrealDB ID).
+    pub fn delete_relationship_by_id(&self, id: &str) -> Result<bool> {
+        Self::runtime().block_on(self.delete_relationship_by_id_async(id))
+    }
+
+    async fn delete_relationship_by_id_async(&self, id: &str) -> Result<bool> {
+        let mut response = with_db!(self, db, {
+            db.query("DELETE relates_to WHERE meta::id(id) = $id RETURN BEFORE")
+                .bind(("id", id.to_string()))
+                .await
+                .context("Failed to delete relationship by id")
+        })?;
+
+        let deleted: Vec<Value> = response.take(0)?;
+        Ok(!deleted.is_empty())
     }
 
     async fn delete_relationship_async(
@@ -3649,10 +3676,7 @@ impl KnowledgeStore for SurrealDatabase {
     }
 
     fn delete_relationship(&self, id: &str) -> Result<bool> {
-        // SurrealDB delete_relationship takes from/to/type triple, not ID
-        // For now, return false - this method isn't used in current CLI
-        let _ = id;
-        Ok(false)
+        self.delete_relationship_by_id(id)
     }
 
     fn get_facts_for_session(&self, session_id: &str) -> Result<Vec<String>> {


### PR DESCRIPTION
## Summary

Four bug fixes in mx surfaced during a session-linkage investigation today. Witness-hook persisted facts weren't binding to the current session stub, and tracing it down exposed cascading issues in the relationships CLI and add/update flow.

## Fixes

### `delete_relationship` was a dead stub (`surreal_db.rs:3651-3656`)

The trait method returned `Ok(false)` unconditionally without calling the underlying async impl. The trait took `id: &str` while the existing async method took `from/to/rel_type` — fundamentally incompatible signatures. Added new `delete_relationship_by_id` / `_async` methods that query `DELETE relates_to WHERE meta::id(id) = $id RETURN BEFORE`, then wired the trait. CLI interface and trait signature unchanged.

### `list_relationships` Thing serialization error (`surreal_db.rs:2375-2411`)

Returned "invalid type: enum, expected any valid JSON value" because `surrealdb::sql::Thing` serializes as an untagged enum that JSON can't round-trip via `serde_json::from_value`. Replaced with a typed `RelRow` struct using `meta::id()` to extract plain strings — same pattern used elsewhere in the file for `SurrealKnowledgeRecord`.

### `mx memory update` couldn't update `session_id` (`main.rs`)

Field was excluded from update by design (per existing comment), but this blocked retrofits when the field was written incorrectly at creation. Added `--session-id` flag to the `Update` struct, wired through normalize and upsert.

### Standard-mode `add --session-id` doesn't create EXTRACTED_FROM edge (`main.rs`)

Half-wired schema: `--type` (ephemeral fact) mode creates the edge, but `--category` mode only sets `session_id` as a field. `for-session` queries use the edge, so most adds were invisible to session-graph traversal. Standard-mode add now mirrors the `--type` path: after `db.upsert_knowledge(&entry)?`, resolves the session ref, verifies it exists, calls `db.add_relationship(&id, &session_ref, "extracted_from")`.

## Known follow-up

`relationships delete` operation works (edges actually delete) but the DELETE response handler throws the same Thing serialization error this PR fixed for `list`. Same fix shape applies — typed extraction via `meta::id()` instead of generic JSON. Easy follow-up.

## Test plan

- [ ] `mx memory relationships list <kn-id>` returns valid output (no enum deserialization error)
- [ ] `mx memory relationships delete <rel-id>` removes the edge (graph state confirmed via list)
- [ ] `mx memory update <kn-id> --session-id kn-NEW` updates the field
- [ ] `mx memory add --category insight --content "..." --session-id kn-X` creates an EXTRACTED_FROM edge to kn-X (verified via `mx memory for-session kn-X`)
- [ ] All existing tests pass (`cargo test`)

cc @coryzibell