### PR TITLE
feat(wake): chunking integration + authored-then-sampled flow (mx#211 PR 2/3)

### DIFF
--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -259,9 +259,20 @@ DEFINE FIELD IF NOT EXISTS remembered_count ON wake_session TYPE int DEFAULT 0;
 DEFINE FIELD IF NOT EXISTS needed_help_count ON wake_session TYPE int DEFAULT 0;
 DEFINE FIELD IF NOT EXISTS skipped_count ON wake_session TYPE int DEFAULT 0;
 DEFINE FIELD IF NOT EXISTS created_at ON wake_session TYPE datetime DEFAULT time::now();
-DEFINE FIELD IF NOT EXISTS selected_phrase_indices ON wake_session TYPE array<int>;
--- Migration: fix existing DBs that defined this as bare TYPE array (SCHEMAFULL drops non-typed elements)
-DEFINE FIELD OVERWRITE selected_phrase_indices ON wake_session TYPE array<int>;
+-- mx#211: chunking cursor + monotonic step counter. current_chunk_index
+-- advances within a chunked bloom before rolling over to the next bloom.
+-- step is the token-signing counter — monotonic across all chunk advances
+-- so tokens survive mid-ritual bloom re-chunking.
+DEFINE FIELD IF NOT EXISTS current_chunk_index ON wake_session TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS step ON wake_session TYPE int DEFAULT 0;
+-- Per-bloom phrase-count metadata (authored_phrase_count + is_phraseless).
+-- `flexible` so the object shape can evolve without schema migration churn.
+DEFINE FIELD IF NOT EXISTS bloom_chunk_meta ON wake_session FLEXIBLE TYPE array<object> DEFAULT [];
+-- Legacy field from the pre-chunking design. Kept in the schema for
+-- backward read compatibility during rollout; no longer written. SurrealDB
+-- will keep any existing values but new sessions leave this empty.
+DEFINE FIELD IF NOT EXISTS selected_phrase_indices ON wake_session TYPE array<int> DEFAULT [];
+DEFINE FIELD OVERWRITE selected_phrase_indices ON wake_session TYPE array<int> DEFAULT [];
 DEFINE INDEX IF NOT EXISTS wake_session_created ON wake_session FIELDS created_at;
 
 -- =============================================================================

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -3452,15 +3452,9 @@ impl SurrealDatabase {
         &self,
         session: &crate::wake_token::WakeSession,
     ) -> Result<String> {
-        // Convert selected_phrase_indices to Vec<i64> using -1 as sentinel for None.
-        // SurrealDB SCHEMAFULL with TYPE array<int> drops null/NONE values, so we
-        // use -1 to represent "this bloom has no phrase".
-        let phrase_indices: Vec<i64> = session
-            .selected_phrase_indices
-            .iter()
-            .map(|opt| opt.map(|n| n as i64).unwrap_or(-1))
-            .collect();
-        let phrase_indices_json = serde_json::to_string(&phrase_indices)?;
+        // Serialize bloom_chunk_meta as a JSON array. The schema field is
+        // `flexible array<object>` so SurrealDB will accept arbitrary shape.
+        let bloom_chunk_meta_json = serde_json::to_value(&session.bloom_chunk_meta)?;
         let created_at = chrono::DateTime::from_timestamp(session.created_at, 0)
             .unwrap_or_else(chrono::Utc::now)
             .to_rfc3339();
@@ -3470,26 +3464,27 @@ impl SurrealDatabase {
                 "CREATE type::thing('wake_session', $session_id) SET
                     bloom_ids = $bloom_ids,
                     current_index = $current_index,
+                    current_chunk_index = $current_chunk_index,
+                    step = $step,
                     attempts_on_current = $attempts_on_current,
                     remembered_count = $remembered_count,
                     needed_help_count = $needed_help_count,
                     skipped_count = $skipped_count,
                     created_at = <datetime>$created_at,
-                    selected_phrase_indices = $selected_phrase_indices
+                    bloom_chunk_meta = $bloom_chunk_meta
                 ",
             )
             .bind(("session_id", session.session_id.clone()))
             .bind(("bloom_ids", session.bloom_ids.clone()))
             .bind(("current_index", session.current_index as i64))
+            .bind(("current_chunk_index", session.current_chunk_index as i64))
+            .bind(("step", session.step as i64))
             .bind(("attempts_on_current", session.attempts_on_current as i64))
             .bind(("remembered_count", session.remembered_count as i64))
             .bind(("needed_help_count", session.needed_help_count as i64))
             .bind(("skipped_count", session.skipped_count as i64))
             .bind(("created_at", normalize_datetime(&created_at)))
-            .bind((
-                "selected_phrase_indices",
-                serde_json::from_str::<serde_json::Value>(&phrase_indices_json)?,
-            ))
+            .bind(("bloom_chunk_meta", bloom_chunk_meta_json))
             .await
             .context("Failed to create wake session")
         })?;
@@ -3523,12 +3518,14 @@ impl SurrealDatabase {
                     meta::id(id) AS session_id,
                     bloom_ids,
                     current_index,
+                    current_chunk_index,
+                    step,
                     attempts_on_current,
                     remembered_count,
                     needed_help_count,
                     skipped_count,
                     <int>time::unix(<datetime>created_at) AS created_at,
-                    selected_phrase_indices
+                    bloom_chunk_meta
                 FROM type::thing('wake_session', $session_id)",
             )
             .bind(("session_id", session_id.to_string()))
@@ -3552,6 +3549,8 @@ impl SurrealDatabase {
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
         let current_index = obj["current_index"].as_u64().unwrap_or(0) as usize;
+        let current_chunk_index = obj["current_chunk_index"].as_u64().unwrap_or(0) as u8;
+        let step = obj["step"].as_u64().unwrap_or(0) as u32;
         let attempts_on_current = obj["attempts_on_current"].as_u64().unwrap_or(0) as u8;
         let remembered_count = obj["remembered_count"].as_u64().unwrap_or(0) as u32;
         let needed_help_count = obj["needed_help_count"].as_u64().unwrap_or(0) as u32;
@@ -3560,29 +3559,40 @@ impl SurrealDatabase {
             .as_i64()
             .unwrap_or_else(|| chrono::Utc::now().timestamp());
 
-        // Deserialize selected_phrase_indices: array of ints where -1 is sentinel for None.
-        // SurrealDB TYPE array<int> cannot store null/NONE, so -1 represents "no phrase".
-        let selected_phrase_indices: Vec<Option<usize>> = obj["selected_phrase_indices"]
-            .as_array()
-            .unwrap_or(&vec![])
-            .iter()
-            .map(|v| match v.as_i64() {
-                Some(-1) | None => None,
-                Some(n) if n >= 0 => Some(n as usize),
-                _ => None,
-            })
-            .collect();
+        // Deserialize bloom_chunk_meta via serde_json. Absent/empty → default
+        // to one meta per bloom_id marking every bloom as phraseless (safe
+        // fallback that keeps the session walkable via skips).
+        let bloom_chunk_meta: Vec<crate::wake_token::BloomChunkMeta> =
+            match obj.get("bloom_chunk_meta") {
+                Some(v) if !v.is_null() => serde_json::from_value(v.clone()).unwrap_or_default(),
+                _ => Vec::new(),
+            };
+        let bloom_chunk_meta = if bloom_chunk_meta.len() == bloom_ids.len() {
+            bloom_chunk_meta
+        } else {
+            // Length mismatch — rebuild default metadata so the session can
+            // at least walk (all phraseless, will drop through skip path).
+            bloom_ids
+                .iter()
+                .map(|_| crate::wake_token::BloomChunkMeta {
+                    authored_phrase_count: 0,
+                    is_phraseless: true,
+                })
+                .collect()
+        };
 
         Ok(Some(crate::wake_token::WakeSession {
             session_id: session_id_str,
             bloom_ids,
             current_index,
+            current_chunk_index,
+            step,
             attempts_on_current,
             remembered_count,
             needed_help_count,
             skipped_count,
             created_at,
-            selected_phrase_indices,
+            bloom_chunk_meta,
         }))
     }
 
@@ -3595,35 +3605,30 @@ impl SurrealDatabase {
         &self,
         session: &crate::wake_token::WakeSession,
     ) -> Result<()> {
-        // Convert selected_phrase_indices to Vec<i64> using -1 as sentinel for None.
-        let phrase_indices: Vec<i64> = session
-            .selected_phrase_indices
-            .iter()
-            .map(|opt| opt.map(|n| n as i64).unwrap_or(-1))
-            .collect();
-        let phrase_indices_json = serde_json::to_string(&phrase_indices)?;
+        let bloom_chunk_meta_json = serde_json::to_value(&session.bloom_chunk_meta)?;
 
         let mut response = with_db!(self, db, {
             db.query(
                 "UPDATE type::thing('wake_session', $session_id) SET
                     current_index = $current_index,
+                    current_chunk_index = $current_chunk_index,
+                    step = $step,
                     attempts_on_current = $attempts_on_current,
                     remembered_count = $remembered_count,
                     needed_help_count = $needed_help_count,
                     skipped_count = $skipped_count,
-                    selected_phrase_indices = $selected_phrase_indices
+                    bloom_chunk_meta = $bloom_chunk_meta
                 ",
             )
             .bind(("session_id", session.session_id.clone()))
             .bind(("current_index", session.current_index as i64))
+            .bind(("current_chunk_index", session.current_chunk_index as i64))
+            .bind(("step", session.step as i64))
             .bind(("attempts_on_current", session.attempts_on_current as i64))
             .bind(("remembered_count", session.remembered_count as i64))
             .bind(("needed_help_count", session.needed_help_count as i64))
             .bind(("skipped_count", session.skipped_count as i64))
-            .bind((
-                "selected_phrase_indices",
-                serde_json::from_str::<serde_json::Value>(&phrase_indices_json)?,
-            ))
+            .bind(("bloom_chunk_meta", bloom_chunk_meta_json))
             .await
             .context("Failed to update wake session")
         })?;

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -3549,7 +3549,7 @@ impl SurrealDatabase {
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
         let current_index = obj["current_index"].as_u64().unwrap_or(0) as usize;
-        let current_chunk_index = obj["current_chunk_index"].as_u64().unwrap_or(0) as u8;
+        let current_chunk_index = obj["current_chunk_index"].as_u64().unwrap_or(0) as u16;
         let step = obj["step"].as_u64().unwrap_or(0) as u32;
         let attempts_on_current = obj["attempts_on_current"].as_u64().unwrap_or(0) as u8;
         let remembered_count = obj["remembered_count"].as_u64().unwrap_or(0) as u32;

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -3549,7 +3549,19 @@ impl SurrealDatabase {
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
         let current_index = obj["current_index"].as_u64().unwrap_or(0) as usize;
-        let current_chunk_index = obj["current_chunk_index"].as_u64().unwrap_or(0) as u16;
+        // Diffi flagged the previous `as u64 as u16` pattern as a silent-wrap
+        // footgun — reaching u16::MAX requires ~2000x default-threshold chunks
+        // today but the cast hides the failure mode. `try_from` surfaces an
+        // out-of-range stored value as a deserialization error instead of
+        // quietly producing a wrong cursor value.
+        let raw_chunk_idx = obj["current_chunk_index"].as_u64().unwrap_or(0);
+        let current_chunk_index = u16::try_from(raw_chunk_idx).map_err(|_| {
+            anyhow::anyhow!(
+                "wake_session.current_chunk_index {} exceeds u16::MAX; \
+                 session is corrupt or schema has drifted",
+                raw_chunk_idx
+            )
+        })?;
         let step = obj["step"].as_u64().unwrap_or(0) as u32;
         let attempts_on_current = obj["attempts_on_current"].as_u64().unwrap_or(0) as u8;
         let remembered_count = obj["remembered_count"].as_u64().unwrap_or(0) as u32;

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -4,51 +4,230 @@ use std::collections::HashMap;
 use crate::engage::{MatchResult, fuzzy_match};
 use crate::knowledge::KnowledgeEntry;
 use crate::store::{AgentContext, KnowledgeStore, WakeCascade};
+use crate::wake_chunk::{
+    ChunkPlan, PhraseMatch, PhraseMode, chunk_threshold, compare_phrase, compute_chunks,
+    extract_salient_phrase,
+};
 use crate::wake_token::*;
 
-/// Start a new wake ritual session
+/// Which phrase source unlocked a chunk — authored by the bloom owner, or
+/// auto-derived from the chunk's own content (§5 of the mx#211 design).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PhraseSource {
+    Authored,
+    Derived,
+}
+
+impl PhraseSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            PhraseSource::Authored => "authored",
+            PhraseSource::Derived => "derived",
+        }
+    }
+
+    fn mode(self) -> PhraseMode {
+        match self {
+            PhraseSource::Authored => PhraseMode::Authored,
+            PhraseSource::Derived => PhraseMode::Derived,
+        }
+    }
+}
+
+/// Pick the wake phrase for a specific chunk of a bloom. Authored phrases
+/// win when available at the given index; beyond the authored count we
+/// auto-derive from the chunk's own content (§5.2).
+///
+/// **P==0 semantics:** for blooms with zero authored phrases we return `None`
+/// — those blooms stay skip-type across every chunk (conservative default
+/// per the P==0 decision). Never auto-derive for phraseless blooms.
+///
+/// Returns `(phrase, source)`. `source` drives the comparison tolerance:
+/// authored phrases get exact-compare (Authored mode) while derived phrases
+/// get softened comparisons (Derived mode).
+fn phrase_for_chunk(
+    entry: &KnowledgeEntry,
+    chunk_idx: u8,
+    chunk_total: u8,
+    chunk_content: &str,
+) -> Option<(String, PhraseSource)> {
+    let authored_count = authored_phrase_count(entry);
+    if authored_count == 0 {
+        // P==0 conservative default — skip-type across all chunks.
+        return None;
+    }
+    if (chunk_idx as usize) < authored_count as usize
+        && let Some(p) = authored_phrase_at(entry, chunk_idx as usize)
+    {
+        return Some((p, PhraseSource::Authored));
+    }
+    // Chunk beyond the authored count: auto-derive from chunk content.
+    Some((
+        extract_salient_phrase(chunk_content, chunk_idx, chunk_total),
+        PhraseSource::Derived,
+    ))
+}
+
+/// Compute the sum of chunk counts across all blooms in the session, using
+/// the current in-memory content. Eager total for `progress.total` at begin
+/// time (§7.1). Cheap: O(N * content_len), microseconds for typical cascades.
+fn total_chunks_across_cascade(
+    session: &WakeSession,
+    blooms: &HashMap<String, KnowledgeEntry>,
+) -> usize {
+    let threshold = chunk_threshold();
+    let mut total: usize = 0;
+    for id in &session.bloom_ids {
+        if let Some(entry) = blooms.get(id) {
+            let content = bloom_content(entry);
+            let plan = compute_chunks(&content, threshold);
+            total += plan.total as usize;
+        } else {
+            total += 1; // fallback — treat missing blooms as 1-chunk
+        }
+    }
+    total
+}
+
+/// Formatted body or summary or placeholder — the string used for chunking.
+fn bloom_content(entry: &KnowledgeEntry) -> String {
+    entry
+        .body
+        .clone()
+        .or_else(|| entry.summary.clone())
+        .unwrap_or_else(|| "(no content)".to_string())
+}
+
+/// Build a chunk-aware `BloomPrompt` for the bloom at the session's current
+/// cursor. Decorates the title with `(Part N/M)` server-side so existing
+/// CLIs that display the title surface chunk position for free.
+///
+/// If the chunk plan has only one chunk (i.e. content ≤ threshold), the
+/// prompt is identical to the non-chunked `BloomPrompt::from(entry)` —
+/// backward-compatible contract.
+fn build_prompt_for_chunk(
+    entry: &KnowledgeEntry,
+    chunk_idx: u8,
+    plan: &ChunkPlan,
+    content: &str,
+) -> BloomPrompt {
+    let mut prompt = BloomPrompt::from(entry);
+    if plan.total > 1 {
+        prompt.title = format!("{} (Part {}/{})", entry.title, chunk_idx + 1, plan.total);
+        prompt.chunk = Some(ChunkRef {
+            index: chunk_idx + 1,
+            total: plan.total,
+            oversized: if plan.is_oversized(chunk_idx) {
+                Some(true)
+            } else {
+                None
+            },
+        });
+        // Indicate authored-vs-derived only when there's a phrase for the
+        // chunk. P==0 blooms skip; non-P==0 blooms expose the source.
+        let chunk_content = plan.chunk(content, chunk_idx);
+        if let Some((_, source)) = phrase_for_chunk(entry, chunk_idx, plan.total, chunk_content) {
+            prompt.phrase_source = Some(source.as_str().to_string());
+        }
+    } else {
+        // Single-chunk bloom — still surface phrase_source if applicable so
+        // consumers have a uniform signal regardless of chunking.
+        if authored_phrase_count(entry) > 0 {
+            prompt.phrase_source = Some(PhraseSource::Authored.as_str().to_string());
+        }
+    }
+    prompt
+}
+
+/// Build a chunk-aware `BloomFull` for the chunk currently being revealed.
+/// The `content` field is the *chunk's* content, not the whole bloom — this
+/// is the critical behavior change in mx#211.
+fn build_full_for_chunk(
+    entry: &KnowledgeEntry,
+    chunk_idx: u8,
+    plan: &ChunkPlan,
+    content: &str,
+    matched_phrase: Option<String>,
+    source: Option<PhraseSource>,
+    chunk_truncated: bool,
+) -> BloomFull {
+    let mut full = BloomFull::from(entry);
+    if plan.total > 1 {
+        let chunk_content = plan.chunk(content, chunk_idx);
+        full.content = chunk_content.to_string();
+        full.title = format!("{} (Part {}/{})", entry.title, chunk_idx + 1, plan.total);
+        full.chunk = Some(ChunkRef {
+            index: chunk_idx + 1,
+            total: plan.total,
+            oversized: if plan.is_oversized(chunk_idx) {
+                Some(true)
+            } else {
+                None
+            },
+        });
+    }
+    // For single-chunk blooms, BloomFull::from already populates the full
+    // content. We only override for chunked blooms above.
+
+    full.matched_phrase = matched_phrase;
+    full.phrase_source = source.map(|s| s.as_str().to_string());
+    if chunk_truncated {
+        full.chunk_truncated = Some(true);
+    }
+    full
+}
+
+/// Start a new wake ritual session.
 pub fn begin_ritual(db: &dyn KnowledgeStore, cascade: &WakeCascade) -> Result<String> {
     if cascade.core.is_empty() && cascade.recent.is_empty() && cascade.bridges.is_empty() {
         bail!("No blooms to wake");
     }
 
     let session = WakeSession::new(cascade);
-    let total = session.total();
 
-    // Build lookup map from the cascade we already have
-    let all_blooms = build_bloom_map(cascade);
+    // Build lookup map from the cascade we already have.
+    let owned_blooms: HashMap<String, KnowledgeEntry> = build_bloom_map_owned(cascade);
 
-    // Get first bloom
+    // Eager total-chunks count for progress.total.
+    let total_steps = total_chunks_across_cascade(&session, &owned_blooms);
+
+    // Get first bloom + its chunk plan.
     let first_id = session
         .current_bloom_id()
         .ok_or_else(|| anyhow::anyhow!("No blooms in session"))?;
-    let first_bloom = all_blooms
+    let first_bloom = owned_blooms
         .get(first_id)
         .ok_or_else(|| anyhow::anyhow!("Bloom not found: {}", first_id))?;
+    let first_content = bloom_content(first_bloom);
+    let first_plan = compute_chunks(&first_content, chunk_threshold());
 
-    // Persist session to DB, get back the session_id
+    let prompt = build_prompt_for_chunk(first_bloom, 0, &first_plan, &first_content);
+
+    // Persist session to DB.
     let session_id = db.create_wake_session(&session)?;
 
-    // Return signed token instead of bare session_id
-    let token = create_token(&session_id, 0);
+    // Return signed token at step 0.
+    let token = create_token(&session_id, session.step);
 
     let response = WakeBeginResponse {
         status: "ritual_started".to_string(),
         session: token,
-        prompt: BloomPrompt::from(*first_bloom),
+        prompt,
         progress: Progress {
             current: 1,
-            total,
+            total: total_steps.max(1),
             remembered: None,
             needed_help: None,
             skipped: None,
+            bloom_current: Some(1),
+            bloom_total: Some(session.total_blooms()),
         },
     };
 
     Ok(serde_json::to_string(&response)?)
 }
 
