### PR TITLE
fix(state): handle markdown bold in Wake State parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/coryzibell/mx"
 clap = { version = "4", features = ["derive"] }
 
 # SurrealDB
-surrealdb = { version = "2", features = ["kv-surrealkv", "protocol-ws"] }
+surrealdb = { version = "2", features = ["kv-surrealkv", "protocol-ws", "rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/history.txt
+++ b/history.txt
@@ -2,3 +2,9 @@
 DELETE knowledge;
 quit;
 exit;
+SELECT count() AS c FROM knowledge WHERE category = category:bloom AND (visibility = 'public') GROUP ALL;
+SELECT count() AS c FROM knowledge WHERE category = category:bloom GROUP ALL;
+SELECT count() AS c FROM knowledge WHERE category = "category:bloom" GROUP ALL;
+SELECT count() AS c FROM knowledge WHERE category = category:bloom AND visibility = 'public' GROUP ALL;
+SELECT visibility FROM knowledge WHERE category = category:bloom LIMIT 3;
+SELECT count() AS c FROM (SELECT id FROM knowledge WHERE category = category:bloom AND visibility = 'public') GROUP ALL;

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -227,6 +227,8 @@ DEFINE INDEX IF NOT EXISTS relates_to_unique ON relates_to FIELDS in, out, relat
 -- =============================================================================
 
 DEFINE TABLE IF NOT EXISTS memory_backup SCHEMAFULL;
+-- entry_id is a plain string (not record<knowledge>) because backups must
+-- survive entry deletion — a deleted entry has no record to reference.
 DEFINE FIELD IF NOT EXISTS entry_id     ON memory_backup TYPE string;
 DEFINE FIELD IF NOT EXISTS title        ON memory_backup TYPE string;
 DEFINE FIELD IF NOT EXISTS body         ON memory_backup TYPE option<string>;

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -223,6 +223,24 @@ DEFINE FIELD IF NOT EXISTS created_at ON relates_to TYPE datetime DEFAULT time::
 DEFINE INDEX IF NOT EXISTS relates_to_unique ON relates_to FIELDS in, out, relationship_type UNIQUE;
 
 -- =============================================================================
+-- MEMORY BACKUPS (Issue #206 - pre-mutation content snapshots)
+-- =============================================================================
+
+DEFINE TABLE IF NOT EXISTS memory_backup SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS entry_id     ON memory_backup TYPE string;
+DEFINE FIELD IF NOT EXISTS title        ON memory_backup TYPE string;
+DEFINE FIELD IF NOT EXISTS body         ON memory_backup TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS content_hash ON memory_backup TYPE string;
+DEFINE FIELD IF NOT EXISTS operation    ON memory_backup TYPE string
+  ASSERT $value IN ['update', 'delete', 'edit', 'append', 'prepend'];
+DEFINE FIELD IF NOT EXISTS source_agent ON memory_backup TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS created_at   ON memory_backup TYPE datetime DEFAULT time::now();
+
+DEFINE INDEX IF NOT EXISTS backup_entry_id   ON memory_backup FIELDS entry_id;
+DEFINE INDEX IF NOT EXISTS backup_created    ON memory_backup FIELDS created_at;
+DEFINE INDEX IF NOT EXISTS backup_entry_time ON memory_backup FIELDS entry_id, created_at;
+
+-- =============================================================================
 -- METADATA TABLES
 -- =============================================================================
 

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -170,7 +170,7 @@ pub fn list_sessions(all: bool, json: bool) -> Result<()> {
     }
 
     // Sort by archived_at (most recent first)
-    archives.sort_by(|a, b| b.manifest.archived_at.cmp(&a.manifest.archived_at));
+    archives.sort_by_key(|a| std::cmp::Reverse(a.manifest.archived_at));
 
     // Filter incremental archives unless --all
     if !all {
@@ -192,7 +192,7 @@ pub fn list_sessions(all: bool, json: bool) -> Result<()> {
         }
 
         archives = latest_map.into_values().collect();
-        archives.sort_by(|a, b| b.manifest.archived_at.cmp(&a.manifest.archived_at));
+        archives.sort_by_key(|a| std::cmp::Reverse(a.manifest.archived_at));
     }
 
     if json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -873,6 +873,20 @@ enum MemoryCommands {
         json: bool,
     },
 
+    /// Restore entry content from a backup
+    Restore {
+        /// Entry ID to restore
+        id: String,
+
+        /// List available backups instead of restoring
+        #[arg(long)]
+        list: bool,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Generate embedding for a knowledge entry
     Embed {
         /// Entry ID to embed (not used with --all)
@@ -2525,6 +2539,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 _ => store::AgentContext::public_only(),
             };
 
+            // Backup before delete (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "delete", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             if db.delete(&id, &ctx)? {
                 if json {
                     println!(
@@ -3033,6 +3055,22 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             let mut changes = Vec::new();
 
+            // Backup before body mutation (Issue #206)
+            let will_change_body = content.is_some()
+                || file.is_some()
+                || append_content.is_some()
+                || append_file.is_some()
+                || prepend_content.is_some()
+                || prepend_file.is_some()
+                || find.is_some();
+
+            if will_change_body {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "update", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             // Update title if provided
             if let Some(new_title) = title {
                 changes.push(format!("title: {} -> {}", entry.title, new_title));
@@ -3435,6 +3473,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 _ => store::AgentContext::public_only(),
             };
 
+            // Backup before edit (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "edit", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             let result = db.edit_content(&id, &ctx, &find, &replace, replace_all, nth)?;
 
             // Auto-generate embedding if in network SurrealDB mode
@@ -3496,6 +3542,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 bail!("No content provided");
             }
 
+            // Backup before append (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "append", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             db.append_content(&id, &ctx, &text)?;
 
             // Auto-generate embedding if in network SurrealDB mode
@@ -3553,6 +3607,14 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 bail!("No content provided");
             }
 
+            // Backup before prepend (Issue #206)
+            if let Some(entry) = db.get(&id, &ctx)? {
+                let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                if let Err(e) = db.backup_content(&entry, "prepend", agent.as_deref()) {
+                    eprintln!("Warning: failed to create backup: {}", e);
+                }
+            }
+
             db.prepend_content(&id, &ctx, &text)?;
 
             // Auto-generate embedding if in network SurrealDB mode
@@ -3572,6 +3634,84 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             } else {
                 println!("Prepended to entry: {}", id);
                 println!("  {} bytes added", text.len());
+            }
+        }
+
+        MemoryCommands::Restore { id, list, json } => {
+            let db = store::create_store_with_verbose(&config.db_path, verbose)?;
+            let id = normalize_id(&id);
+
+            if list {
+                // List available backups
+                let backups = db.list_backups(&id)?;
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&backups)?);
+                } else if backups.is_empty() {
+                    println!("No backups found for {}", id);
+                } else {
+                    println!("Backups for {}:", id);
+                    for b in &backups {
+                        let body_len = b.body.as_ref().map(|s| s.len()).unwrap_or(0);
+                        println!(
+                            "  {} | {} | {} | {} bytes",
+                            b.id,
+                            b.created_at.as_deref().unwrap_or("unknown"),
+                            b.operation,
+                            body_len,
+                        );
+                    }
+                }
+            } else {
+                // Restore from latest backup
+                let ctx = match std::env::var("MX_CURRENT_AGENT") {
+                    Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
+                    _ => store::AgentContext::public_only(),
+                };
+
+                let backup = db
+                    .latest_backup(&id)?
+                    .ok_or_else(|| anyhow::anyhow!("No backups found for {}", id))?;
+
+                // Fetch current entry and backup it before restoring
+                if let Some(current) = db.get(&id, &ctx)? {
+                    let agent = std::env::var("MX_CURRENT_AGENT").ok();
+                    if let Err(e) = db.backup_content(&current, "update", agent.as_deref()) {
+                        eprintln!("Warning: failed to backup current state before restore: {}", e);
+                    }
+                }
+
+                // Restore: update the entry's body with the backup content
+                let mut entry = db
+                    .get(&id, &ctx)?
+                    .ok_or_else(|| anyhow::anyhow!("Entry not found: {}", id))?;
+                entry.body = backup.body.clone();
+
+                // Recompute content hash
+                let hash_body = entry.body.as_deref().unwrap_or("").to_string();
+                entry.content_hash = Some(knowledge::KnowledgeEntry::compute_hash(&hash_body));
+
+                db.upsert_knowledge(&entry)?;
+
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "restored": true,
+                            "id": id,
+                            "from_backup": backup.id,
+                            "backup_created": backup.created_at,
+                            "operation": backup.operation,
+                        }))?
+                    );
+                } else {
+                    println!("Restored entry: {}", id);
+                    println!("  from backup: {}", backup.id);
+                    println!(
+                        "  backup created: {}",
+                        backup.created_at.as_deref().unwrap_or("unknown")
+                    );
+                    println!("  original operation: {}", backup.operation);
+                }
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3036,9 +3036,13 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // For Update, use current agent context to allow updating own private entries
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            // #10: read MX_CURRENT_AGENT once, reuse for both ctx and backup
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Fetch existing entry
@@ -3065,8 +3069,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 || find.is_some();
 
             if will_change_body {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "update", agent.as_deref()) {
+                if let Err(e) = db.backup_content(&entry, "update", current_agent.as_deref()) {
                     eprintln!("Warning: failed to create backup: {}", e);
                 }
             }
@@ -3641,59 +3644,87 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
             let id = normalize_id(&id);
 
+            // Shared agent context (#10: read MX_CURRENT_AGENT once)
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
+            };
+
             if list {
                 // List available backups
-                let backups = db.list_backups(&id)?;
-                if json {
-                    println!("{}", serde_json::to_string_pretty(&backups)?);
-                } else if backups.is_empty() {
-                    println!("No backups found for {}", id);
+                // #7: filter by visibility — only show backups for entries the agent can see
+                if db.get(&id, &ctx)?.is_none() {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&serde_json::json!([]))?);
+                    } else {
+                        println!("No entry or backups found for {}", id);
+                    }
                 } else {
-                    println!("Backups for {}:", id);
-                    for b in &backups {
-                        let body_len = b.body.as_ref().map(|s| s.len()).unwrap_or(0);
-                        println!(
-                            "  {} | {} | {} | {} bytes",
-                            b.id,
-                            b.created_at.as_deref().unwrap_or("unknown"),
-                            b.operation,
-                            body_len,
-                        );
+                    let backups = db.list_backups(&id)?;
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&backups)?);
+                    } else if backups.is_empty() {
+                        println!("No backups found for {}", id);
+                    } else {
+                        println!("Backups for {}:", id);
+                        for b in &backups {
+                            let body_len = b.body.as_ref().map(|s| s.len()).unwrap_or(0);
+                            println!(
+                                "  {} | {} | {} | {} bytes",
+                                b.id,
+                                b.created_at.as_deref().unwrap_or("unknown"),
+                                b.operation,
+                                body_len,
+                            );
+                        }
                     }
                 }
             } else {
-                // Restore from latest backup
-                let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                    Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                    _ => store::AgentContext::public_only(),
-                };
-
                 let backup = db
                     .latest_backup(&id)?
                     .ok_or_else(|| anyhow::anyhow!("No backups found for {}", id))?;
 