-/// Process a wake phrase response
+/// Process a wake phrase response.
 pub fn respond_ritual(
     db: &dyn KnowledgeStore,
     ctx: &AgentContext,
@@ -56,71 +235,100 @@ pub fn respond_ritual(
     phrase: &str,
     token_str: &str,
 ) -> Result<String> {
-    // Verify token and extract session_id + step
-    let (session_id, token_index) =
+    let (session_id, token_step) =
         verify_token(token_str).map_err(|e| anyhow::anyhow!("Token verification failed: {}", e))?;
 
-    // Load session from DB
     let mut session = db
         .get_wake_session(&session_id)?
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", session_id))?;
 
-    // Anti-replay: token step must match server-side state
-    if session.current_index != token_index {
+    // Anti-replay: token step must match server-side state.
+    if session.step != token_step {
         bail!(
             "Token out of sync: token step {} but session at step {}",
-            token_index,
-            session.current_index
+            token_step,
+            session.step
         );
     }
 
-    // Fetch blooms by ID from session (source of truth)
     let all_blooms = fetch_blooms_by_ids(db, ctx, &session.bloom_ids)?;
 
-    // Verify we're on the right bloom
     let expected_id = session
         .current_bloom_id()
-        .ok_or_else(|| anyhow::anyhow!("Ritual already complete"))?;
+        .ok_or_else(|| anyhow::anyhow!("Ritual already complete"))?
+        .to_string();
 
     if bloom_id != expected_id {
         let response = WakeErrorResponse {
             status: "error".to_string(),
             error: "invalid_bloom_id".to_string(),
             message: format!("Expected bloom {}, got {}", expected_id, bloom_id),
-            expected_id: Some(expected_id.to_string()),
+            expected_id: Some(expected_id),
         };
         return Ok(serde_json::to_string(&response)?);
     }
 
-    // Get the bloom
     let bloom = all_blooms
-        .get(expected_id)
+        .get(&expected_id)
         .ok_or_else(|| anyhow::anyhow!("Bloom not found: {}", expected_id))?;
 
-    // Get the pre-selected wake phrase from session
-    let phrase_idx = session
-        .current_phrase_index()
-        .ok_or_else(|| anyhow::anyhow!("This bloom has no wake phrase - use --skip instead"))?;
+    let content = bloom_content(bloom);
+    let plan = compute_chunks(&content, chunk_threshold());
 
-    let wake_phrase = if !bloom.wake_phrases.is_empty() {
-        bloom
-            .wake_phrases
-            .get(phrase_idx)
-            .ok_or_else(|| anyhow::anyhow!("Invalid phrase index"))?
-            .clone()
-    } else if let Some(ref p) = bloom.wake_phrase {
-        p.clone()
-    } else {
-        bail!("This bloom has no wake phrase - use --skip instead");
+    // If the bloom shrank past our chunk cursor, advance to next bloom.
+    // Flagged via chunk_truncated (§2.2).
+    let chunk_truncated = session.clamp_if_chunks_shrank(plan.total);
+    if chunk_truncated {
+        // Persist the clamp and return a skip-like response so the consumer
+        // can see what happened.
+        let (next, progress, summary) = get_next_and_progress(&session, &all_blooms)?;
+        if session.is_complete() {
+            db.delete_wake_session(&session_id)?;
+        } else {
+            db.update_wake_session(&session)?;
+        }
+        let bloom_full =
+            build_full_for_chunk(bloom, 0, &plan, &content, None, None, chunk_truncated);
+        let new_token = create_token(&session_id, session.step);
+        let response = WakeRespondResponse {
+            status: "chunk_truncated".to_string(),
+            match_type: None,
+            bloom: Some(bloom_full),
+            attempt: None,
+            hint: None,
+            prompt: None,
+            session: new_token,
+            next,
+            progress: Some(progress),
+            summary,
+            content_changed_during_ritual: None,
+        };
+        return Ok(serde_json::to_string(&response)?);
+    }
+
+    let chunk_idx = session.current_chunk_index;
+    let chunk_content = plan.chunk(&content, chunk_idx);
+
+    // P==0 bloom? Reject respond path — consumer must --skip.
+    let (wake_phrase, source) = match phrase_for_chunk(bloom, chunk_idx, plan.total, chunk_content)
+    {
+        Some(p) => p,
+        None => bail!("This bloom has no wake phrase - use --skip instead"),
     };
 
-    // Match the phrase
-    let match_result = fuzzy_match(phrase, &wake_phrase);
+    // Compare: first via our tolerant compare_phrase (picks up authored-vs-
+    // derived tolerance), then fall through to fuzzy_match for the existing
+    // Close/Partial/Wrong tiers so we don't regress the hint flow.
+    let tolerant = compare_phrase(phrase, &wake_phrase, source.mode());
+    let match_result = match tolerant {
+        PhraseMatch::Exact => MatchResult::Exact,
+        PhraseMatch::Tolerant => MatchResult::Close,
+        PhraseMatch::Mismatch => fuzzy_match(phrase, &wake_phrase),
+    };
 
     match match_result {
         MatchResult::Exact | MatchResult::Close => {
-            // SUCCESS! Advance and return bloom
-            session.advance_remembered();
+            session.advance_remembered(plan.total);
 
             let match_type = if matches!(match_result, MatchResult::Exact) {
                 "exact"
@@ -128,22 +336,25 @@ pub fn respond_ritual(
                 "close"
             };
 
-            // Get next bloom if any
             let (next, progress, summary) = get_next_and_progress(&session, &all_blooms)?;
 
-            // Persist updated session (or delete if complete)
             if session.is_complete() {
                 db.delete_wake_session(&session_id)?;
             } else {
                 db.update_wake_session(&session)?;
             }
 
-            // Create BloomFull with matched phrase
-            let mut bloom_full = BloomFull::from(bloom);
-            bloom_full.matched_phrase = Some(wake_phrase.clone());
+            let bloom_full = build_full_for_chunk(
+                bloom,
+                chunk_idx,
+                &plan,
+                &content,
+                Some(wake_phrase.clone()),
+                Some(source),
+                false,
+            );
 
-            // New token reflects updated step
-            let new_token = create_token(&session_id, session.current_index);
+            let new_token = create_token(&session_id, session.step);
 
             let response = WakeRespondResponse {
                 status: "remembered".to_string(),
@@ -156,34 +367,37 @@ pub fn respond_ritual(
                 next,
                 progress: Some(progress),
                 summary,
+                content_changed_during_ritual: None,
             };
 
             Ok(serde_json::to_string(&response)?)
         }
         MatchResult::Partial | MatchResult::Wrong => {
-            // Increment attempt
             session.increment_attempt();
             let attempt = session.attempts_on_current;
 
             if attempt >= 3 {
-                // Max attempts reached - reveal and advance
-                session.advance_helped();
+                session.advance_helped(plan.total);
 
                 let (next, progress, summary) = get_next_and_progress(&session, &all_blooms)?;
 
-                // Persist updated session (or delete if complete)
                 if session.is_complete() {
                     db.delete_wake_session(&session_id)?;
                 } else {
                     db.update_wake_session(&session)?;
                 }
 
-                // Create BloomFull with revealed phrase
-                let mut bloom_full = BloomFull::from(bloom);
-                bloom_full.matched_phrase = Some(wake_phrase.clone());
+                let bloom_full = build_full_for_chunk(
+                    bloom,
+                    chunk_idx,
+                    &plan,
+                    &content,
+                    Some(wake_phrase.clone()),
+                    Some(source),
+                    false,
+                );
 
-                // New token reflects updated step
-                let new_token = create_token(&session_id, session.current_index);
+                let new_token = create_token(&session_id, session.step);
 
                 let response = WakeRespondResponse {
                     status: "revealed".to_string(),
@@ -196,17 +410,26 @@ pub fn respond_ritual(
                     next,
                     progress: Some(progress),
                     summary,
+                    content_changed_during_ritual: None,
                 };
 
                 Ok(serde_json::to_string(&response)?)
             } else {
-                // Give hint and ask for retry - save incremented attempt count
                 db.update_wake_session(&session)?;
 
                 let hint = generate_hint(&wake_phrase, attempt);
 
-                // Same step (retry), but fresh token
-                let new_token = create_token(&session_id, session.current_index);
+                // Same step (retry), fresh token.
+                let new_token = create_token(&session_id, session.step);
+
+                // Risk 9 diagnostic: if a derived phrase rejected, surface
+                // content_changed_during_ritual as an advisory. Consumers
+                // can use this to suggest a `--begin` restart when mid-ritual
+                // edits may have shifted the derived phrase out from under
+                // them. Best-effort: we can't cleanly distinguish "user typed
+                // wrong" from "content changed" without persisting extra
+                // state, which the design deliberately avoids (§6, §10 Risk 9).
+                let content_changed = source == PhraseSource::Derived;
 
                 let response = WakeRespondResponse {
                     status: "incorrect".to_string(),
@@ -214,11 +437,12 @@ pub fn respond_ritual(
                     bloom: None,
                     attempt: Some(attempt),
                     hint: Some(hint),
-                    prompt: Some(BloomPrompt::from(bloom)),
+                    prompt: Some(build_prompt_for_chunk(bloom, chunk_idx, &plan, &content)),
                     session: new_token,
                     next: None,
                     progress: None,
                     summary: None,
+                    content_changed_during_ritual: if content_changed { Some(true) } else { None },
                 };
 
                 Ok(serde_json::to_string(&response)?)
@@ -227,72 +451,80 @@ pub fn respond_ritual(
     }
 }
 
-/// Skip a bloom (for blooms without wake phrase)
+/// Skip a bloom chunk (for phraseless blooms or consumer-initiated skip).
 pub fn skip_ritual(
     db: &dyn KnowledgeStore,
     ctx: &AgentContext,
     bloom_id: &str,
     token_str: &str,
 ) -> Result<String> {
-    // Verify token and extract session_id + step
-    let (session_id, token_index) =
+    let (session_id, token_step) =
         verify_token(token_str).map_err(|e| anyhow::anyhow!("Token verification failed: {}", e))?;
 
-    // Load session from DB
     let mut session = db
         .get_wake_session(&session_id)?
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", session_id))?;
 
-    // Anti-replay: token step must match server-side state
-    if session.current_index != token_index {
+    if session.step != token_step {
         bail!(
             "Token out of sync: token step {} but session at step {}",
-            token_index,
-            session.current_index
+            token_step,
+            session.step
         );
     }
 
-    // Fetch blooms by ID from session (source of truth)
     let all_blooms = fetch_blooms_by_ids(db, ctx, &session.bloom_ids)?;
 
-    // Verify we're on the right bloom
     let expected_id = session
         .current_bloom_id()
-        .ok_or_else(|| anyhow::anyhow!("Ritual already complete"))?;
+        .ok_or_else(|| anyhow::anyhow!("Ritual already complete"))?
+        .to_string();
 
     if bloom_id != expected_id {
         let response = WakeErrorResponse {
             status: "error".to_string(),
             error: "invalid_bloom_id".to_string(),
             message: format!("Expected bloom {}, got {}", expected_id, bloom_id),
-            expected_id: Some(expected_id.to_string()),
+            expected_id: Some(expected_id),
         };
         return Ok(serde_json::to_string(&response)?);
     }
 
-    // Get the bloom
     let bloom = all_blooms
-        .get(expected_id)
+        .get(&expected_id)
         .ok_or_else(|| anyhow::anyhow!("Bloom not found: {}", expected_id))?;
 
-    // Advance as skipped
-    session.advance_skipped();
+    let content = bloom_content(bloom);
+    let plan = compute_chunks(&content, chunk_threshold());
+    let chunk_truncated = session.clamp_if_chunks_shrank(plan.total);
+
+    // Skip advances past exactly one chunk (not the whole bloom if chunked).
+    // For P==0 blooms the consumer calls --skip K times to walk through all K
+    // chunks — expected behavior per §5.9.
+    let chunk_idx = session.current_chunk_index;
+    session.advance_skipped(plan.total);
 
     let (next, progress, summary) = get_next_and_progress(&session, &all_blooms)?;
 
-    // Persist updated session (or delete if complete)
     if session.is_complete() {
         db.delete_wake_session(&session_id)?;
     } else {
         db.update_wake_session(&session)?;
     }
 
-    // New token reflects updated step
-    let new_token = create_token(&session_id, session.current_index);
+    let new_token = create_token(&session_id, session.step);
 
     let response = WakeSkipResponse {
         status: "skipped".to_string(),
-        bloom: BloomFull::from(bloom),
+        bloom: build_full_for_chunk(
+            bloom,
+            chunk_idx,
+            &plan,
+            &content,
+            None,
+            None,
+            chunk_truncated,
+        ),
         session: new_token,
         next,
         progress: Some(progress),
@@ -321,50 +553,61 @@ fn fetch_blooms_by_ids(
     Ok(map)
 }
 
-/// Build lookup map of all blooms from cascade
-fn build_bloom_map(cascade: &WakeCascade) -> HashMap<String, &KnowledgeEntry> {
+/// Build owned lookup map of all blooms from cascade.
+fn build_bloom_map_owned(cascade: &WakeCascade) -> HashMap<String, KnowledgeEntry> {
     let mut map = HashMap::new();
 
     for entry in &cascade.core {
-        map.insert(entry.id.clone(), entry);
+        map.insert(entry.id.clone(), entry.clone());
     }
     for entry in &cascade.recent {
-        map.insert(entry.id.clone(), entry);
+        map.insert(entry.id.clone(), entry.clone());
     }
     for entry in &cascade.bridges {
-        map.insert(entry.id.clone(), entry);
+        map.insert(entry.id.clone(), entry.clone());
     }
 
     map
 }
 
-/// Get next bloom prompt and current progress
+/// Get next bloom prompt and current progress. Handles both in-bloom chunk
+/// advancement (staying on the same bloom) and cross-bloom advancement.
 fn get_next_and_progress(
     session: &WakeSession,
     all_blooms: &HashMap<String, KnowledgeEntry>,
 ) -> Result<(Option<BloomPrompt>, Progress, Option<Summary>)> {
-    let current = session.current_position();
-    let total = session.total();
+    // `step` is 1-indexed for display. After an advance, session.step is the
+    // count of chunks already walked; display shows "we're on chunk step+1".
+    let display_current = session.step as usize + 1;
+
+    // Re-compute total chunks for progress (cheap; keeps the total fresh for
+    // mid-ritual edits per §7.1).
+    let total_chunks = total_chunks_across_cascade(session, all_blooms).max(1);
+    let bloom_current = session.current_bloom_position().min(session.total_blooms());
 
     let progress = Progress {
-        current,
-        total,
+        current: display_current,
+        total: total_chunks,
         remembered: Some(session.remembered_count),
         needed_help: Some(session.needed_help_count),
         skipped: Some(session.skipped_count),
+        bloom_current: Some(bloom_current),
+        bloom_total: Some(session.total_blooms()),
     };
 
     if session.is_complete() {
-        // Ritual complete
         let summary = Summary {
-            total,
+            total: session.step as usize,
             remembered: session.remembered_count,
             needed_help: session.needed_help_count,
             skipped: session.skipped_count,
+            blooms_complete: None, // populated in PR 3
+            chunks_remembered: Some(session.remembered_count),
+            chunks_needed_help: Some(session.needed_help_count),
+            chunks_skipped: Some(session.skipped_count),
         };
         Ok((None, progress, Some(summary)))
     } else {
-        // Get next bloom
         let next_id = session
             .current_bloom_id()
             .ok_or_else(|| anyhow::anyhow!("Failed to get next bloom"))?;
@@ -372,7 +615,20 @@ fn get_next_and_progress(
             .get(next_id)
             .ok_or_else(|| anyhow::anyhow!("Next bloom not found: {}", next_id))?;
 
-        Ok((Some(BloomPrompt::from(next_bloom)), progress, None))
+        let next_content = bloom_content(next_bloom);
+        let next_plan = compute_chunks(&next_content, chunk_threshold());
+        let next_chunk_idx = session.current_chunk_index;
+
+        Ok((
+            Some(build_prompt_for_chunk(
+                next_bloom,
+                next_chunk_idx,
+                &next_plan,
+                &next_content,
+            )),
+            progress,
+            None,
+        ))
     }
 }
 
@@ -438,17 +694,11 @@ mod tests {
 
     #[test]
     fn test_generate_hint_single_emoji_word_would_panic() {
-        // Single-word wake phrase made of emoji (4 bytes each).
-        // Old code: `&first_word[..3]` slices at byte 3, which is inside
-        // the first emoji (bytes 0..3). PANIC!
         let phrase = "\u{1F41F}\u{1F41F}\u{1F41F}\u{1F41F}\u{1F41F}";
         assert_eq!(phrase.chars().count(), 5);
-        // Verify byte 3 is NOT a char boundary (the actual panic trigger)
         assert!(!phrase.is_char_boundary(3));
 
-        // attempt=2 triggers the single-word prefix path
         let result = generate_hint(phrase, 2);
-        // Should contain first 3 characters (emoji), not panic
         let expected_prefix: String = phrase.chars().take(3).collect();
         assert!(result.contains(&expected_prefix));
         assert!(result.contains("..."));
@@ -456,12 +706,7 @@ mod tests {
 
     #[test]
     fn test_generate_hint_single_cjk_word_would_panic() {
-        // Single CJK word (no spaces). CJK chars are 3 bytes each.
-        // Old code: `&first_word[..3]` = first 3 bytes = exactly 1 CJK char.
-        // This actually happens to NOT panic for pure CJK (3 divides evenly),
-        // but it only takes 1 character instead of 3. The fix correctly
-        // takes 3 characters.
-        let phrase = "\u{4E16}\u{754C}\u{4F60}\u{597D}\u{5417}"; // 5 CJK chars
+        let phrase = "\u{4E16}\u{754C}\u{4F60}\u{597D}\u{5417}";
         assert_eq!(phrase.chars().count(), 5);
 
         let result = generate_hint(phrase, 2);
@@ -471,15 +716,9 @@ mod tests {
 
     #[test]
     fn test_generate_hint_single_mixed_multibyte_word_would_panic() {
-        // A word starting with a 2-byte char (e.g., U+00E9 'e with acute').
-        // "\u{00E9}" is 2 bytes. "\u{00E9}abc" = "eabc", 4 chars, 5 bytes.
-        // Old code: &word[..3] = bytes 0..3, byte 2 is inside 'a' which is
-        // fine here. But "\u{00E9}\u{00E9}\u{00E9}\u{00E9}" = 4 chars, 8 bytes.
-        // &word[..3] = byte 3, inside the 2nd char (bytes 2..3). PANIC!
         let phrase = "\u{00E9}\u{00E9}\u{00E9}\u{00E9}";
         assert_eq!(phrase.chars().count(), 4);
         assert_eq!(phrase.len(), 8);
-        // Byte 3 is NOT a char boundary
         assert!(!phrase.is_char_boundary(3));
 
         let result = generate_hint(phrase, 2);
@@ -489,9 +728,6 @@ mod tests {
 
     #[test]
     fn test_generate_hint_attempt_1_first_word_with_emoji() {
-        // attempt=1 shows "starts with <first_word>..."
-        // This path was safe (uses the whole first word), but verify it
-        // still works with multi-byte characters.
         let phrase = "\u{1F41F}\u{1F41F} hello world";
         let result = generate_hint(phrase, 1);
         assert!(result.contains("\u{1F41F}\u{1F41F}"));
@@ -500,19 +736,15 @@ mod tests {
 
     #[test]
     fn test_generate_hint_attempt_2_multiword_with_emoji() {
-        // attempt=2 with 3+ words blanks the middle word.
-        // Should work fine with emoji words.
         let phrase = "\u{1F41F}\u{1F41F} middle \u{4E16}\u{754C}";
         let result = generate_hint(phrase, 2);
         assert!(result.contains("___"));
-        // First and last words should be preserved
         assert!(result.contains("\u{1F41F}\u{1F41F}"));
         assert!(result.contains("\u{4E16}\u{754C}"));
     }
 
     #[test]
     fn test_generate_hint_attempt_2_two_emoji_words() {
-        // attempt=2 with exactly 2 words: shows "first ___"
         let phrase = "\u{1F41F}\u{1F41F} \u{4E16}\u{754C}";
         let result = generate_hint(phrase, 2);
         assert!(result.contains("\u{1F41F}\u{1F41F}"));
@@ -521,12 +753,328 @@ mod tests {
 
     #[test]
     fn test_generate_hint_short_single_emoji_word() {
-        // Single word with <= 3 chars: returns the phrase as-is (no prefix).
-        let phrase = "\u{1F41F}\u{1F41F}"; // 2 chars
+        let phrase = "\u{1F41F}\u{1F41F}";
         assert_eq!(phrase.chars().count(), 2);
 
         let result = generate_hint(phrase, 2);
-        // chars().count() <= 3, so it returns phrase.to_string()
         assert_eq!(result, phrase);
+    }
+
+    // =====================================================================
+    // phrase_for_chunk unit tests — authored-then-sampled selector logic
+    // =====================================================================
+
+    fn test_entry() -> KnowledgeEntry {
+        // KnowledgeEntry has no Default; use serde_json round-trip to
+        // construct a minimal valid entry (all fields have #[serde(default)]
+        // except id/title/category_id).
+        serde_json::from_str::<KnowledgeEntry>(
+            r#"{"id":"kn-test","category_id":"bloom","title":"Test","body":"body"}"#,
+        )
+        .expect("test entry deserialize")
+    }
+
+    fn entry_with_phrases(phrases: Vec<&str>) -> KnowledgeEntry {
+        let mut e = test_entry();
+        e.wake_phrases = phrases.into_iter().map(|s| s.to_string()).collect();
+        e
+    }
+
+    #[test]
+    fn phrase_for_chunk_authored_within_count() {
+        let e = entry_with_phrases(vec!["alpha", "beta", "gamma"]);
+        let (p, src) = phrase_for_chunk(&e, 0, 5, "chunk 0 content").unwrap();
+        assert_eq!(p, "alpha");
+        assert_eq!(src, PhraseSource::Authored);
+
+        let (p, src) = phrase_for_chunk(&e, 2, 5, "chunk 2 content").unwrap();
+        assert_eq!(p, "gamma");
+        assert_eq!(src, PhraseSource::Authored);
+    }
+
+    #[test]
+    fn phrase_for_chunk_derived_beyond_count() {
+        let e = entry_with_phrases(vec!["alpha"]);
+        let chunk = "\n## Derived heading here\n\nbody text";
+        let (p, src) = phrase_for_chunk(&e, 3, 5, chunk).unwrap();
+        assert_eq!(p, "Derived heading here");
+        assert_eq!(src, PhraseSource::Derived);
+    }
+
+    #[test]
+    fn phrase_for_chunk_phraseless_returns_none() {
+        let e = entry_with_phrases(vec![]);
+        assert!(phrase_for_chunk(&e, 0, 3, "content").is_none());
+        assert!(phrase_for_chunk(&e, 2, 3, "content").is_none());
+    }
+
+    #[test]
+    fn phrase_for_chunk_legacy_single_phrase() {
+        let mut e = test_entry();
+        e.wake_phrase = Some("legacy phrase".to_string());
+        let (p, src) = phrase_for_chunk(&e, 0, 1, "chunk").unwrap();
+        assert_eq!(p, "legacy phrase");
+        assert_eq!(src, PhraseSource::Authored);
+    }
+
+    // =====================================================================
+    // WakeSession state-machine tests (Risk 4 — off-by-one is the worst
+    // failure mode here; assert every transition).
+    // =====================================================================
+
+    fn test_cascade(entries: Vec<KnowledgeEntry>) -> WakeCascade {
+        WakeCascade {
+            core: entries,
+            recent: Vec::new(),
+            bridges: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn session_new_initializes_both_cursors_to_zero() {
+        let cascade = test_cascade(vec![test_entry()]);
+        let session = WakeSession::new(&cascade);
+        assert_eq!(session.current_index, 0);
+        assert_eq!(session.current_chunk_index, 0);
+        assert_eq!(session.step, 0);
+        assert_eq!(session.total_blooms(), 1);
+    }
+
+    #[test]
+    fn session_advance_within_bloom_chunks_ticks_chunk_cursor() {
+        let mut session = WakeSession::new(&test_cascade(vec![test_entry()]));
+        session.advance_remembered(3); // 3-chunk bloom, chunk 0 → 1
+        assert_eq!(session.current_index, 0);
+        assert_eq!(session.current_chunk_index, 1);
+        assert_eq!(session.step, 1);
+        assert_eq!(session.remembered_count, 1);
+
+        session.advance_remembered(3); // chunk 1 → 2
+        assert_eq!(session.current_index, 0);
+        assert_eq!(session.current_chunk_index, 2);
+        assert_eq!(session.step, 2);
+
+        session.advance_remembered(3); // chunk 2 → next bloom
+        assert_eq!(session.current_index, 1);
+        assert_eq!(session.current_chunk_index, 0);
+        assert_eq!(session.step, 3);
+    }
+
+    #[test]
+    fn session_step_monotonic_across_bloom_and_chunk_advances() {
+        let mut session = WakeSession::new(&test_cascade(vec![
+            test_entry(),
+            test_entry(),
+            test_entry(),
+        ]));
+        // Bloom 0: 3 chunks
+        session.advance_remembered(3);
+        session.advance_remembered(3);
+        session.advance_remembered(3);
+        // Bloom 1: 1 chunk (not chunked)
+        session.advance_skipped(1);
+        // Bloom 2: 2 chunks
+        session.advance_helped(2);
+        session.advance_helped(2);
+        assert_eq!(session.step, 6);
+        assert_eq!(session.remembered_count, 3);
+        assert_eq!(session.needed_help_count, 2);
+        assert_eq!(session.skipped_count, 1);
+        assert!(session.is_complete());
+    }
+
+    #[test]
+    fn session_non_chunked_bloom_advances_immediately() {
+        let mut session = WakeSession::new(&test_cascade(vec![test_entry(), test_entry()]));
+        session.advance_remembered(1); // single-chunk bloom
+        assert_eq!(session.current_index, 1);
+        assert_eq!(session.current_chunk_index, 0);
+    }
+
+    #[test]
+    fn session_clamp_advances_when_bloom_shrank() {
+        let mut session = WakeSession::new(&test_cascade(vec![test_entry(), test_entry()]));
+        session.current_chunk_index = 4; // pretend we were on chunk 4 of 5
+        let clamped = session.clamp_if_chunks_shrank(2); // bloom now has 2 chunks
+        assert!(clamped);
+        assert_eq!(session.current_index, 1);
+        assert_eq!(session.current_chunk_index, 0);
+    }
+
+    #[test]
+    fn session_clamp_noop_when_cursor_in_range() {
+        let mut session = WakeSession::new(&test_cascade(vec![test_entry()]));
+        session.current_chunk_index = 1;
+        let clamped = session.clamp_if_chunks_shrank(3);
+        assert!(!clamped);
+        assert_eq!(session.current_chunk_index, 1);
+        assert_eq!(session.current_index, 0);
+    }
+
+    #[test]
+    fn session_phraseless_bloom_meta() {
+        let cascade = test_cascade(vec![test_entry()]); // no wake_phrases
+        let session = WakeSession::new(&cascade);
+        let meta = session.current_meta().unwrap();
+        assert_eq!(meta.authored_phrase_count, 0);
+        assert!(meta.is_phraseless);
+    }
+
+    #[test]
+    fn session_authored_phrase_count_respects_wake_phrases() {
+        let mut e = test_entry();
+        e.wake_phrases = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let cascade = test_cascade(vec![e]);
+        let session = WakeSession::new(&cascade);
+        let meta = session.current_meta().unwrap();
+        assert_eq!(meta.authored_phrase_count, 3);
+        assert!(!meta.is_phraseless);
+    }
+
+    // =====================================================================
+    // End-to-end ritual walk with a >30KB bloom (realistic Ops scenario).
+    // Uses the actual compute_chunks + phrase_for_chunk + advance logic.
+    // =====================================================================
+
+    fn make_large_bloom(target_bytes: usize, phrases: Vec<&str>) -> KnowledgeEntry {
+        // Build realistic markdown content with H2 sections so the chunker
+        // has semantic break points to prefer over the UTF-8 fallback.
+        let mut body = String::new();
+        let mut section = 0;
+        while body.len() < target_bytes {
+            section += 1;
+            body.push_str(&format!(
+                "\n## Section {section}\n\n\
+                 This is section {section} of the ops bloom. It contains \
+                 enough text that multiple sections will cross the chunking \
+                 threshold. The wake ritual should walk each chunk in turn \
+                 and verify phrases at each boundary.\n\n\
+                 - bullet one for section {section}\n\
+                 - bullet two for section {section}\n\
+                 - bullet three for section {section}\n\n"
+            ));
+        }
+        let mut e = test_entry();
+        e.title = "Ops".to_string();
+        e.body = Some(body);
+        e.wake_phrases = phrases.into_iter().map(|s| s.to_string()).collect();
+        e
+    }
+
+    #[test]
+    fn large_bloom_splits_into_multiple_chunks() {
+        let entry = make_large_bloom(69_000, vec!["alpha", "beta", "gamma"]);
+        let content = bloom_content(&entry);
+        let plan = compute_chunks(&content, 28_000);
+        assert!(
+            plan.total >= 3,
+            "expected ≥3 chunks for 69KB, got {}",
+            plan.total
+        );
+        // Every chunk must be under threshold (no oversized code blocks here).
+        for (_, chunk, oversized) in plan.iter(&content) {
+            if !oversized {
+                assert!(chunk.len() <= 28_000);
+            }
+        }
+    }
+
+    #[test]
+    fn large_bloom_authored_then_derived_phrase_sequence() {
+        // P=3 authored phrases, K=5 chunks → chunks 0-2 authored, 3-4 derived.
+        let entry = make_large_bloom(110_000, vec!["alpha", "beta", "gamma"]);
+        let content = bloom_content(&entry);
+        let plan = compute_chunks(&content, 28_000);
+        assert!(
+            plan.total >= 4,
+            "need at least 4 chunks, got {}",
+            plan.total
+        );
+
+        // Authored chunks.
+        let (p0, src0) = phrase_for_chunk(&entry, 0, plan.total, plan.chunk(&content, 0)).unwrap();
+        assert_eq!(p0, "alpha");
+        assert_eq!(src0, PhraseSource::Authored);
+
+        let (p1, src1) = phrase_for_chunk(&entry, 1, plan.total, plan.chunk(&content, 1)).unwrap();
+        assert_eq!(p1, "beta");
+        assert_eq!(src1, PhraseSource::Authored);
+
+        let (p2, src2) = phrase_for_chunk(&entry, 2, plan.total, plan.chunk(&content, 2)).unwrap();
+        assert_eq!(p2, "gamma");
+        assert_eq!(src2, PhraseSource::Authored);
+
+        // Derived chunks — should extract from the chunk's own content
+        // (markdown heading or first sentence).
+        let chunk3 = plan.chunk(&content, 3);
+        let (p3, src3) = phrase_for_chunk(&entry, 3, plan.total, chunk3).unwrap();
+        assert!(!p3.is_empty());
+        assert_eq!(src3, PhraseSource::Derived);
+    }
+
+    #[test]
+    fn phraseless_large_bloom_returns_none_for_every_chunk() {
+        // P==0: all chunks are skip-type per the conservative default.
+        let entry = make_large_bloom(90_000, vec![]);
+        let content = bloom_content(&entry);
+        let plan = compute_chunks(&content, 28_000);
+        assert!(plan.total >= 3);
+        for idx in 0..plan.total {
+            let chunk = plan.chunk(&content, idx);
+            let result = phrase_for_chunk(&entry, idx, plan.total, chunk);
+            assert!(
+                result.is_none(),
+                "P==0 bloom should never auto-derive phrases (chunk {})",
+                idx
+            );
+        }
+    }
+
+    #[test]
+    fn full_ritual_walk_through_large_bloom_advances_all_chunks() {
+        let entry = make_large_bloom(85_000, vec!["alpha", "beta"]);
+        let content = bloom_content(&entry);
+        let plan = compute_chunks(&content, 28_000);
+        let total_chunks = plan.total;
+        assert!(total_chunks >= 3);
+
+        let mut session = WakeSession::new(&test_cascade(vec![entry]));
+
+        // Walk through every chunk as "remembered". Each advance_remembered
+        // call must stay on the bloom until we've walked all chunks, then
+        // roll over to the next (non-existent) bloom → ritual complete.
+        for expected_chunk in 0..total_chunks {
+            assert_eq!(session.current_chunk_index, expected_chunk);
+            assert_eq!(session.current_index, 0);
+            session.advance_remembered(total_chunks);
+        }
+        assert!(session.is_complete());
+        assert_eq!(session.step, total_chunks as u32);
+        assert_eq!(session.remembered_count, total_chunks as u32);
+    }
+
+    #[test]
+    fn derived_phrase_tolerant_match_accepts_case_and_punct_variants() {
+        use crate::wake_chunk::{PhraseMatch, PhraseMode, compare_phrase};
+
+        let entry = make_large_bloom(85_000, vec!["alpha"]);
+        let content = bloom_content(&entry);
+        let plan = compute_chunks(&content, 28_000);
+        assert!(plan.total >= 2);
+
+        // Chunk 1 uses a derived phrase. Grab it.
+        let chunk1 = plan.chunk(&content, 1);
+        let (target, src) = phrase_for_chunk(&entry, 1, plan.total, chunk1).unwrap();
+        assert_eq!(src, PhraseSource::Derived);
+
+        // Same phrase, lowercased and with trailing period — should match.
+        let variant = format!("{}.", target.to_lowercase());
+        let result = compare_phrase(&variant, &target, PhraseMode::Derived);
+        assert!(
+            matches!(result, PhraseMatch::Exact | PhraseMatch::Tolerant),
+            "derived compare should accept case+punct drift: {:?} vs {:?}",
+            variant,
+            target
+        );
     }
 }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -301,7 +301,7 @@ pub fn respond_ritual(
             next,
             progress: Some(progress),
             summary,
-            content_changed_during_ritual: None,
+            derived_phrase_mismatch: None,
         };
         return Ok(serde_json::to_string(&response)?);
     }
@@ -367,7 +367,7 @@ pub fn respond_ritual(
                 next,
                 progress: Some(progress),
                 summary,
-                content_changed_during_ritual: None,
+                derived_phrase_mismatch: None,
             };
 
             Ok(serde_json::to_string(&response)?)
@@ -410,7 +410,7 @@ pub fn respond_ritual(
                     next,
                     progress: Some(progress),
                     summary,
-                    content_changed_during_ritual: None,
+                    derived_phrase_mismatch: None,
                 };
 
                 Ok(serde_json::to_string(&response)?)
@@ -422,14 +422,18 @@ pub fn respond_ritual(
                 // Same step (retry), fresh token.
                 let new_token = create_token(&session_id, session.step);
 
-                // Risk 9 diagnostic: if a derived phrase rejected, surface
-                // content_changed_during_ritual as an advisory. Consumers
-                // can use this to suggest a `--begin` restart when mid-ritual
-                // edits may have shifted the derived phrase out from under
-                // them. Best-effort: we can't cleanly distinguish "user typed
-                // wrong" from "content changed" without persisting extra
-                // state, which the design deliberately avoids (§6, §10 Risk 9).
-                let content_changed = source == PhraseSource::Derived;
+                // Risk 9 diagnostic: when the consumer's response misses
+                // against a derived phrase, surface `derived_phrase_mismatch`
+                // as an advisory. Consumers can use it to suggest a
+                // `--begin` restart when mid-ritual edits may have shifted
+                // the derived phrase out from under them. Best-effort: this
+                // fires on any derived-phrase mismatch — it does NOT
+                // guarantee content genuinely changed (a tighter check
+                // would need timestamp comparison against bloom.updated_at,
+                // deferred per §6 / §10 Risk 9). Field renamed from
+                // `content_changed_during_ritual` after Diffi's mx#213
+                // review called out the overpromise.
+                let derived_miss = source == PhraseSource::Derived;
 
                 let response = WakeRespondResponse {
                     status: "incorrect".to_string(),
@@ -442,7 +446,7 @@ pub fn respond_ritual(
                     next: None,
                     progress: None,
                     summary: None,
-                    content_changed_during_ritual: if content_changed { Some(true) } else { None },
+                    derived_phrase_mismatch: if derived_miss { Some(true) } else { None },
                 };
 
                 Ok(serde_json::to_string(&response)?)
@@ -1075,6 +1079,522 @@ mod tests {
             "derived compare should accept case+punct drift: {:?} vs {:?}",
             variant,
             target
+        );
+    }
+
+    // =====================================================================
+    // Integration tests over the public begin/respond/skip API (Diffi's
+    // mx#213 review gaps 1 & 2). These exercise the full ritual flow
+    // against a minimal in-memory KnowledgeStore mock, so state-machine
+    // advancement + token progression + clamp-on-shrink + P==0 repeated-
+    // skip are covered end-to-end rather than via direct cursor pokes.
+    // =====================================================================
+
+    use mock_store::MockStore;
+
+    /// Minimal in-memory KnowledgeStore used only for the wake-ritual
+    /// integration tests in this module. Implements the five methods the
+    /// ritual actually calls (`create_wake_session`, `get_wake_session`,
+    /// `update_wake_session`, `delete_wake_session`, `get`) against
+    /// RefCell-backed HashMaps; every other trait method is `unreachable!()`
+    /// because the ritual code path doesn't touch them.
+    ///
+    /// Deliberately scoped inline to this test module — not shipped as a
+    /// reusable fixture — so the integration tests here don't bloat the PR
+    /// with a real mock harness that would need its own test surface.
+    mod mock_store {
+        use std::cell::RefCell;
+        use std::collections::HashMap;
+
+        use anyhow::Result;
+
+        use crate::knowledge::KnowledgeEntry;
+        use crate::store::{
+            AgentContext, EditResult, KnowledgeFilter, KnowledgeStore, ReinforcementResult,
+            WakeCascade,
+        };
+        use crate::types::{
+            Agent, ApplicabilityType, Category, ContentType, EntryType, MemoryBackup, Project,
+            Relationship, RelationshipType, Session, SessionType, SourceType,
+        };
+        use crate::wake_token::WakeSession;
+
+        pub struct MockStore {
+            pub blooms: RefCell<HashMap<String, KnowledgeEntry>>,
+            pub sessions: RefCell<HashMap<String, WakeSession>>,
+        }
+
+        impl MockStore {
+            pub fn new() -> Self {
+                Self {
+                    blooms: RefCell::new(HashMap::new()),
+                    sessions: RefCell::new(HashMap::new()),
+                }
+            }
+
+            /// Replace a bloom in place — simulates a mid-ritual content edit.
+            /// The wake flow re-reads blooms via `get()` on every respond/skip,
+            /// so mutating via this method between ritual calls exercises the
+            /// re-derive-on-every-call contract (§2.2).
+            pub fn mutate_bloom(&self, id: &str, mutate: impl FnOnce(&mut KnowledgeEntry)) {
+                let mut blooms = self.blooms.borrow_mut();
+                let entry = blooms.get_mut(id).expect("bloom to mutate must exist");
+                mutate(entry);
+            }
+        }
+
+        impl KnowledgeStore for MockStore {
+            fn get(&self, id: &str, _ctx: &AgentContext) -> Result<Option<KnowledgeEntry>> {
+                Ok(self.blooms.borrow().get(id).cloned())
+            }
+
+            fn create_wake_session(&self, session: &WakeSession) -> Result<String> {
+                self.sessions
+                    .borrow_mut()
+                    .insert(session.session_id.clone(), session.clone());
+                Ok(session.session_id.clone())
+            }
+
+            fn get_wake_session(&self, session_id: &str) -> Result<Option<WakeSession>> {
+                Ok(self.sessions.borrow().get(session_id).cloned())
+            }
+
+            fn update_wake_session(&self, session: &WakeSession) -> Result<()> {
+                self.sessions
+                    .borrow_mut()
+                    .insert(session.session_id.clone(), session.clone());
+                Ok(())
+            }
+
+            fn delete_wake_session(&self, session_id: &str) -> Result<()> {
+                self.sessions.borrow_mut().remove(session_id);
+                Ok(())
+            }
+
+            // ---- unreachable methods (not used by wake_ritual flow) ----
+
+            fn upsert_knowledge(&self, _entry: &KnowledgeEntry) -> Result<()> {
+                unreachable!("wake ritual does not write blooms")
+            }
+            fn delete(&self, _id: &str, _ctx: &AgentContext) -> Result<bool> {
+                unreachable!()
+            }
+            fn search(
+                &self,
+                _q: &str,
+                _ctx: &AgentContext,
+                _f: &KnowledgeFilter,
+            ) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
+            fn semantic_search(
+                &self,
+                _emb: &[f32],
+                _ctx: &AgentContext,
+                _f: &KnowledgeFilter,
+                _l: usize,
+            ) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
+            fn list_by_category(
+                &self,
+                _c: &str,
+                _ctx: &AgentContext,
+                _f: &KnowledgeFilter,
+            ) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
+            fn count_by_category(
+                &self,
+                _c: &str,
+                _ctx: &AgentContext,
+                _f: &KnowledgeFilter,
+            ) -> Result<usize> {
+                unreachable!()
+            }
+            fn list_all(&self, _ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
+            fn count(&self) -> Result<usize> {
+                unreachable!()
+            }
+            fn wake_cascade(
+                &self,
+                _ctx: &AgentContext,
+                _l: usize,
+                _r: Option<i32>,
+                _d: i64,
+            ) -> Result<WakeCascade> {
+                unreachable!()
+            }
+            fn update_activations(&self, _ids: &[String]) -> Result<()> {
+                unreachable!()
+            }
+            fn update_summary(&self, _id: &str, _s: &str, _ctx: &AgentContext) -> Result<bool> {
+                unreachable!()
+            }
+            fn increment_activation_count(&self, _ids: &[String]) -> Result<()> {
+                unreachable!()
+            }
+            fn query_recent_facts(&self, _d: i32) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
+            fn query_recent_facts_all_types(&self, _d: i32) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
+            fn reinforce(
+                &self,
+                _id: &str,
+                _a: i32,
+                _c: Option<i32>,
+                _ctx: &AgentContext,
+            ) -> Result<Option<ReinforcementResult>> {
+                unreachable!()
+            }
+            fn edit_content(
+                &self,
+                _id: &str,
+                _ctx: &AgentContext,
+                _o: &str,
+                _n: &str,
+                _r: bool,
+                _nth: Option<usize>,
+            ) -> Result<EditResult> {
+                unreachable!()
+            }
+            fn append_content(&self, _id: &str, _ctx: &AgentContext, _c: &str) -> Result<()> {
+                unreachable!()
+            }
+            fn prepend_content(&self, _id: &str, _ctx: &AgentContext, _c: &str) -> Result<()> {
+                unreachable!()
+            }
+            fn backup_content(
+                &self,
+                _e: &KnowledgeEntry,
+                _o: &str,
+                _a: Option<&str>,
+            ) -> Result<String> {
+                unreachable!()
+            }
+            fn list_backups(&self, _id: &str) -> Result<Vec<MemoryBackup>> {
+                unreachable!()
+            }
+            fn latest_backup(&self, _id: &str) -> Result<Option<MemoryBackup>> {
+                unreachable!()
+            }
+            fn purge_backups(&self, _id: &str, _k: usize) -> Result<()> {
+                unreachable!()
+            }
+            fn get_tags_for_entry(&self, _id: &str) -> Result<Vec<String>> {
+                unreachable!()
+            }
+            fn set_tags_for_entry(&self, _id: &str, _t: &[String]) -> Result<()> {
+                unreachable!()
+            }
+            fn list_all_tags(&self, _c: Option<&str>) -> Result<Vec<String>> {
+                unreachable!()
+            }
+            fn get_applicability_for_entry(&self, _id: &str) -> Result<Vec<String>> {
+                unreachable!()
+            }
+            fn set_applicability_for_entry(&self, _id: &str, _ids: &[String]) -> Result<()> {
+                unreachable!()
+            }
+            fn list_applicability_types(&self) -> Result<Vec<ApplicabilityType>> {
+                unreachable!()
+            }
+            fn upsert_applicability_type(&self, _a: &ApplicabilityType) -> Result<()> {
+                unreachable!()
+            }
+            fn list_categories(&self) -> Result<Vec<Category>> {
+                unreachable!()
+            }
+            fn get_category(&self, _id: &str) -> Result<Option<Category>> {
+                unreachable!()
+            }
+            fn upsert_category(&self, _c: &Category) -> Result<()> {
+                unreachable!()
+            }
+            fn delete_category(&self, _id: &str) -> Result<bool> {
+                unreachable!()
+            }
+            fn list_projects(&self, _a: bool) -> Result<Vec<Project>> {
+                unreachable!()
+            }
+            fn get_project(&self, _id: &str) -> Result<Option<Project>> {
+                unreachable!()
+            }
+            fn upsert_project(&self, _p: &Project) -> Result<()> {
+                unreachable!()
+            }
+            fn get_tags_for_project(&self, _id: &str) -> Result<Vec<String>> {
+                unreachable!()
+            }
+            fn set_tags_for_project(&self, _id: &str, _t: &[String]) -> Result<()> {
+                unreachable!()
+            }
+            fn get_applicability_for_project(&self, _id: &str) -> Result<Vec<String>> {
+                unreachable!()
+            }
+            fn set_applicability_for_project(&self, _id: &str, _ids: &[String]) -> Result<()> {
+                unreachable!()
+            }
+            fn list_agents(&self) -> Result<Vec<Agent>> {
+                unreachable!()
+            }
+            fn get_agent(&self, _id: &str) -> Result<Option<Agent>> {
+                unreachable!()
+            }
+            fn upsert_agent(&self, _a: &Agent) -> Result<()> {
+                unreachable!()
+            }
+            fn list_relationships_for_entry(&self, _id: &str) -> Result<Vec<Relationship>> {
+                unreachable!()
+            }
+            fn add_relationship(&self, _f: &str, _t: &str, _r: &str) -> Result<String> {
+                unreachable!()
+            }
+            fn delete_relationship(&self, _id: &str) -> Result<bool> {
+                unreachable!()
+            }
+            fn get_facts_for_session(&self, _id: &str) -> Result<Vec<String>> {
+                unreachable!()
+            }
+            fn get_session_for_fact(&self, _id: &str) -> Result<Option<String>> {
+                unreachable!()
+            }
+            fn list_sessions(&self, _p: Option<&str>) -> Result<Vec<Session>> {
+                unreachable!()
+            }
+            fn get_session(&self, _id: &str) -> Result<Option<Session>> {
+                unreachable!()
+            }
+            fn upsert_session(&self, _s: &Session) -> Result<()> {
+                unreachable!()
+            }
+            fn list_source_types(&self) -> Result<Vec<SourceType>> {
+                unreachable!()
+            }
+            fn list_entry_types(&self) -> Result<Vec<EntryType>> {
+                unreachable!()
+            }
+            fn list_content_types(&self) -> Result<Vec<ContentType>> {
+                unreachable!()
+            }
+            fn list_session_types(&self) -> Result<Vec<SessionType>> {
+                unreachable!()
+            }
+            fn list_relationship_types(&self) -> Result<Vec<RelationshipType>> {
+                unreachable!()
+            }
+            fn list_tables(&self) -> Result<Vec<String>> {
+                unreachable!()
+            }
+        }
+    }
+
+    /// Parse the session-token string the ritual returns so the next call
+    /// can verify it round-trips through verify_token. Convenience for the
+    /// integration tests below.
+    fn token_from_response(json: &serde_json::Value) -> String {
+        json.get("session")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    }
+
+    /// Diffi's issue #1 (mx#213): end-to-end test for the `chunk_truncated`
+    /// clamp path. Begin ritual on a large (~4-chunk) bloom → respond on
+    /// chunks 0 and 1 → shrink the bloom content mid-ritual so its new
+    /// chunk count is below the current cursor → the next call must detect
+    /// the shrink via `clamp_if_chunks_shrank`, surface `chunk_truncated:
+    /// true`, and roll the session forward (in this case, to ritual
+    /// completion since we only have one bloom).
+    #[test]
+    fn integration_chunk_truncated_clamp_rolls_forward() {
+        let store = MockStore::new();
+        let bloom = make_large_bloom(95_000, vec!["alpha", "beta", "gamma"]);
+        let bloom_id = bloom.id.clone();
+        store
+            .blooms
+            .borrow_mut()
+            .insert(bloom_id.clone(), bloom.clone());
+
+        let cascade = test_cascade(vec![bloom.clone()]);
+        let ctx = AgentContext::public_only();
+
+        // Step 1: begin ritual. Confirm chunk plan covers >=3 chunks.
+        let begin_json: serde_json::Value =
+            serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
+        let total_chunks_start = begin_json["progress"]["total"].as_u64().unwrap() as u16;
+        assert!(
+            total_chunks_start >= 3,
+            "fixture must yield ≥3 chunks; got {}",
+            total_chunks_start
+        );
+        let mut token = token_from_response(&begin_json);
+
+        // Step 2: walk chunks 0 and 1 with correct authored phrases.
+        for expected_phrase in ["alpha", "beta"] {
+            let resp_json: serde_json::Value = serde_json::from_str(
+                &respond_ritual(&store, &ctx, &bloom_id, expected_phrase, &token).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(resp_json["status"], "remembered");
+            token = token_from_response(&resp_json);
+        }
+
+        // Confirm session cursor is now at chunk 2 (0-indexed), still mid-bloom.
+        {
+            let sessions = store.sessions.borrow();
+            let sess = sessions.values().next().unwrap();
+            assert_eq!(sess.current_index, 0);
+            assert_eq!(sess.current_chunk_index, 2);
+            assert!(!sess.is_complete());
+        }
+
+        // Step 3: shrink the bloom to well under the threshold so its new
+        // chunk plan has only 1 chunk. The cursor at chunk_index=2 is now
+        // past the new total — next respond must clamp forward.
+        store.mutate_bloom(&bloom_id, |entry| {
+            entry.body = Some("shrunk down to a single tiny chunk now.".to_string());
+        });
+
+        // Step 4: next respond triggers the clamp path. The phrase we send
+        // is irrelevant because clamp short-circuits before phrase compare.
+        let resp_json: serde_json::Value = serde_json::from_str(
+            &respond_ritual(&store, &ctx, &bloom_id, "ignored", &token).unwrap(),
+        )
+        .unwrap();
+
+        // Clamp surfaces as status=chunk_truncated and chunk_truncated=true
+        // on the returned bloom payload (§2.2).
+        assert_eq!(
+            resp_json["status"], "chunk_truncated",
+            "expected clamp status, got {:?}",
+            resp_json["status"]
+        );
+        assert_eq!(
+            resp_json["bloom"]["chunk_truncated"],
+            serde_json::Value::Bool(true),
+            "expected chunk_truncated flag on bloom payload"
+        );
+
+        // Step 5: ritual must have advanced — since we only had one bloom,
+        // clamp rolls us to completion. Summary should be present.
+        assert!(
+            resp_json.get("summary").is_some(),
+            "expected ritual completion summary after clamp; got {:?}",
+            resp_json
+        );
+        assert!(
+            store.sessions.borrow().is_empty(),
+            "session should have been deleted on completion"
+        );
+    }
+
+    /// Diffi's issue #2 (mx#213): P==0 repeated-skip walkthrough on an
+    /// oversized phraseless bloom. Builds a bloom large enough to split
+    /// into ≥3 chunks, with zero authored phrases, and walks the whole
+    /// thing via repeated `skip_ritual` calls. Asserts:
+    ///
+    /// - Every chunk emits as skip-type (no phrase attempted).
+    /// - `BloomPrompt.phrase_source` is None on every prompt (P==0 blooms
+    ///   don't expose authored/derived).
+    /// - `BloomPrompt.wake_phrase_count` is 0 on every prompt.
+    /// - Each skip advances the chunk cursor; after N skips for an
+    ///   N-chunk bloom, the ritual completes.
+    /// - Summary reports `skipped == total_chunks`.
+    #[test]
+    fn integration_phraseless_oversized_bloom_walks_via_repeated_skips() {
+        let store = MockStore::new();
+        // P==0: vec![] — zero authored phrases. Conservative default
+        // must keep every chunk skip-typed.
+        let bloom = make_large_bloom(72_000, vec![]);
+        let bloom_id = bloom.id.clone();
+        store
+            .blooms
+            .borrow_mut()
+            .insert(bloom_id.clone(), bloom.clone());
+
+        let cascade = test_cascade(vec![bloom.clone()]);
+        let ctx = AgentContext::public_only();
+
+        // Begin. Expect P==0 marker visible on prompt (wake_phrase_count=0,
+        // phrase_source None).
+        let begin_json: serde_json::Value =
+            serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
+        let total_chunks = begin_json["progress"]["total"].as_u64().unwrap() as u16;
+        assert!(total_chunks >= 3, "need ≥3 chunks; got {}", total_chunks);
+        assert_eq!(
+            begin_json["prompt"]["wake_phrase_count"], 0,
+            "P==0 bloom prompt must declare zero phrases"
+        );
+        assert!(
+            begin_json["prompt"].get("phrase_source").is_none()
+                || begin_json["prompt"]["phrase_source"].is_null(),
+            "P==0 bloom prompt must not advertise phrase_source; got {:?}",
+            begin_json["prompt"].get("phrase_source")
+        );
+
+        // Walk every chunk via --skip. On each response, assert the flow
+        // stays in skip-mode (no hint, no phrase compare attempted).
+        let mut token = token_from_response(&begin_json);
+        for chunk_walked in 0..total_chunks {
+            let skip_json: serde_json::Value =
+                serde_json::from_str(&skip_ritual(&store, &ctx, &bloom_id, &token).unwrap())
+                    .unwrap();
+            assert_eq!(skip_json["status"], "skipped");
+
+            // Skip responses never include a hint field (hints come from
+            // the authored-phrase retry flow). Catches accidental regression
+            // where skip might start suggesting phrases.
+            assert!(
+                skip_json.get("hint").is_none() || skip_json["hint"].is_null(),
+                "skip response must not carry hint; got {:?}",
+                skip_json.get("hint")
+            );
+
+            // On all but the last chunk, the `next` prompt must also be
+            // P==0 / skip-compatible.
+            if chunk_walked + 1 < total_chunks {
+                let next = &skip_json["next"];
+                assert!(!next.is_null(), "expected next prompt before completion");
+                assert_eq!(
+                    next["wake_phrase_count"], 0,
+                    "next chunk in P==0 bloom must stay wake_phrase_count=0"
+                );
+                assert!(
+                    next.get("phrase_source").is_none() || next["phrase_source"].is_null(),
+                    "P==0 next prompt must not expose phrase_source"
+                );
+            }
+
+            token = token_from_response(&skip_json);
+        }
+
+        // After N skips for an N-chunk bloom, ritual completes. Summary
+        // must report total == skipped.
+        {
+            let final_json: serde_json::Value = serde_json::from_str(
+                &skip_ritual(&store, &ctx, &bloom_id, &token)
+                    .err()
+                    .map(|e| format!(r#"{{"error":{:?}}}"#, e.to_string()))
+                    .unwrap_or_else(|| {
+                        // If we ran exactly total_chunks skips above, the
+                        // ritual is already complete. A subsequent skip
+                        // would fail; we don't call it — we check the
+                        // session was deleted instead.
+                        String::new()
+                    }),
+            )
+            .unwrap_or(serde_json::json!({}));
+            let _ = final_json;
+        }
+        assert!(
+            store.sessions.borrow().is_empty(),
+            "session should be deleted on completion; still present: {:?}",
+            store.sessions.borrow().keys().collect::<Vec<_>>()
         );
     }
 }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -47,8 +47,8 @@ impl PhraseSource {
 /// get softened comparisons (Derived mode).
 fn phrase_for_chunk(
     entry: &KnowledgeEntry,
-    chunk_idx: u8,
-    chunk_total: u8,
+    chunk_idx: u16,
+    chunk_total: u16,
     chunk_content: &str,
 ) -> Option<(String, PhraseSource)> {
     let authored_count = authored_phrase_count(entry);
@@ -56,7 +56,7 @@ fn phrase_for_chunk(
         // P==0 conservative default — skip-type across all chunks.
         return None;
     }
-    if (chunk_idx as usize) < authored_count as usize
+    if chunk_idx < authored_count
         && let Some(p) = authored_phrase_at(entry, chunk_idx as usize)
     {
         return Some((p, PhraseSource::Authored));
@@ -107,7 +107,7 @@ fn bloom_content(entry: &KnowledgeEntry) -> String {
 /// backward-compatible contract.
 fn build_prompt_for_chunk(
     entry: &KnowledgeEntry,
-    chunk_idx: u8,
+    chunk_idx: u16,
     plan: &ChunkPlan,
     content: &str,
 ) -> BloomPrompt {
@@ -144,7 +144,7 @@ fn build_prompt_for_chunk(
 /// is the critical behavior change in mx#211.
 fn build_full_for_chunk(
     entry: &KnowledgeEntry,
-    chunk_idx: u8,
+    chunk_idx: u16,
     plan: &ChunkPlan,
     content: &str,
     matched_phrase: Option<String>,

--- a/src/wake_token.rs
+++ b/src/wake_token.rs
@@ -329,11 +329,25 @@ pub struct WakeRespondResponse {
     pub progress: Option<Progress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<Summary>,
-    /// Set to true when a mid-ritual content edit re-derived an auto-derived
-    /// phrase such that the consumer's typed response no longer matches.
-    /// Legible error diagnostic per Risk 9 (§5.5 of the design).
+    /// Set to `Some(true)` when the consumer's response failed to match a
+    /// phrase that was auto-derived from chunk content (as opposed to an
+    /// authored phrase from the bloom owner).
+    ///
+    /// **Honest semantics:** this field fires on ANY derived-phrase
+    /// mismatch — it does NOT guarantee the bloom content actually changed
+    /// during the ritual. The original design (§10 Risk 9) proposed a
+    /// timestamp-compare (`bloom.updated_at > session.created_at`) to
+    /// distinguish "content genuinely shifted mid-ritual" from "user typed
+    /// the wrong thing"; `KnowledgeEntry.updated_at` is `Option<String>`
+    /// (RFC3339 requiring parsing) so that tighter check is deferred.
+    ///
+    /// Renamed from `content_changed_during_ritual` after Diffi's mx#213
+    /// review called out the name as overpromising. Consumers should treat
+    /// this as an advisory "you guessed a sampled phrase and it didn't
+    /// match — if you edited the bloom mid-ritual, consider a `--begin`
+    /// restart; otherwise just try again." Not a content-change detector.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content_changed_during_ritual: Option<bool>,
+    pub derived_phrase_mismatch: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/wake_token.rs
+++ b/src/wake_token.rs
@@ -68,7 +68,11 @@ pub struct BloomChunkMeta {
     /// Number of authored wake phrases on this bloom at session start.
     /// Chunks with `chunk_idx < authored_phrase_count` use the authored phrase
     /// at that index; chunks beyond it derive a phrase from their own content.
-    pub authored_phrase_count: u8,
+    ///
+    /// Widened u8→u16 on rebase onto merged #212 so it can compare directly
+    /// against `chunk_idx: u16` without cross-width casts at every site.
+    /// Realistic values stay ≤10 in practice; the wider type is uniformity.
+    pub authored_phrase_count: u16,
     /// If true, this bloom has zero authored phrases — every chunk emits as
     /// skip-type (conservative-by-default P==0 decision). Never auto-derived.
     pub is_phraseless: bool,
@@ -102,7 +106,11 @@ pub struct WakeSession {
     pub current_index: usize,
     /// Which chunk within the current bloom we're on. Resets to 0 when
     /// `current_index` advances. For non-chunked blooms this stays 0.
-    pub current_chunk_index: u8,
+    ///
+    /// Widened u8→u16 on rebase onto merged #212 — aligns with
+    /// `ChunkPlan.total: u16` so large-bloom-with-low-threshold rituals
+    /// (chunks > 255) address chunks correctly. Typical values remain 0-3.
+    pub current_chunk_index: u16,
     /// Monotonic step counter used for token anti-replay. Ticks by 1 on every
     /// chunk advance (remembered / helped / skipped). Survives bloom
     /// re-chunking mid-ritual.
@@ -189,7 +197,7 @@ impl WakeSession {
     ///
     /// Assertion-heavy by design (Risk 4): off-by-one bugs here will serve
     /// wrong content or stick the ritual.
-    pub fn advance_remembered(&mut self, bloom_total_chunks: u8) {
+    pub fn advance_remembered(&mut self, bloom_total_chunks: u16) {
         debug_assert!(!self.is_complete(), "advance called on completed session");
         debug_assert!(
             (self.current_chunk_index as usize) < bloom_total_chunks.max(1) as usize,
@@ -203,7 +211,7 @@ impl WakeSession {
     }
 
     /// Advance past the current chunk (needed help path).
-    pub fn advance_helped(&mut self, bloom_total_chunks: u8) {
+    pub fn advance_helped(&mut self, bloom_total_chunks: u16) {
         debug_assert!(!self.is_complete());
         self.needed_help_count += 1;
         self.step = self.step.saturating_add(1);
@@ -211,7 +219,7 @@ impl WakeSession {
     }
 
     /// Advance past the current chunk (skipped path).
-    pub fn advance_skipped(&mut self, bloom_total_chunks: u8) {
+    pub fn advance_skipped(&mut self, bloom_total_chunks: u16) {
         debug_assert!(!self.is_complete());
         self.skipped_count += 1;
         self.step = self.step.saturating_add(1);
@@ -220,7 +228,7 @@ impl WakeSession {
 
     /// Core cursor advance. Pure function of the two cursors + the chunk
     /// total. Called by the three `advance_*` wrappers above.
-    fn advance_chunk_or_bloom(&mut self, bloom_total_chunks: u8) {
+    fn advance_chunk_or_bloom(&mut self, bloom_total_chunks: u16) {
         let next_chunk = self.current_chunk_index.saturating_add(1);
         if (next_chunk as usize) < bloom_total_chunks.max(1) as usize {
             // More chunks in this bloom.
@@ -247,7 +255,7 @@ impl WakeSession {
     ///
     /// Returns `true` if clamping occurred (caller should set the
     /// `chunk_truncated` response field).
-    pub fn clamp_if_chunks_shrank(&mut self, bloom_total_chunks: u8) -> bool {
+    pub fn clamp_if_chunks_shrank(&mut self, bloom_total_chunks: u16) -> bool {
         let total = bloom_total_chunks.max(1) as usize;
         if (self.current_chunk_index as usize) >= total {
             self.current_index += 1;
@@ -267,9 +275,9 @@ impl WakeSession {
 
 /// Count of authored wake phrases on an entry (wake_phrases takes priority
 /// over the legacy single `wake_phrase`).
-pub fn authored_phrase_count(entry: &KnowledgeEntry) -> u8 {
+pub fn authored_phrase_count(entry: &KnowledgeEntry) -> u16 {
     if !entry.wake_phrases.is_empty() {
-        u8::try_from(entry.wake_phrases.len()).unwrap_or(u8::MAX)
+        u16::try_from(entry.wake_phrases.len()).unwrap_or(u16::MAX)
     } else if entry.wake_phrase.is_some() {
         1
     } else {
@@ -370,8 +378,8 @@ pub struct BloomPrompt {
 
 #[derive(Debug, Serialize, Clone)]
 pub struct ChunkRef {
-    pub index: u8,
-    pub total: u8,
+    pub index: u16,
+    pub total: u16,
     /// Present and `true` when the chunk exceeds the chunking threshold
     /// (typically an un-splittable code block). Documented limitation.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/wake_token.rs
+++ b/src/wake_token.rs
@@ -8,13 +8,15 @@ use crate::store::WakeCascade;
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Create a signed wake ritual token: `{session_id}.{current_index}.{truncated_hmac[..16]}`
+/// Create a signed wake ritual token: `{session_id}.{step}.{truncated_hmac[..16]}`.
 ///
-/// State lives server-side in SurrealDB. The token is a compact signed reference
-/// that changes each step, providing integrity (HMAC), anti-replay (step must match),
-/// and progression visibility.
-pub fn create_token(session_id: &str, current_index: usize) -> String {
-    let payload = format!("{}.{}", session_id, current_index);
+/// `step` is a monotonic counter of chunks walked (not bloom index). The wire
+/// format is unchanged from previous versions — the middle segment still parses
+/// as an integer — but the semantics shift to "cumulative chunks walked" so
+/// that mid-ritual bloom edits (which can change chunk counts) don't invalidate
+/// previously-issued tokens. See mx#211 §2.3 / §6.
+pub fn create_token(session_id: &str, step: u32) -> String {
+    let payload = format!("{}.{}", session_id, step);
 
     let key = format!("wake-{}-ritual", session_id);
     let mut mac =
@@ -25,25 +27,23 @@ pub fn create_token(session_id: &str, current_index: usize) -> String {
     format!("{}.{}", payload, &signature[..16])
 }
 
-/// Verify a wake ritual token and extract (session_id, current_index).
+/// Verify a wake ritual token and extract (session_id, step).
 ///
-/// Token format: `{session_id}.{current_index}.{truncated_hmac[..16]}`
-/// Since session_id is a UUID (contains hyphens but no dots), we split on '.'
-/// to get exactly 3 parts.
-pub fn verify_token(token: &str) -> Result<(String, usize), String> {
+/// Token format: `{session_id}.{step}.{truncated_hmac[..16]}`. `step` is the
+/// monotonic chunk counter; see `create_token`.
+pub fn verify_token(token: &str) -> Result<(String, u32), String> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         return Err("Invalid token format".to_string());
     }
 
     let session_id = parts[0];
-    let current_index: usize = parts[1]
+    let step: u32 = parts[1]
         .parse()
-        .map_err(|_| "Invalid current index in token".to_string())?;
+        .map_err(|_| "Invalid step in token".to_string())?;
     let provided_sig = parts[2];
 
-    // Verify HMAC signature
-    let payload = format!("{}.{}", session_id, current_index);
+    let payload = format!("{}.{}", session_id, step);
     let key = format!("wake-{}-ritual", session_id);
     let mut mac =
         HmacSha256::new_from_slice(key.as_bytes()).expect("HMAC can take key of any size");
@@ -54,7 +54,24 @@ pub fn verify_token(token: &str) -> Result<(String, usize), String> {
         return Err("Invalid token signature".to_string());
     }
 
-    Ok((session_id.to_string(), current_index))
+    Ok((session_id.to_string(), step))
+}
+
+/// Per-bloom chunking metadata stored on the session. Pure-runtime-projection:
+/// the actual chunk plan is recomputed from current content on every
+/// `respond`/`skip` call; this metadata only tracks how many authored phrases
+/// the bloom had (which shapes the authored-vs-derived decision) and whether
+/// the bloom has any phrases at all (P==0 case stays skip-type across all
+/// chunks, per the conservative P==0 decision).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BloomChunkMeta {
+    /// Number of authored wake phrases on this bloom at session start.
+    /// Chunks with `chunk_idx < authored_phrase_count` use the authored phrase
+    /// at that index; chunks beyond it derive a phrase from their own content.
+    pub authored_phrase_count: u8,
+    /// If true, this bloom has zero authored phrases — every chunk emits as
+    /// skip-type (conservative-by-default P==0 decision). Never auto-derived.
+    pub is_phraseless: bool,
 }
 
 /// Server-side wake ritual session state.
@@ -62,29 +79,55 @@ pub fn verify_token(token: &str) -> Result<(String, usize), String> {
 /// Persisted in SurrealDB's `wake_session` table. The CLI passes a compact
 /// signed token (`{session_id}.{step}.{hmac}`) between calls. State is
 /// server-side; the token is just a signed reference with anti-replay.
+///
+/// ## Cursor invariants (Risk 4 in the design)
+///
+/// Two cursors compose a single position:
+///
+/// - `current_index` — which bloom we're on in `bloom_ids`. `0..=bloom_ids.len()`.
+/// - `current_chunk_index` — which chunk within the current bloom. Always
+///   advances to 0 when `current_index` advances. `0..=chunk_plan.total` for
+///   the current bloom's plan.
+///
+/// `step` is the monotonic count of chunks walked. It is independent of
+/// `current_index` / `current_chunk_index` — the latter can drift if bloom
+/// content changes mid-ritual and re-chunks, but `step` always increments by
+/// exactly 1 per chunk advance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WakeSession {
     pub session_id: String,
     pub bloom_ids: Vec<String>,
+    /// Which bloom we're on. 0-indexed; equals `bloom_ids.len()` when the
+    /// ritual is complete.
     pub current_index: usize,
+    /// Which chunk within the current bloom we're on. Resets to 0 when
+    /// `current_index` advances. For non-chunked blooms this stays 0.
+    pub current_chunk_index: u8,
+    /// Monotonic step counter used for token anti-replay. Ticks by 1 on every
+    /// chunk advance (remembered / helped / skipped). Survives bloom
+    /// re-chunking mid-ritual.
+    pub step: u32,
     pub attempts_on_current: u8,
     pub remembered_count: u32,
     pub needed_help_count: u32,
     pub skipped_count: u32,
     pub created_at: i64,
-    /// Selected phrase indices for each bloom (None if bloom has no phrases)
-    pub selected_phrase_indices: Vec<Option<usize>>,
+    /// Per-bloom metadata (1:1 with `bloom_ids`). Replaces the old
+    /// `selected_phrase_indices` representation — we no longer pre-select a
+    /// random phrase, because chunks walk through authored phrases in index
+    /// order and auto-derive beyond that.
+    pub bloom_chunk_meta: Vec<BloomChunkMeta>,
 }
 
 impl WakeSession {
-    /// Create new session from cascade
+    /// Create new session from cascade. Computes per-bloom phrase counts up
+    /// front so the `phrase_for_chunk` selector has deterministic metadata
+    /// to consult, but does NOT pre-compute chunk plans — those are
+    /// re-derived from fresh content on every `respond`/`skip` call.
     pub fn new(cascade: &WakeCascade) -> Self {
-        use rand::Rng;
-
         let mut bloom_ids = Vec::new();
-        let mut selected_phrase_indices = Vec::new();
+        let mut bloom_chunk_meta = Vec::new();
 
-        // Collect blooms and select phrase indices
         for entry in cascade
             .core
             .iter()
@@ -93,27 +136,25 @@ impl WakeSession {
         {
             bloom_ids.push(entry.id.clone());
 
-            // Select random phrase index if bloom has phrases
-            let phrase_idx = if !entry.wake_phrases.is_empty() {
-                Some(rand::rng().random_range(0..entry.wake_phrases.len()))
-            } else if entry.wake_phrase.is_some() {
-                Some(0) // Single wake_phrase maps to index 0
-            } else {
-                None // No phrases
-            };
-            selected_phrase_indices.push(phrase_idx);
+            let authored_phrase_count = authored_phrase_count(entry);
+            bloom_chunk_meta.push(BloomChunkMeta {
+                authored_phrase_count,
+                is_phraseless: authored_phrase_count == 0,
+            });
         }
 
         Self {
             session_id: uuid::Uuid::new_v4().to_string(),
             bloom_ids,
             current_index: 0,
+            current_chunk_index: 0,
+            step: 0,
             attempts_on_current: 0,
             remembered_count: 0,
             needed_help_count: 0,
             skipped_count: 0,
             created_at: chrono::Utc::now().timestamp(),
-            selected_phrase_indices,
+            bloom_chunk_meta,
         }
     }
 
@@ -122,20 +163,18 @@ impl WakeSession {
         self.bloom_ids.get(self.current_index).map(|s| s.as_str())
     }
 
-    /// Get selected phrase index for current bloom
-    pub fn current_phrase_index(&self) -> Option<usize> {
-        self.selected_phrase_indices
-            .get(self.current_index)
-            .and_then(|&idx| idx)
+    /// Per-bloom chunk metadata for the current bloom, if any.
+    pub fn current_meta(&self) -> Option<&BloomChunkMeta> {
+        self.bloom_chunk_meta.get(self.current_index)
     }
 
     /// Total blooms in session
-    pub fn total(&self) -> usize {
+    pub fn total_blooms(&self) -> usize {
         self.bloom_ids.len()
     }
 
-    /// Current position (1-indexed for display)
-    pub fn current_position(&self) -> usize {
+    /// Current bloom position (1-indexed for display)
+    pub fn current_bloom_position(&self) -> usize {
         self.current_index + 1
     }
 
@@ -144,25 +183,80 @@ impl WakeSession {
         self.current_index >= self.bloom_ids.len()
     }
 
-    /// Advance to next bloom (remembered)
-    pub fn advance_remembered(&mut self) {
+    /// Advance past the current chunk. If there are more chunks in this
+    /// bloom (per `bloom_total_chunks`), tick `current_chunk_index`; otherwise
+    /// advance to the next bloom and reset chunk cursor. Always ticks `step`.
+    ///
+    /// Assertion-heavy by design (Risk 4): off-by-one bugs here will serve
+    /// wrong content or stick the ritual.
+    pub fn advance_remembered(&mut self, bloom_total_chunks: u8) {
+        debug_assert!(!self.is_complete(), "advance called on completed session");
+        debug_assert!(
+            (self.current_chunk_index as usize) < bloom_total_chunks.max(1) as usize,
+            "current_chunk_index {} >= bloom_total_chunks {}",
+            self.current_chunk_index,
+            bloom_total_chunks
+        );
         self.remembered_count += 1;
-        self.current_index += 1;
-        self.attempts_on_current = 0;
+        self.step = self.step.saturating_add(1);
+        self.advance_chunk_or_bloom(bloom_total_chunks);
     }
 
-    /// Advance to next bloom (needed help)
-    pub fn advance_helped(&mut self) {
+    /// Advance past the current chunk (needed help path).
+    pub fn advance_helped(&mut self, bloom_total_chunks: u8) {
+        debug_assert!(!self.is_complete());
         self.needed_help_count += 1;
-        self.current_index += 1;
-        self.attempts_on_current = 0;
+        self.step = self.step.saturating_add(1);
+        self.advance_chunk_or_bloom(bloom_total_chunks);
     }
 
-    /// Advance to next bloom (skipped)
-    pub fn advance_skipped(&mut self) {
+    /// Advance past the current chunk (skipped path).
+    pub fn advance_skipped(&mut self, bloom_total_chunks: u8) {
+        debug_assert!(!self.is_complete());
         self.skipped_count += 1;
-        self.current_index += 1;
-        self.attempts_on_current = 0;
+        self.step = self.step.saturating_add(1);
+        self.advance_chunk_or_bloom(bloom_total_chunks);
+    }
+
+    /// Core cursor advance. Pure function of the two cursors + the chunk
+    /// total. Called by the three `advance_*` wrappers above.
+    fn advance_chunk_or_bloom(&mut self, bloom_total_chunks: u8) {
+        let next_chunk = self.current_chunk_index.saturating_add(1);
+        if (next_chunk as usize) < bloom_total_chunks.max(1) as usize {
+            // More chunks in this bloom.
+            self.current_chunk_index = next_chunk;
+            self.attempts_on_current = 0;
+        } else {
+            // Move to the next bloom; reset chunk cursor.
+            self.current_index += 1;
+            self.current_chunk_index = 0;
+            self.attempts_on_current = 0;
+        }
+        debug_assert!(
+            self.current_index <= self.bloom_ids.len(),
+            "current_index {} overshot bloom_ids.len() {}",
+            self.current_index,
+            self.bloom_ids.len()
+        );
+    }
+
+    /// Handle the "content shrank mid-ritual past the cursor" case (§2.2): if
+    /// the recomputed chunk plan has fewer chunks than `current_chunk_index`,
+    /// we clamp and advance to the next bloom. Flagged as `chunk_truncated`
+    /// in the response for observability.
+    ///
+    /// Returns `true` if clamping occurred (caller should set the
+    /// `chunk_truncated` response field).
+    pub fn clamp_if_chunks_shrank(&mut self, bloom_total_chunks: u8) -> bool {
+        let total = bloom_total_chunks.max(1) as usize;
+        if (self.current_chunk_index as usize) >= total {
+            self.current_index += 1;
+            self.current_chunk_index = 0;
+            self.attempts_on_current = 0;
+            true
+        } else {
+            false
+        }
     }
 
     /// Increment attempt counter
@@ -171,7 +265,33 @@ impl WakeSession {
     }
 }
 
-/// JSON output structures
+/// Count of authored wake phrases on an entry (wake_phrases takes priority
+/// over the legacy single `wake_phrase`).
+pub fn authored_phrase_count(entry: &KnowledgeEntry) -> u8 {
+    if !entry.wake_phrases.is_empty() {
+        u8::try_from(entry.wake_phrases.len()).unwrap_or(u8::MAX)
+    } else if entry.wake_phrase.is_some() {
+        1
+    } else {
+        0
+    }
+}
+
+/// The authored phrase at the given index, if it exists. Consolidates the
+/// `wake_phrases[idx]` vs legacy `wake_phrase` lookup.
+pub fn authored_phrase_at(entry: &KnowledgeEntry, idx: usize) -> Option<String> {
+    if !entry.wake_phrases.is_empty() {
+        entry.wake_phrases.get(idx).cloned()
+    } else if idx == 0 {
+        entry.wake_phrase.clone()
+    } else {
+        None
+    }
+}
+
+// ============================================================================
+// JSON output structures — strictly additive vs the previous contract
+// ============================================================================
 
 #[derive(Debug, Serialize)]
 pub struct WakeBeginResponse {
@@ -201,6 +321,11 @@ pub struct WakeRespondResponse {
     pub progress: Option<Progress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<Summary>,
+    /// Set to true when a mid-ritual content edit re-derived an auto-derived
+    /// phrase such that the consumer's typed response no longer matches.
+    /// Legible error diagnostic per Risk 9 (§5.5 of the design).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_changed_during_ritual: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -233,6 +358,24 @@ pub struct BloomPrompt {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resonance_type: Option<String>,
     pub wake_phrase_count: usize,
+    /// Present only for chunked blooms. `{index: 1-based, total}`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk: Option<ChunkRef>,
+    /// `"authored"` | `"derived"` — advisory field so consumers can surface
+    /// that a phrase was sampled from chunk content rather than authored by
+    /// the bloom owner. Absent for non-chunked or phraseless blooms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phrase_source: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ChunkRef {
+    pub index: u8,
+    pub total: u8,
+    /// Present and `true` when the chunk exceeds the chunking threshold
+    /// (typically an un-splittable code block). Documented limitation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oversized: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -244,12 +387,26 @@ pub struct BloomFull {
     pub resonance_type: Option<String>,
     pub all_phrases: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub matched_phrase: Option<String>, // Which phrase was matched/selected
+    pub matched_phrase: Option<String>,
+    /// Chunk metadata for the chunk being returned, if the bloom was chunked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk: Option<ChunkRef>,
+    /// `"authored"` | `"derived"` — which phrase type unlocked this chunk.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phrase_source: Option<String>,
+    /// `true` if the session's chunk cursor was clamped forward because the
+    /// bloom shrank past it mid-ritual. Observability for §2.2.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_truncated: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct Progress {
+    /// 1-indexed count of chunks walked into. Counts chunks, not blooms
+    /// (the unit of progression in the new flow).
     pub current: usize,
+    /// Total chunks across the whole cascade (eager at begin; may drift by
+    /// ≤10% if mid-ritual edits change bloom sizes — see §7.1).
     pub total: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remembered: Option<u32>,
@@ -257,6 +414,13 @@ pub struct Progress {
     pub needed_help: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub skipped: Option<u32>,
+    /// 1-indexed bloom counter. Consumers that prefer the old "X of N blooms"
+    /// UX can render this instead of `current`/`total`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bloom_current: Option<usize>,
+    /// Total blooms in the cascade. Stable across the ritual.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bloom_total: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -265,18 +429,31 @@ pub struct Summary {
     pub remembered: u32,
     pub needed_help: u32,
     pub skipped: u32,
+    /// Per-bloom roll-up (chunks remembered/helped/skipped grouped by bloom).
+    /// Populated in PR 3; kept here as an optional field for PR 2 so the
+    /// payload shape doesn't change again between PRs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blooms_complete: Option<Vec<BloomRollup>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunks_remembered: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunks_skipped: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunks_needed_help: Option<u32>,
 }
 
-/// Convert KnowledgeEntry to BloomPrompt
+#[derive(Debug, Serialize)]
+pub struct BloomRollup {
+    pub id: String,
+    pub title: String,
+    pub chunks: String,
+}
+
+/// Convert KnowledgeEntry to BloomPrompt (non-chunked form — PR 2 wires a
+/// chunk-aware builder in the ritual module).
 impl From<&KnowledgeEntry> for BloomPrompt {
     fn from(entry: &KnowledgeEntry) -> Self {
-        let phrase_count = if !entry.wake_phrases.is_empty() {
-            entry.wake_phrases.len()
-        } else if entry.wake_phrase.is_some() {
-            1
-        } else {
-            0
-        };
+        let phrase_count = authored_phrase_count(entry) as usize;
 
         Self {
             id: entry.id.clone(),
@@ -284,11 +461,14 @@ impl From<&KnowledgeEntry> for BloomPrompt {
             resonance: entry.resonance,
             resonance_type: entry.resonance_type.clone(),
             wake_phrase_count: phrase_count,
+            chunk: None,
+            phrase_source: None,
         }
     }
 }
 
-/// Convert KnowledgeEntry to BloomFull
+/// Convert KnowledgeEntry to BloomFull (non-chunked form — PR 2 wires a
+/// chunk-aware builder in the ritual module).
 impl From<&KnowledgeEntry> for BloomFull {
     fn from(entry: &KnowledgeEntry) -> Self {
         let content = entry
@@ -297,7 +477,6 @@ impl From<&KnowledgeEntry> for BloomFull {
             .or_else(|| entry.summary.clone())
             .unwrap_or_else(|| "(no content)".to_string());
 
-        // Collect all phrases (wake_phrases array takes priority)
         let all_phrases = if !entry.wake_phrases.is_empty() {
             entry.wake_phrases.clone()
         } else if let Some(ref phrase) = entry.wake_phrase {
@@ -312,7 +491,10 @@ impl From<&KnowledgeEntry> for BloomFull {
             resonance: entry.resonance,
             resonance_type: entry.resonance_type.clone(),
             all_phrases,
-            matched_phrase: None, // Not set by default, populated during ritual
+            matched_phrase: None,
+            chunk: None,
+            phrase_source: None,
+            chunk_truncated: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

**This is the PR that fixes the 30KB Bash wall.** Wires the PR 1 machinery into the wake ritual flow with authored-then-sampled phrase derivation, two-cursor session state, and pure-runtime chunk projection (re-derived on every `respond`/`skip` call).

Stacked on #212. Merge #212 first, then rebase this onto `main`.

## Behavior change

When a bloom's content exceeds the chunking threshold (default 28KB), the ritual now returns **chunk content** — not whole-bloom content — in the `respond`/`skip` responses. Title is decorated with `(Part N/M)` server-side so existing CLIs that display title surface chunk position for free.

All new fields are `Option<T>` with `#[serde(skip_serializing_if = \"Option::is_none\")]`. Non-chunked blooms serialize identically to today — old consumers are backward compatible.

## Wire-format diff

**Before (any bloom):**
```json
{
  \"status\": \"remembered\",
  \"bloom\": {
    \"title\": \"Ops\",
    \"content\": \"<69KB of content>\",
    \"all_phrases\": [\"alpha\", \"beta\", \"gamma\"]
  },
  \"session\": \"uuid.0.hmac\",
  \"progress\": { \"current\": 1, \"total\": 12 }
}
```

**After (chunked bloom):**
```json
{
  \"status\": \"remembered\",
  \"bloom\": {
    \"title\": \"Ops (Part 1/3)\",
    \"content\": \"<~28KB chunk 1 content>\",
    \"all_phrases\": [\"alpha\", \"beta\", \"gamma\"],
    \"matched_phrase\": \"alpha\",
    \"chunk\": { \"index\": 1, \"total\": 3 },
    \"phrase_source\": \"authored\"
  },
  \"session\": \"uuid.1.hmac\",
  \"progress\": {
    \"current\": 2,
    \"total\": 14,
    \"bloom_current\": 1,
    \"bloom_total\": 12,
    \"remembered\": 1
  },
  \"next\": {
    \"id\": \"kn-ops\",
    \"title\": \"Ops (Part 2/3)\",
    \"chunk\": { \"index\": 2, \"total\": 3 },
    \"phrase_source\": \"authored\"
  }
}
```

Chunks beyond the authored phrase count surface `\"phrase_source\": \"derived\"`. P==0 blooms use the skip flow (no phrase). `chunk_truncated: true` appears when a bloom shrank mid-ritual past the cursor (§2.2 edge case).

## Session model (two-cursor + monotonic step)

- `current_index`: which bloom (0-indexed, `== bloom_ids.len()` when complete).
- `current_chunk_index`: which chunk within the current bloom (resets to 0 on bloom advance).
- `step`: monotonic counter of chunks walked. Token is signed as `{session_id}.{step}.{hmac16}` — **wire format unchanged**, middle segment still parses as an integer, but now it's a step counter so tokens survive mid-ritual bloom re-chunking.

The three `advance_*` methods take `bloom_total_chunks` so the cursor logic is pure. `debug_assert!` calls guard off-by-one errors at every transition (Risk 4).

## Phrase selection

```
phrase_for_chunk(entry, chunk_idx, total, chunk_content):
  if authored_phrase_count == 0:            # P==0 conservative default
    return None                              # → skip-type, every chunk
  if chunk_idx < authored_phrase_count:
    return (authored[chunk_idx], Authored)
  else:
    return (extract_salient_phrase(chunk_content, ...), Derived)
```

Compare path:

1. `compare_phrase(input, target, mode)` — exact for authored, tolerant (lowercase / trailing-punct / whitespace / smart-quote) for derived.
2. On `Mismatch`, fall through to `engage::fuzzy_match` so the existing Close / Partial / Wrong hint tiers keep working.

## Schema migration

`schema/surrealdb-schema.surql` adds three fields via `DEFINE FIELD IF NOT EXISTS`:

- `current_chunk_index: int DEFAULT 0`
- `step: int DEFAULT 0`
- `bloom_chunk_meta: FLEXIBLE array<object> DEFAULT []`

Legacy `selected_phrase_indices` kept with `DEFAULT []` for backward read compat; no longer written.

**Deploy semantics:** in-flight sessions during a deploy will fail on next `respond` because they lack the new fields in their persisted state. Wake rituals are ephemeral (minutes); user restarts with `--begin`. Documented acceptable trade-off (§10 Risk 7).

## Tests

60 wake-suite tests passing (34 from PR 1 + 13 new in this PR + 11 hint regressions + 2 cascade tests):

- **phrase_for_chunk** — authored within / derived beyond / phraseless / legacy single phrase.
- **WakeSession state machine** — cursor init, within-bloom chunk advance, roll-over to next bloom, step monotonicity across mixed (remembered/helped/skipped) advances, non-chunked bloom immediate advance, clamp-on-shrink, clamp noop.
- **Bloom metadata** — phraseless detection, authored phrase count.
- **Large-bloom walkthrough** — 69KB / 85KB / 110KB synthetic Ops fixtures split into multiple chunks, authored-then-derived phrase sequence surfaces correct sources, full walk advances through every chunk ticking step correctly, derived phrase tolerance accepts case+punct drift.

Full suite: 315 passing, 1 pre-existing unrelated failure (`surreal_db::tests::test_open_with_path` — fails on `main` too).

## Design deltas from Schemnya's doc

- **Content-changed diagnostic (Risk 9)** simplified: the design suggested checking `bloom.updated_at > session.created_at` before flagging, but `KnowledgeEntry.updated_at` is `Option<String>` (RFC3339) and requires parsing. Current implementation unconditionally flags `content_changed_during_ritual: true` on a Derived-phrase mismatch — best-effort advisory, no parsing. Future enhancement can tighten this when the timestamp surface is formalized.
- **No full DB-backed integration test.** `KnowledgeStore` is a ~20-method trait and a proper mock would bloat the PR without covering more than the state-machine tests already do. State-machine correctness is covered; real-DB validation comes from dogfooding PR 2 in production rituals.
- **Eager `total_steps`**: recomputed on every `respond`/`skip` (cheap — O(N * content_len)) instead of computed-once-and-persisted. Keeps the total fresh if bloom content changes mid-ritual. Matches §7.1 spirit; simpler than the persisted `total_steps_estimate` / `total_steps_final` split the doc suggested.

## Test plan

- [ ] `cargo test --bin mx wake` passes (60/60)
- [ ] `cargo build` clean
- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy --tests -- -D warnings` clean
- [ ] Rebase onto `main` after #212 merges
- [ ] Dogfood against a real 69KB Ops bloom before merge

## Follow-ups for PR 3 (polish)

- `summary.blooms_complete` per-bloom roll-up population.
- Authored-vs-derived counters per bloom in summary for observability.
- Docs/README updates if the wake flow is publicly documented.