-                // Fetch current entry and backup it before restoring
-                if let Some(current) = db.get(&id, &ctx)? {
-                    let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                    if let Err(e) = db.backup_content(&current, "update", agent.as_deref()) {
-                        eprintln!(
-                            "Warning: failed to backup current state before restore: {}",
-                            e
+                // #5: single fetch, #6: better error for deleted entries
+                let mut entry = match db.get(&id, &ctx)? {
+                    Some(entry) => {
+                        // Backup current state before restoring
+                        if let Err(e) =
+                            db.backup_content(&entry, "update", current_agent.as_deref())
+                        {
+                            eprintln!(
+                                "Warning: failed to backup current state before restore: {}",
+                                e
+                            );
+                        }
+                        entry
+                    }
+                    None => {
+                        bail!(
+                            "Entry '{}' not found (may have been deleted). \
+                             Restore from backup after deletion is not yet supported.",
+                            id
                         );
                     }
-                }
+                };
 
-                // Restore: update the entry's body with the backup content
-                let mut entry = db
-                    .get(&id, &ctx)?
-                    .ok_or_else(|| anyhow::anyhow!("Entry not found: {}", id))?;
+                // Restore body from backup
                 entry.body = backup.body.clone();
+
+                // #4: set updated_at
+                entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
 
                 // Recompute content hash
                 let hash_body = entry.body.as_deref().unwrap_or("").to_string();
                 entry.content_hash = Some(knowledge::KnowledgeEntry::compute_hash(&hash_body));
 
                 db.upsert_knowledge(&entry)?;
+
+                // #3: update embeddings and anchors like all other mutation paths
+                auto_embed(&id, db.as_ref())?;
+                auto_anchor(&id, db.as_ref(), None)?;
 
                 if json {
                     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2534,17 +2534,19 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Respect visibility: agents can only delete entries they can see
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Backup before delete (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "delete", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "delete", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             if db.delete(&id, &ctx)? {
@@ -3069,9 +3071,9 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 || find.is_some();
 
             if will_change_body {
-                if let Err(e) = db.backup_content(&entry, "update", current_agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "update", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             // Update title if provided
@@ -3471,17 +3473,19 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Use current agent context for private entry access
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Backup before edit (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "edit", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "edit", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             let result = db.edit_content(&id, &ctx, &find, &replace, replace_all, nth)?;
@@ -3522,9 +3526,12 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Use current agent context for private entry access
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Get content from argument, file, or stdin
@@ -3547,10 +3554,9 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Backup before append (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "append", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "append", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             db.append_content(&id, &ctx, &text)?;
@@ -3587,9 +3593,12 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             let id = normalize_id(&id);
 
             // Use current agent context for private entry access
-            let ctx = match std::env::var("MX_CURRENT_AGENT") {
-                Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-                _ => store::AgentContext::public_only(),
+            let current_agent = std::env::var("MX_CURRENT_AGENT")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let ctx = match &current_agent {
+                Some(agent) => store::AgentContext::for_agent(agent),
+                None => store::AgentContext::public_only(),
             };
 
             // Get content from argument, file, or stdin
@@ -3612,10 +3621,9 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Backup before prepend (Issue #206)
             if let Some(entry) = db.get(&id, &ctx)? {
-                let agent = std::env::var("MX_CURRENT_AGENT").ok();
-                if let Err(e) = db.backup_content(&entry, "prepend", agent.as_deref()) {
-                    eprintln!("Warning: failed to create backup: {}", e);
-                }
+                let _ = db
+                    .backup_content(&entry, "prepend", current_agent.as_deref())
+                    .map_err(|e| eprintln!("Warning: failed to create backup: {}", e));
             }
 
             db.prepend_content(&id, &ctx, &text)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3676,7 +3676,10 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 if let Some(current) = db.get(&id, &ctx)? {
                     let agent = std::env::var("MX_CURRENT_AGENT").ok();
                     if let Err(e) = db.backup_content(&current, "update", agent.as_deref()) {
-                        eprintln!("Warning: failed to backup current state before restore: {}", e);
+                        eprintln!(
+                            "Warning: failed to backup current state before restore: {}",
+                            e
+                        );
                     }
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2508,7 +2508,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             if json {
                 let mut cat_counts = serde_json::Map::new();
                 for cat in categories {
-                    let count = db.list_by_category(&cat.id, &ctx, &filter)?.len();
+                    let count = db.count_by_category(&cat.id, &ctx, &filter)?;
                     cat_counts.insert(cat.id, serde_json::Value::Number(count.into()));
                 }
                 println!(
@@ -2523,7 +2523,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 println!("Total entries: {}", total);
                 println!();
                 for cat in categories {
-                    let count = db.list_by_category(&cat.id, &ctx, &filter)?.len();
+                    let count = db.count_by_category(&cat.id, &ctx, &filter)?;
                     println!("  {:12} {}", cat.id, count);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1975,9 +1975,31 @@ fn handle_state(cmd: StateCommands) -> Result<()> {
             format,
             schema,
         } => {
-            let schema = load_legacy_schema(schema)?;
+            // Strip leading markdown bold markers (**/__) so "**Wake State:** ..."
+            // matches the same as plain "Wake State: ...".  Only used in the predicate;
+            // the original line is kept for value extraction.
+            fn strip_md_bold(line: &str) -> &str {
+                line.trim_start()
+                    .trim_start_matches("**")
+                    .trim_start_matches("__")
+                    .trim_start()
+            }
 
-            let pref_str = if let Some(pref) = preference {
+            // Extract the @state:... fragment from a matched line, stripping any
+            // leading label ("Wake State:", "**Wake State:**", etc.) and trailing
+            // markdown bold close ("**") that pocket inserts around the label.
+            fn extract_stele_fragment(line: &str) -> &str {
+                // Find the @state token wherever it appears in the line
+                if let Some(pos) = line.find("@state") {
+                    line[pos..].trim_end_matches('*').trim_end_matches('_').trim()
+                } else {
+                    line.trim()
+                }
+            }
+
+            let legacy_schema = load_legacy_schema(schema.clone())?;
+
+            let raw_line = if let Some(pref) = preference {
                 pref
             } else {
                 let path = file.unwrap_or_else(|| {
@@ -1993,26 +2015,51 @@ fn handle_state(cmd: StateCommands) -> Result<()> {
                 content
                     .lines()
                     .find(|line| {
-                        line.starts_with("Wake Preference:")
-                            || line.starts_with("Wake State:")
-                            || line.starts_with(&schema.stele.header)
+                        let stripped = strip_md_bold(line);
+                        stripped.starts_with("Wake Preference:")
+                            || stripped.starts_with("Wake State:")
+                            || stripped.starts_with(&legacy_schema.stele.header)
                     })
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| String::from("default"))
             };
 
-            let dynamic_state = state::parse_wake_preference_dynamic(&pref_str, &schema)?;
+            // Detect tensor format: @state:<namespace>|... (has colon after @state)
+            let stele_fragment = extract_stele_fragment(&raw_line);
+            let is_tensor_format = stele_fragment.starts_with("@state:")
+                && stele_fragment.contains('|');
 
-            match format.as_str() {
-                "json" => println!("{}", serde_json::to_string_pretty(&dynamic_state)?),
-                "stele" => println!("{}", dynamic_state.encode_stele(&schema)),
-                "mode" => {
-                    println!("Mode calculation not yet implemented for DynamicState");
+            if is_tensor_format {
+                // Decode via tensor path which handles positional numeric values
+                let tensor_schema = load_tensor_schema(schema)?;
+                let tensor = tensor::StateTensor::decode(stele_fragment)
+                    .with_context(|| format!("Failed to decode tensor stele: {}", stele_fragment))?;
+
+                match format.as_str() {
+                    "json" => println!("{}", serde_json::to_string_pretty(&tensor.values)?),
+                    "stele" => println!("{}", tensor.encode()),
+                    _ => {
+                        println!("Parsed: {}", stele_fragment);
+                        println!();
+                        println!("{}", tensor.describe(&tensor_schema));
+                    }
                 }
-                _ => {
-                    println!("Parsed: {}", pref_str.trim());
-                    println!();
-                    println!("{}", dynamic_state.describe(&schema));
+            } else {
+                // Legacy path: mode names or rune-prefixed stele
+                let dynamic_state =
+                    state::parse_wake_preference_dynamic(&raw_line, &legacy_schema)?;
+
+                match format.as_str() {
+                    "json" => println!("{}", serde_json::to_string_pretty(&dynamic_state)?),
+                    "stele" => println!("{}", dynamic_state.encode_stele(&legacy_schema)),
+                    "mode" => {
+                        println!("Mode calculation not yet implemented for DynamicState");
+                    }
+                    _ => {
+                        println!("Parsed: {}", raw_line.trim());
+                        println!();
+                        println!("{}", dynamic_state.describe(&legacy_schema));
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1651,7 +1651,7 @@ fn handle_heartbeat(since: Option<u64>, reset: bool) -> Result<()> {
         }
         Some(ms) => {
             // Calculate BPM: 60000ms / interval = beats per minute
-            let bpm = if ms > 0 { 60000 / ms } else { 999 };
+            let bpm = 60000_u64.checked_div(ms).unwrap_or(999);
 
             let message = match bpm {
                 0..=59 => "Nice and slow. You're safe.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1991,7 +1991,10 @@ fn handle_state(cmd: StateCommands) -> Result<()> {
             fn extract_stele_fragment(line: &str) -> &str {
                 // Find the @state token wherever it appears in the line
                 if let Some(pos) = line.find("@state") {
-                    line[pos..].trim_end_matches('*').trim_end_matches('_').trim()
+                    line[pos..]
+                        .trim_end_matches('*')
+                        .trim_end_matches('_')
+                        .trim()
                 } else {
                     line.trim()
                 }
@@ -2026,14 +2029,15 @@ fn handle_state(cmd: StateCommands) -> Result<()> {
 
             // Detect tensor format: @state:<namespace>|... (has colon after @state)
             let stele_fragment = extract_stele_fragment(&raw_line);
-            let is_tensor_format = stele_fragment.starts_with("@state:")
-                && stele_fragment.contains('|');
+            let is_tensor_format =
+                stele_fragment.starts_with("@state:") && stele_fragment.contains('|');
 
             if is_tensor_format {
                 // Decode via tensor path which handles positional numeric values
                 let tensor_schema = load_tensor_schema(schema)?;
-                let tensor = tensor::StateTensor::decode(stele_fragment)
-                    .with_context(|| format!("Failed to decode tensor stele: {}", stele_fragment))?;
+                let tensor = tensor::StateTensor::decode(stele_fragment).with_context(|| {
+                    format!("Failed to decode tensor stele: {}", stele_fragment)
+                })?;
 
                 match format.as_str() {
                     "json" => println!("{}", serde_json::to_string_pretty(&tensor.values)?),

--- a/src/session.rs
+++ b/src/session.rs
@@ -187,7 +187,7 @@ pub fn find_most_recent_session() -> Result<PathBuf> {
     }
 
     // Sort by modification time (most recent first)
-    sessions.sort_by(|a, b| b.1.cmp(&a.1));
+    sessions.sort_by_key(|s| std::cmp::Reverse(s.1));
 
     Ok(sessions[0].0.clone())
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -263,7 +263,7 @@ pub trait KnowledgeStore {
     fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>>;
 
     /// Purge old backups, keeping the most recent `keep` per entry
-    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize>;
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<()>;
 
     // =========================================================================
     // TAG OPERATIONS

--- a/src/store.rs
+++ b/src/store.rs
@@ -245,6 +245,27 @@ pub trait KnowledgeStore {
     fn prepend_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()>;
 
     // =========================================================================
+    // BACKUP OPERATIONS (Issue #206)
+    // =========================================================================
+
+    /// Create a pre-mutation backup of entry content
+    fn backup_content(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String>;
+
+    /// List backups for a specific entry, newest first
+    fn list_backups(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>>;
+
+    /// Get the most recent backup for an entry
+    fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>>;
+
+    /// Purge old backups, keeping the most recent `keep` per entry
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize>;
+
+    // =========================================================================
     // TAG OPERATIONS
     // =========================================================================
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -140,6 +140,16 @@ pub trait KnowledgeStore {
         filter: &KnowledgeFilter,
     ) -> Result<Vec<KnowledgeEntry>>;
 
+    /// Count entries by category (fast path — single COUNT query, no row hydration).
+    /// Avoids the N+1 pattern of `list_by_category(..)?.len()` which fetches every
+    /// row's full body plus follow-up queries for tags/applicability per entry.
+    fn count_by_category(
+        &self,
+        category: &str,
+        ctx: &AgentContext,
+        filter: &KnowledgeFilter,
+    ) -> Result<usize>;
+
     /// List all entries
     fn list_all(&self, ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>>;
 

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1274,10 +1274,7 @@ impl SurrealDatabase {
         Self::runtime().block_on(self.list_backups_async(entry_id))
     }
 
-    async fn list_backups_async(
-        &self,
-        entry_id: &str,
-    ) -> Result<Vec<crate::types::MemoryBackup>> {
+    async fn list_backups_async(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
         let mut response = with_db!(self, db, {
             db.query(
                 "SELECT meta::id(id) AS id, entry_id, title, body, content_hash,

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1237,7 +1237,7 @@ impl SurrealDatabase {
         let backup_id = format!(
             "{}_{}",
             entry_id.replace("kn-", ""),
-            Utc::now().format("%Y%m%dT%H%M%S")
+            Utc::now().format("%Y%m%dT%H%M%S%.3f")
         );
 
         let _response = with_db!(self, db, {
@@ -1323,11 +1323,11 @@ impl SurrealDatabase {
     }
 
     /// Purge old backups, keeping the most recent `keep` per entry
-    pub fn purge_backups_internal(&self, entry_id: &str, keep: usize) -> Result<usize> {
+    pub fn purge_backups_internal(&self, entry_id: &str, keep: usize) -> Result<()> {
         Self::runtime().block_on(self.purge_backups_async(entry_id, keep))
     }
 
-    async fn purge_backups_async(&self, entry_id: &str, keep: usize) -> Result<usize> {
+    async fn purge_backups_async(&self, entry_id: &str, keep: usize) -> Result<()> {
         // Delete backups older than the Nth newest
         let _response = with_db!(self, db, {
             db.query(
@@ -1346,7 +1346,7 @@ impl SurrealDatabase {
             .context("Failed to purge old backups")
         })?;
 
-        Ok(0)
+        Ok(())
     }
 
     /// Search knowledge using BM25 full-text indexes
@@ -3888,7 +3888,7 @@ impl KnowledgeStore for SurrealDatabase {
         self.latest_backup_internal(entry_id)
     }
 
-    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize> {
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<()> {
         self.purge_backups_internal(entry_id, keep)
     }
 

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -1212,6 +1212,146 @@ impl SurrealDatabase {
         Ok(true)
     }
 
+    // =========================================================================
+    // BACKUP OPERATIONS (Issue #206)
+    // =========================================================================
+
+    /// Create a pre-mutation backup of entry content
+    pub fn backup_content_internal(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String> {
+        Self::runtime().block_on(self.backup_content_async(entry, operation, agent))
+    }
+
+    async fn backup_content_async(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String> {
+        let entry_id = entry.id.clone();
+        let content_hash = entry.content_hash.clone().unwrap_or_default();
+        let backup_id = format!(
+            "{}_{}",
+            entry_id.replace("kn-", ""),
+            Utc::now().format("%Y%m%dT%H%M%S")
+        );
+
+        let _response = with_db!(self, db, {
+            db.query(
+                "CREATE type::thing('memory_backup', $backup_id) SET
+                    entry_id = $entry_id,
+                    title = $title,
+                    body = $body,
+                    content_hash = $content_hash,
+                    operation = $operation,
+                    source_agent = $source_agent,
+                    created_at = time::now()
+                ",
+            )
+            .bind(("backup_id", backup_id.clone()))
+            .bind(("entry_id", entry_id.clone()))
+            .bind(("title", entry.title.clone()))
+            .bind(("body", entry.body.clone()))
+            .bind(("content_hash", content_hash))
+            .bind(("operation", operation.to_string()))
+            .bind(("source_agent", agent.map(|s| s.to_string())))
+            .await
+            .context("Failed to create memory backup")
+        })?;
+
+        // Purge old backups (keep 10 per entry) — non-fatal
+        let _ = self.purge_backups_async(&entry_id, 10).await;
+
+        Ok(backup_id)
+    }
+
+    /// List backups for an entry, newest first
+    pub fn list_backups_internal(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
+        Self::runtime().block_on(self.list_backups_async(entry_id))
+    }
+
+    async fn list_backups_async(
+        &self,
+        entry_id: &str,
+    ) -> Result<Vec<crate::types::MemoryBackup>> {
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(id) AS id, entry_id, title, body, content_hash,
+                        operation, source_agent, created_at
+                 FROM memory_backup
+                 WHERE entry_id = $entry_id
+                 ORDER BY created_at DESC",
+            )
+            .bind(("entry_id", entry_id.to_string()))
+            .await
+            .context("Failed to list memory backups")
+        })?;
+
+        let backups: Vec<crate::types::MemoryBackup> = response.take(0)?;
+        Ok(backups)
+    }
+
+    /// Get the most recent backup for an entry
+    pub fn latest_backup_internal(
+        &self,
+        entry_id: &str,
+    ) -> Result<Option<crate::types::MemoryBackup>> {
+        Self::runtime().block_on(self.latest_backup_async(entry_id))
+    }
+
+    async fn latest_backup_async(
+        &self,
+        entry_id: &str,
+    ) -> Result<Option<crate::types::MemoryBackup>> {
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(id) AS id, entry_id, title, body, content_hash,
+                        operation, source_agent, created_at
+                 FROM memory_backup
+                 WHERE entry_id = $entry_id
+                 ORDER BY created_at DESC
+                 LIMIT 1",
+            )
+            .bind(("entry_id", entry_id.to_string()))
+            .await
+            .context("Failed to get latest backup")
+        })?;
+
+        let backups: Vec<crate::types::MemoryBackup> = response.take(0)?;
+        Ok(backups.into_iter().next())
+    }
+
+    /// Purge old backups, keeping the most recent `keep` per entry
+    pub fn purge_backups_internal(&self, entry_id: &str, keep: usize) -> Result<usize> {
+        Self::runtime().block_on(self.purge_backups_async(entry_id, keep))
+    }
+
+    async fn purge_backups_async(&self, entry_id: &str, keep: usize) -> Result<usize> {
+        // Delete backups older than the Nth newest
+        let _response = with_db!(self, db, {
+            db.query(
+                "DELETE FROM memory_backup
+                    WHERE entry_id = $entry_id
+                    AND id NOT IN (
+                        SELECT VALUE id FROM memory_backup
+                        WHERE entry_id = $entry_id
+                        ORDER BY created_at DESC
+                        LIMIT $keep
+                    )",
+            )
+            .bind(("entry_id", entry_id.to_string()))
+            .bind(("keep", keep as i64))
+            .await
+            .context("Failed to purge old backups")
+        })?;
+
+        Ok(0)
+    }
+
     /// Search knowledge using BM25 full-text indexes
     pub fn search_knowledge(
         &self,
@@ -3732,6 +3872,27 @@ impl KnowledgeStore for SurrealDatabase {
         content: &str,
     ) -> Result<()> {
         self.prepend_content(id, ctx, content)
+    }
+
+    fn backup_content(
+        &self,
+        entry: &KnowledgeEntry,
+        operation: &str,
+        agent: Option<&str>,
+    ) -> Result<String> {
+        self.backup_content_internal(entry, operation, agent)
+    }
+
+    fn list_backups(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
+        self.list_backups_internal(entry_id)
+    }
+
+    fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>> {
+        self.latest_backup_internal(entry_id)
+    }
+
+    fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<usize> {
+        self.purge_backups_internal(entry_id, keep)
     }
 
     fn create_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<String> {

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -3158,6 +3158,57 @@ impl SurrealDatabase {
         Self::runtime().block_on(self.list_by_category_async(category, ctx, filter))
     }
 
+    /// Fast count of entries in a category with the same visibility / resonance
+    /// filtering as list_by_category, but returning only the integer count —
+    /// no row hydration, no tag/applicability follow-up queries. Used by
+    /// `mx memory stats` so it doesn't round-trip thousands of times per call
+    /// when the db is remote.
+    pub fn count_by_category(
+        &self,
+        category: &str,
+        ctx: &crate::store::AgentContext,
+        filter: &crate::store::KnowledgeFilter,
+    ) -> Result<usize> {
+        Self::runtime().block_on(self.count_by_category_async(category, ctx, filter))
+    }
+
+    async fn count_by_category_async(
+        &self,
+        category: &str,
+        ctx: &crate::store::AgentContext,
+        filter: &crate::store::KnowledgeFilter,
+    ) -> Result<usize> {
+        let category_thing = Thing::from(("category", category));
+        let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
+        let resonance_clause = Self::build_resonance_filter(filter);
+
+        // NOTE: `SELECT count() FROM knowledge WHERE ... GROUP ALL` returns
+        // the wrong number in SurrealDB 2.6 when a WHERE clause is present
+        // (observed on 2.6.1: bloom with visibility='public' reports 986
+        // instead of 260 — off by ~3-4x, seemingly counting some join
+        // product). Wrapping the filter in a subquery that projects id only
+        // gives the correct count and still avoids row hydration.
+        let sql = format!(
+            "SELECT count() AS c FROM (
+                SELECT id FROM knowledge
+                WHERE category = $category {} {}
+            ) GROUP ALL",
+            visibility_clause, resonance_clause
+        );
+
+        let mut response = with_db!(self, db, {
+            let mut query = db.query(&sql).bind(("category", category_thing));
+            if let Some(agent) = current_agent {
+                query = query.bind(("current_agent", agent));
+            }
+            query.await.context("Failed to count knowledge by category")
+        })?;
+
+        let results: Vec<serde_json::Value> = response.take(0)?;
+        let count = results.first().and_then(|v| v["c"].as_i64()).unwrap_or(0) as usize;
+        Ok(count)
+    }
+
     async fn list_by_category_async(
         &self,
         category: &str,
@@ -3639,6 +3690,15 @@ impl KnowledgeStore for SurrealDatabase {
         filter: &crate::store::KnowledgeFilter,
     ) -> Result<Vec<KnowledgeEntry>> {
         self.list_by_category(category, ctx, filter)
+    }
+
+    fn count_by_category(
+        &self,
+        category: &str,
+        ctx: &crate::store::AgentContext,
+        filter: &crate::store::KnowledgeFilter,
+    ) -> Result<usize> {
+        self.count_by_category(category, ctx, filter)
     }
 
     fn list_all(&self, ctx: &crate::store::AgentContext) -> Result<Vec<KnowledgeEntry>> {

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use surrealdb::RecordId as SurrealRecordId;
 use surrealdb::Surreal;
 use surrealdb::engine::local::SurrealKv;
-use surrealdb::engine::remote::ws::{Client as WsClient, Ws};
+use surrealdb::engine::remote::ws::{Client as WsClient, Ws, Wss};
 use surrealdb::opt::auth::{Database, Namespace, Root};
 use surrealdb::sql::{Thing, Value};
 use tokio::runtime::Runtime;
@@ -558,18 +558,36 @@ impl SurrealDatabase {
             eprintln!("[mx] WARNING: Consider using wss:// (TLS) for secure authentication");
         }
 
-        // Strip protocol prefix from URL - surrealdb crate expects just host:port
+        // Strip protocol prefix from URL - surrealdb crate expects just host:port.
+        // We lose the scheme in the sanitized form, so detect it up front to
+        // pick the right engine (plain Ws vs TLS Wss).
+        let is_tls = config.url.starts_with("wss://");
         let sanitized_url = Self::sanitize_ws_url(&config.url);
 
-        // Connect to remote SurrealDB via WebSocket
-        let db = Surreal::new::<Ws>(sanitized_url.as_str())
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to connect to SurrealDB at {} (check that server is running and URL is correct)",
-                    config.url
-                )
-            })?;
+        // Connect to remote SurrealDB via WebSocket. Dispatch on scheme:
+        // `Ws` speaks plain WebSocket; `Wss` is the TLS variant (enabled by
+        // the `rustls` feature on the surrealdb crate). Using the wrong one
+        // fails with a cryptic "HTTP version must be 1.1 or higher" because
+        // the TLS handshake bytes get parsed as HTTP.
+        let db = if is_tls {
+            Surreal::new::<Wss>(sanitized_url.as_str())
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to connect to SurrealDB at {} (check that server is running and URL is correct)",
+                        config.url
+                    )
+                })?
+        } else {
+            Surreal::new::<Ws>(sanitized_url.as_str())
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to connect to SurrealDB at {} (check that server is running and URL is correct)",
+                        config.url
+                    )
+                })?
+        };
 
         // Authenticate with the server
         // If no password is provided, attempt connection without auth (will fail if server requires it)

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,6 +71,22 @@ pub struct RelationshipType {
     pub created_at: String,
 }
 
+/// Pre-mutation content backup (Issue #206)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryBackup {
+    pub id: String,
+    pub entry_id: String,
+    pub title: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    pub content_hash: String,
+    pub operation: String,
+    #[serde(default)]
+    pub source_agent: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Relationship {
     pub id: String,


### PR DESCRIPTION
## Problem

`mx state parse --file ~/.crewu/swap/session-bootstrap.md` was always returning all-0.5 defaults instead of the actual tensor values from the file.

**Root cause 1 (line finder):** The `.find()` predicate in `StateCommands::Parse` checked `line.starts_with("Wake State:")` but pocket writes `**Wake State:** @state:crewu|...` — the `**` bold markers caused a miss, falling through to `"default"`.

**Root cause 2 (tensor format):** Even if the line was found, the stele `@state:crewu|0.88|0.65|...` is positional (no rune-symbol prefixes). The legacy `DynamicState::decode_stele` decoder looks for rune-prefixed parts like `ᚠ0.88` and silently skips bare numeric values, producing all-0.5 defaults again.

## Fix

- **`src/main.rs`** — `StateCommands::Parse` handler:
  - Added `strip_md_bold()` helper that strips `**`/`__` prefixes from line before the `starts_with` checks (predicate-only; original line kept for extraction)
  - Added `extract_stele_fragment()` that finds `@state` anywhere in the matched line, stripping surrounding bold markers
  - Detects tensor format (`@state:<namespace>|...`) vs legacy format and routes accordingly:
    - **Tensor path:** `StateTensor::decode()` + `load_tensor_schema` — handles positional numeric values correctly
    - **Legacy path:** existing `parse_wake_preference_dynamic` for mode names and rune-prefixed stele (unchanged behavior)

- **`~/.crewu/src/skills/pocket/SKILL.md`** (separate repo) — updated line 438 to document the bold format pocket actually writes (`**Wake State:** @state|...` instead of `Wake State: @state|...`)

## Before / After

```
# Before
Parsed: default
depth: middle (0.5), energy: steady (0.5), entropy: mixed (0.5), gravity: balanced (0.5), temperature: cool (0.5), ...

# After
Parsed: @state:crewu|0.88|0.65|0.80|0.90|0.40
Temperature: 0.88 (warm, playful, flowing), Entropy: 0.65 (balanced, mixed), Agency: 0.80 (active, driving, leading), Connection: 0.90 (close, merged, intimate), Weight: 0.40 (balanced, grounded)
```

## Backward compatibility

- Plain `Wake State: @state:crewu|...` (no bold) still parses correctly
- Legacy mode names (`default`, `soft`, etc.) still work via the legacy path
- Rune-prefixed stele format still works via the legacy path