### PR TITLE
auto-generate phrases for phraseless chunks (#218)

### DIFF
--- a/src/wake_chunk.rs
+++ b/src/wake_chunk.rs
@@ -726,16 +726,12 @@ fn extract_sentences(content: &str) -> Vec<String> {
 
         // Check for `. ` sentence boundaries within the accumulated text.
         // Split greedily on `. ` — each fragment before the last is a sentence.
-        loop {
-            if let Some(pos) = current.find(". ") {
-                let sentence = current[..=pos].trim().to_string(); // include the period
-                if !sentence.is_empty() {
-                    sentences.push(sentence);
-                }
-                current = current[pos + 2..].to_string();
-            } else {
-                break;
+        while let Some(pos) = current.find(". ") {
+            let sentence = current[..=pos].trim().to_string(); // include the period
+            if !sentence.is_empty() {
+                sentences.push(sentence);
             }
+            current = current[pos + 2..].to_string();
         }
     }
 

--- a/src/wake_chunk.rs
+++ b/src/wake_chunk.rs
@@ -507,11 +507,22 @@ fn first_sentence(content: &str) -> Option<String> {
 }
 
 fn first_non_empty_line(content: &str) -> Option<String> {
-    content
-        .lines()
-        .map(|l| l.trim())
-        .find(|l| !l.is_empty())
-        .map(|l| l.to_string())
+    let mut in_fence = false;
+    for line in content.lines() {
+        let trimmed_start = line.trim_start();
+        if trimmed_start.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
 }
 
 fn synthetic_phrase(content: &str, chunk_idx: u16, total: u16) -> String {
@@ -718,11 +729,20 @@ fn extract_sentences(content: &str) -> Vec<String> {
             continue;
         }
 
+        // Strip markdown list-item prefixes so warmth-brick lines like
+        // "- kautau noticed the pattern" don't keep the `- ` artifact.
+        let mut cleaned = line.trim();
+        if let Some(rest) = cleaned.strip_prefix("- ") {
+            cleaned = rest;
+        } else if let Some(rest) = cleaned.strip_prefix("* ") {
+            cleaned = rest;
+        }
+
         // Append line to current accumulator, separated by space.
         if !current.is_empty() {
             current.push(' ');
         }
-        current.push_str(line.trim());
+        current.push_str(cleaned);
 
         // Check for `. ` sentence boundaries within the accumulated text.
         // Split greedily on `. ` — each fragment before the last is a sentence.
@@ -1511,5 +1531,83 @@ mod tests {
             idx1, idx2,
             "different content should usually select different indices"
         );
+    }
+
+    // --- first_non_empty_line fence-skip tests (Diffi review #221 fix 2) ---
+
+    #[test]
+    fn first_non_empty_line_skips_fenced_code_block() {
+        // Content that starts with a fenced code block — the first non-empty
+        // line outside the fence should be returned, not "```rust".
+        let content = "```rust\nfn main() {}\n```\n\nActual first line.";
+        let line = first_non_empty_line(content);
+        assert_eq!(
+            line.as_deref(),
+            Some("Actual first line."),
+            "should skip fenced code block, got {:?}",
+            line
+        );
+    }
+
+    #[test]
+    fn first_non_empty_line_all_fenced_returns_none() {
+        // If the entire content is inside a code fence, no non-empty line
+        // exists outside of it.
+        let content = "```\nonly code here\nmore code\n```";
+        let line = first_non_empty_line(content);
+        assert_eq!(line, None, "all-fenced content should return None");
+    }
+
+    #[test]
+    fn first_non_empty_line_between_fences() {
+        let content = "```\ncode\n```\n\nSandwiched line\n\n```\nmore code\n```";
+        let line = first_non_empty_line(content);
+        assert_eq!(line.as_deref(), Some("Sandwiched line"));
+    }
+
+    // --- extract_sentences list-item stripping tests (Diffi review #221 fix 5) ---
+
+    #[test]
+    fn extract_sentences_strips_dash_list_prefix() {
+        let content = "- first brick line\n- second brick line";
+        let sentences = extract_sentences(content);
+        for s in &sentences {
+            assert!(
+                !s.starts_with("- "),
+                "sentence should not keep `- ` prefix: {:?}",
+                s
+            );
+        }
+        // The two lines join into one sentence (no paragraph break or `. `).
+        assert!(!sentences.is_empty());
+        assert!(
+            sentences[0].contains("first brick line"),
+            "expected content without prefix, got {:?}",
+            sentences
+        );
+    }
+
+    #[test]
+    fn extract_sentences_strips_star_list_prefix() {
+        let content = "* item alpha\n* item beta";
+        let sentences = extract_sentences(content);
+        for s in &sentences {
+            assert!(
+                !s.starts_with("* "),
+                "sentence should not keep `* ` prefix: {:?}",
+                s
+            );
+        }
+        assert!(!sentences.is_empty());
+        assert!(sentences[0].contains("item alpha"));
+    }
+
+    #[test]
+    fn extract_sentences_list_items_with_paragraph_breaks() {
+        let content = "- first item\n\n- second item";
+        let sentences = extract_sentences(content);
+        assert_eq!(sentences.len(), 2);
+        assert_eq!(sentences[0], "first item");
+        assert_eq!(sentences[1], "second item");
     }
 }

--- a/src/wake_chunk.rs
+++ b/src/wake_chunk.rs
@@ -640,6 +640,125 @@ pub fn normalize_derived(s: &str) -> String {
 }
 
 // ============================================================================
+// extract_auto_phrase — four-tier cascade for phraseless blooms (mx#218)
+// ============================================================================
+
+/// Extract a wake phrase from content for a chunk that has neither authored
+/// nor derived phrases. This is the mx#218 auto-phrase: ensures every chunk
+/// in every bloom has a phrase so the 3-attempt + reveal engagement flow
+/// applies universally — no bloom can be `--skip`'d without engagement.
+///
+/// Four-tier cascade:
+///
+/// 1. **First markdown heading** (outside fenced code blocks).
+/// 2. **Content-hash-seeded sentence selection** — deterministic but varies
+///    across blooms (same content = same phrase, different content = different
+///    sentence selected).
+/// 3. **First non-empty line** truncated to ~80 chars.
+/// 4. **Title fallback** — bloom title as the phrase (guaranteed non-empty).
+///
+/// The function is total: non-empty `title` → non-empty output, always.
+pub fn extract_auto_phrase(content: &str, title: &str) -> String {
+    // Tier 1: first markdown heading outside fenced code blocks.
+    if let Some(heading) = first_heading(content) {
+        return cap_chars(heading.trim(), PHRASE_MAX_CHARS);
+    }
+
+    // Tier 2: content-hash-seeded sentence selection.
+    let sentences = extract_sentences(content);
+    if !sentences.is_empty() {
+        let refs: Vec<&str> = sentences.iter().map(|s| s.as_str()).collect();
+        let idx = select_sentence_index(&refs, content);
+        let s = sentences[idx].trim();
+        if !s.is_empty() {
+            return cap_chars(s, SENTENCE_MAX_CHARS);
+        }
+    }
+
+    // Tier 3: first non-empty line truncated.
+    if let Some(line) = first_non_empty_line(content) {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            return cap_chars(trimmed, LINE_FALLBACK_MAX_CHARS);
+        }
+    }
+
+    // Tier 4: title fallback (guaranteed non-empty by caller contract).
+    cap_chars(title.trim(), PHRASE_MAX_CHARS)
+}
+
+/// Split content into sentences. A sentence boundary is:
+/// - `. ` followed by an uppercase letter or end-of-content
+/// - `\n\n` (paragraph break)
+///
+/// Returns non-empty trimmed sentences. Skips content inside fenced code
+/// blocks to avoid picking code comments as sentences.
+fn extract_sentences(content: &str) -> Vec<String> {
+    let mut sentences = Vec::new();
+    let mut current = String::new();
+    let mut in_fence = false;
+
+    for line in content.lines() {
+        let trimmed_start = line.trim_start();
+        if trimmed_start.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        if line.trim().is_empty() {
+            // Paragraph break — flush current sentence.
+            let trimmed = current.trim().to_string();
+            if !trimmed.is_empty() {
+                sentences.push(trimmed);
+            }
+            current.clear();
+            continue;
+        }
+
+        // Append line to current accumulator, separated by space.
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(line.trim());
+
+        // Check for `. ` sentence boundaries within the accumulated text.
+        // Split greedily on `. ` — each fragment before the last is a sentence.
+        loop {
+            if let Some(pos) = current.find(". ") {
+                let sentence = current[..=pos].trim().to_string(); // include the period
+                if !sentence.is_empty() {
+                    sentences.push(sentence);
+                }
+                current = current[pos + 2..].to_string();
+            } else {
+                break;
+            }
+        }
+    }
+
+    // Flush remaining.
+    let trimmed = current.trim().to_string();
+    if !trimmed.is_empty() {
+        sentences.push(trimmed);
+    }
+
+    sentences
+}
+
+/// Deterministic sentence index selection based on content hash. Same
+/// content always selects the same sentence, but different blooms select
+/// different sentences — prevents memorization of "always first sentence."
+fn select_sentence_index(sentences: &[&str], content: &str) -> usize {
+    let seed: u64 = content
+        .bytes()
+        .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
+    seed as usize % sentences.len()
+}
+
+// ============================================================================
 // Tests — unit, property, cascade, tolerance
 // ============================================================================
 
@@ -1234,5 +1353,157 @@ mod tests {
                 PhraseMatch::Exact
             );
         }
+    }
+
+    // --- extract_auto_phrase unit tests (mx#218) ---------------------------------
+
+    #[test]
+    fn auto_phrase_from_heading() {
+        let content = "Some intro text.\n\n## The Spark\n\nBody text here.";
+        let p = extract_auto_phrase(content, "Fallback Title");
+        assert_eq!(p, "The Spark");
+    }
+
+    #[test]
+    fn auto_phrase_from_sentence() {
+        // No heading — should fall through to sentence selection.
+        let content = "The warmth accumulator stores relational bricks. Each brick records a moment of connection.";
+        let p = extract_auto_phrase(content, "Warmth Accumulator");
+        // Must be one of the two sentences, deterministically selected.
+        assert!(
+            p.contains("warmth accumulator") || p.contains("brick records"),
+            "expected a sentence from the content, got {:?}",
+            p
+        );
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn auto_phrase_from_line() {
+        // No headings, no sentence terminators — falls to first non-empty line.
+        let content = "- brick one: kautau noticed the pattern\n- brick two: something else";
+        let p = extract_auto_phrase(content, "Fallback");
+        assert!(
+            p.contains("brick one"),
+            "expected first line as phrase, got {:?}",
+            p
+        );
+    }
+
+    #[test]
+    fn auto_phrase_from_title_fallback() {
+        // Empty content — must fall back to title.
+        let p = extract_auto_phrase("", "Warmth Accumulator");
+        assert_eq!(p, "Warmth Accumulator");
+    }
+
+    #[test]
+    fn auto_phrase_never_empty() {
+        // Non-empty title always produces a non-empty phrase.
+        let cases = ["", " ", "\n", "\n\n", "\t\t"];
+        for c in cases {
+            let p = extract_auto_phrase(c, "Title");
+            assert!(!p.is_empty(), "empty auto-phrase for content {:?}", c);
+        }
+    }
+
+    #[test]
+    fn auto_phrase_deterministic() {
+        let content = "Some paragraph with multiple sentences. Another one here. And a third.";
+        let a = extract_auto_phrase(content, "Title");
+        let b = extract_auto_phrase(content, "Title");
+        assert_eq!(a, b, "auto-phrase must be deterministic");
+    }
+
+    #[test]
+    fn auto_phrase_skips_fenced_headings() {
+        // Heading inside a code block must not be selected.
+        let content = "```markdown\n## Fake Heading\n```\n\nReal first sentence here.";
+        let p = extract_auto_phrase(content, "Title");
+        assert!(
+            !p.contains("Fake Heading"),
+            "auto-phrase picked heading inside fenced block: {:?}",
+            p
+        );
+    }
+
+    #[test]
+    fn auto_phrase_warmth_bricks() {
+        // A list of `- ` prefixed bricks with no heading or sentence boundaries.
+        let content = "- kautau noticed the pattern and said so\n- Q remembered the first wake\n- Semvii brought coffee";
+        let p = extract_auto_phrase(content, "Warmth Accumulator");
+        // Should pick a brick line (first non-empty line tier or sentence tier).
+        assert!(
+            p.contains("kautau") || p.contains("Q remembered") || p.contains("Semvii"),
+            "expected a brick line, got {:?}",
+            p
+        );
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn auto_phrase_content_hash_varies_across_blooms() {
+        // Different content should (usually) select different sentences.
+        // Not a hard guarantee (hash collisions exist) but for these two
+        // distinct inputs the seed should differ.
+        let content_a = "First sentence here. Second sentence here. Third sentence here.";
+        let content_b = "Alpha sentence here. Beta sentence here. Gamma sentence here.";
+        let p_a = extract_auto_phrase(content_a, "A");
+        let p_b = extract_auto_phrase(content_b, "B");
+        // They CAN be the same index by coincidence, but the phrases themselves
+        // will differ because the content differs.
+        assert_ne!(p_a, p_b, "different content should produce different phrases");
+    }
+
+    // --- extract_sentences unit tests ---
+
+    #[test]
+    fn extract_sentences_basic() {
+        let content = "First sentence. Second sentence. Third.";
+        let sentences = extract_sentences(content);
+        assert!(sentences.len() >= 2, "expected >=2 sentences, got {:?}", sentences);
+        assert!(sentences[0].contains("First sentence."));
+    }
+
+    #[test]
+    fn extract_sentences_paragraph_break() {
+        let content = "Paragraph one\n\nParagraph two";
+        let sentences = extract_sentences(content);
+        assert_eq!(sentences.len(), 2);
+        assert_eq!(sentences[0], "Paragraph one");
+        assert_eq!(sentences[1], "Paragraph two");
+    }
+
+    #[test]
+    fn extract_sentences_skips_fenced_blocks() {
+        let content = "Real sentence.\n\n```\nFake sentence inside code.\n```\n\nAnother real one.";
+        let sentences = extract_sentences(content);
+        for s in &sentences {
+            assert!(
+                !s.contains("Fake sentence"),
+                "sentence extractor should skip fenced blocks, got {:?}",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn select_sentence_index_deterministic() {
+        let sentences = vec!["a", "b", "c", "d", "e"];
+        let content = "some content for hashing";
+        let idx1 = select_sentence_index(&sentences, content);
+        let idx2 = select_sentence_index(&sentences, content);
+        assert_eq!(idx1, idx2);
+        assert!(idx1 < sentences.len());
+    }
+
+    #[test]
+    fn select_sentence_index_varies_with_content() {
+        let sentences = vec!["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+        let idx1 = select_sentence_index(&sentences, "content alpha");
+        let idx2 = select_sentence_index(&sentences, "content beta");
+        // With 10 choices and different seeds, these should differ.
+        // Not a hard guarantee but very likely with this hash function.
+        assert_ne!(idx1, idx2, "different content should usually select different indices");
     }
 }

--- a/src/wake_chunk.rs
+++ b/src/wake_chunk.rs
@@ -1452,7 +1452,10 @@ mod tests {
         let p_b = extract_auto_phrase(content_b, "B");
         // They CAN be the same index by coincidence, but the phrases themselves
         // will differ because the content differs.
-        assert_ne!(p_a, p_b, "different content should produce different phrases");
+        assert_ne!(
+            p_a, p_b,
+            "different content should produce different phrases"
+        );
     }
 
     // --- extract_sentences unit tests ---
@@ -1461,7 +1464,11 @@ mod tests {
     fn extract_sentences_basic() {
         let content = "First sentence. Second sentence. Third.";
         let sentences = extract_sentences(content);
-        assert!(sentences.len() >= 2, "expected >=2 sentences, got {:?}", sentences);
+        assert!(
+            sentences.len() >= 2,
+            "expected >=2 sentences, got {:?}",
+            sentences
+        );
         assert!(sentences[0].contains("First sentence."));
     }
 
@@ -1504,6 +1511,9 @@ mod tests {
         let idx2 = select_sentence_index(&sentences, "content beta");
         // With 10 choices and different seeds, these should differ.
         // Not a hard guarantee but very likely with this hash function.
-        assert_ne!(idx1, idx2, "different content should usually select different indices");
+        assert_ne!(
+            idx1, idx2,
+            "different content should usually select different indices"
+        );
     }
 }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -6,16 +6,21 @@ use crate::knowledge::KnowledgeEntry;
 use crate::store::{AgentContext, KnowledgeStore, WakeCascade};
 use crate::wake_chunk::{
     ChunkPlan, PhraseMatch, PhraseMode, chunk_threshold, compare_phrase, compute_chunks,
-    extract_salient_phrase,
+    extract_auto_phrase, extract_salient_phrase,
 };
 use crate::wake_token::*;
 
-/// Which phrase source unlocked a chunk — authored by the bloom owner, or
-/// auto-derived from the chunk's own content (§5 of the mx#211 design).
+/// Which phrase source unlocked a chunk — authored by the bloom owner,
+/// auto-derived from the chunk's own content (§5 of the mx#211 design),
+/// or auto-generated for a phraseless bloom (mx#218).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PhraseSource {
     Authored,
     Derived,
+    /// Auto-generated phrase for a chunk that has neither authored nor derived
+    /// phrases. Extracted from the chunk's content via `extract_auto_phrase`
+    /// (mx#218). Uses the same tolerant matching as Derived phrases.
+    Auto,
 }
 
 impl PhraseSource {
@@ -23,13 +28,16 @@ impl PhraseSource {
         match self {
             PhraseSource::Authored => "authored",
             PhraseSource::Derived => "derived",
+            PhraseSource::Auto => "auto",
         }
     }
 
     fn mode(self) -> PhraseMode {
         match self {
             PhraseSource::Authored => PhraseMode::Authored,
-            PhraseSource::Derived => PhraseMode::Derived,
+            // Auto phrases use the same tolerant comparison as derived —
+            // case-insensitive, trailing punct stripped, whitespace collapsed.
+            PhraseSource::Derived | PhraseSource::Auto => PhraseMode::Derived,
         }
     }
 
@@ -40,6 +48,7 @@ impl PhraseSource {
         match self {
             PhraseSource::Authored => PhraseSourceTag::Authored,
             PhraseSource::Derived => PhraseSourceTag::Derived,
+            PhraseSource::Auto => PhraseSourceTag::Auto,
         }
     }
 }
@@ -48,13 +57,15 @@ impl PhraseSource {
 /// win when available at the given index; beyond the authored count we
 /// auto-derive from the chunk's own content (§5.2).
 ///
-/// **P==0 semantics:** for blooms with zero authored phrases we return `None`
-/// — those blooms stay skip-type across every chunk (conservative default
-/// per the P==0 decision). Never auto-derive for phraseless blooms.
+/// **P==0 semantics (mx#218):** for blooms with zero authored phrases we
+/// auto-generate a phrase from the chunk's content via `extract_auto_phrase`.
+/// This ensures every chunk in every bloom has a phrase — the 3-attempt +
+/// reveal engagement flow applies universally. No bloom can be `--skip`'d
+/// without engagement.
 ///
 /// Returns `(phrase, source)`. `source` drives the comparison tolerance:
-/// authored phrases get exact-compare (Authored mode) while derived phrases
-/// get softened comparisons (Derived mode).
+/// authored phrases get exact-compare (Authored mode) while derived and
+/// auto phrases get softened comparisons (Derived mode).
 fn phrase_for_chunk(
     entry: &KnowledgeEntry,
     chunk_idx: u16,
@@ -63,8 +74,11 @@ fn phrase_for_chunk(
 ) -> Option<(String, PhraseSource)> {
     let authored_count = authored_phrase_count(entry);
     if authored_count == 0 {
-        // P==0 conservative default — skip-type across all chunks.
-        return None;
+        // P==0: auto-generate a phrase from the chunk's content (mx#218).
+        // Uses `extract_auto_phrase` which has a title fallback tier,
+        // guaranteeing a non-empty phrase even for empty content.
+        let phrase = extract_auto_phrase(chunk_content, &entry.title);
+        return Some((phrase, PhraseSource::Auto));
     }
     if chunk_idx < authored_count
         && let Some(p) = authored_phrase_at(entry, chunk_idx as usize)
@@ -122,6 +136,23 @@ fn build_prompt_for_chunk(
     content: &str,
 ) -> BloomPrompt {
     let mut prompt = BloomPrompt::from(entry);
+
+    // Determine phrase source for this chunk. After mx#218 every chunk has a
+    // phrase — authored, derived, or auto — so this always returns Some.
+    let chunk_content = if plan.total > 1 {
+        plan.chunk(content, chunk_idx)
+    } else {
+        content
+    };
+    if let Some((_, source)) = phrase_for_chunk(entry, chunk_idx, plan.total, chunk_content) {
+        prompt.phrase_source = Some(source.as_str().to_string());
+        // Auto-phrased chunks report wake_phrase_count=1 so the consumer
+        // knows a phrase exists and --respond is required (mx#218).
+        if source == PhraseSource::Auto {
+            prompt.wake_phrase_count = 1;
+        }
+    }
+
     if plan.total > 1 {
         prompt.title = format!("{} (Part {}/{})", entry.title, chunk_idx + 1, plan.total);
         prompt.chunk = Some(ChunkRef {
@@ -133,18 +164,6 @@ fn build_prompt_for_chunk(
                 None
             },
         });
-        // Indicate authored-vs-derived only when there's a phrase for the
-        // chunk. P==0 blooms skip; non-P==0 blooms expose the source.
-        let chunk_content = plan.chunk(content, chunk_idx);
-        if let Some((_, source)) = phrase_for_chunk(entry, chunk_idx, plan.total, chunk_content) {
-            prompt.phrase_source = Some(source.as_str().to_string());
-        }
-    } else {
-        // Single-chunk bloom — still surface phrase_source if applicable so
-        // consumers have a uniform signal regardless of chunking.
-        if authored_phrase_count(entry) > 0 {
-            prompt.phrase_source = Some(PhraseSource::Authored.as_str().to_string());
-        }
     }
     prompt
 }
@@ -512,22 +531,27 @@ pub fn skip_ritual(
     let plan = compute_chunks(&content, chunk_threshold());
     let chunk_truncated = session.clamp_if_chunks_shrank(plan.total);
 
-    // Gate: skip is only valid for phraseless blooms (mx#216). If the bloom
-    // has any wake phrases (authored, legacy, or derived-eligible), reject
-    // with a structured error. The consumer must use --respond instead.
-    if !chunk_truncated && authored_phrase_count(bloom) > 0 {
-        let response = WakeErrorResponse {
-            status: "error".to_string(),
-            error: "skip_requires_phraseless_bloom".to_string(),
-            message: "This chunk has a wake phrase and cannot be skipped. Attempt a guess — three incorrect attempts will reveal the content. Priming requires engagement.".to_string(),
-            expected_id: Some(expected_id),
-        };
-        return Ok(serde_json::to_string(&response)?);
+    // Gate: skip is rejected for ALL blooms that have a phrase (mx#218
+    // extends mx#216). After auto-phrase generation, every chunk has a phrase
+    // — authored, derived, or auto — so --skip is only valid when
+    // chunk_truncated (content shrank past cursor). Consumers must use
+    // --respond; 3 incorrect attempts reveal the content. Priming requires
+    // engagement.
+    if !chunk_truncated {
+        let chunk_content = plan.chunk(&content, session.current_chunk_index);
+        if phrase_for_chunk(bloom, session.current_chunk_index, plan.total, chunk_content).is_some()
+        {
+            let response = WakeErrorResponse {
+                status: "error".to_string(),
+                error: "skip_requires_phraseless_bloom".to_string(),
+                message: "This chunk has a wake phrase and cannot be skipped. Attempt a guess — three incorrect attempts will reveal the content. Priming requires engagement.".to_string(),
+                expected_id: Some(expected_id),
+            };
+            return Ok(serde_json::to_string(&response)?);
+        }
     }
 
     // Skip advances past exactly one chunk (not the whole bloom if chunked).
-    // For P==0 blooms the consumer calls --skip K times to walk through all K
-    // chunks — expected behavior per §5.9.
     let chunk_idx = session.current_chunk_index;
     session.advance_skipped(plan.total);
 
@@ -654,6 +678,7 @@ fn build_bloom_rollups(
                 total: total_outcomes,
                 authored_chunks: meta.authored_chunks,
                 derived_chunks: meta.derived_chunks,
+                auto_chunks: meta.auto_chunks,
             }
         })
         .collect()
@@ -891,10 +916,16 @@ mod tests {
     }
 
     #[test]
-    fn phrase_for_chunk_phraseless_returns_none() {
+    fn phrase_for_chunk_phraseless_returns_auto() {
+        // mx#218: P==0 blooms now get auto-generated phrases instead of None.
         let e = entry_with_phrases(vec![]);
-        assert!(phrase_for_chunk(&e, 0, 3, "content").is_none());
-        assert!(phrase_for_chunk(&e, 2, 3, "content").is_none());
+        let (p0, src0) = phrase_for_chunk(&e, 0, 3, "content").unwrap();
+        assert!(!p0.is_empty());
+        assert_eq!(src0, PhraseSource::Auto);
+
+        let (p2, src2) = phrase_for_chunk(&e, 2, 3, "## A heading\n\nbody").unwrap();
+        assert_eq!(p2, "A heading");
+        assert_eq!(src2, PhraseSource::Auto);
     }
 
     #[test]
@@ -1111,20 +1142,18 @@ mod tests {
     }
 
     #[test]
-    fn phraseless_large_bloom_returns_none_for_every_chunk() {
-        // P==0: all chunks are skip-type per the conservative default.
+    fn phraseless_large_bloom_returns_auto_for_every_chunk() {
+        // mx#218: P==0 blooms now get auto-generated phrases for every chunk.
         let entry = make_large_bloom(90_000, vec![]);
         let content = bloom_content(&entry);
         let plan = compute_chunks(&content, 28_000);
         assert!(plan.total >= 3);
         for idx in 0..plan.total {
             let chunk = plan.chunk(&content, idx);
-            let result = phrase_for_chunk(&entry, idx, plan.total, chunk);
-            assert!(
-                result.is_none(),
-                "P==0 bloom should never auto-derive phrases (chunk {})",
-                idx
-            );
+            let (phrase, source) = phrase_for_chunk(&entry, idx, plan.total, chunk)
+                .expect("P==0 bloom should have auto-phrase for every chunk");
+            assert!(!phrase.is_empty(), "auto-phrase must not be empty (chunk {})", idx);
+            assert_eq!(source, PhraseSource::Auto, "P==0 bloom should use Auto source (chunk {})", idx);
         }
     }
 
@@ -1587,23 +1616,21 @@ mod tests {
         );
     }
 
-    /// Diffi's issue #2 (mx#213): P==0 repeated-skip walkthrough on an
-    /// oversized phraseless bloom. Builds a bloom large enough to split
-    /// into ≥3 chunks, with zero authored phrases, and walks the whole
-    /// thing via repeated `skip_ritual` calls. Asserts:
+    /// mx#218: P==0 bloom with auto-phrases walks via the 3-attempt + reveal
+    /// flow. Builds a bloom large enough to split into >=3 chunks, with zero
+    /// authored phrases. After mx#218, every chunk gets an auto-generated
+    /// phrase. Walking through with wrong guesses must trigger the hint flow
+    /// and eventual reveal (3 failures).
     ///
-    /// - Every chunk emits as skip-type (no phrase attempted).
-    /// - `BloomPrompt.phrase_source` is None on every prompt (P==0 blooms
-    ///   don't expose authored/derived).
-    /// - `BloomPrompt.wake_phrase_count` is 0 on every prompt.
-    /// - Each skip advances the chunk cursor; after N skips for an
-    ///   N-chunk bloom, the ritual completes.
-    /// - Summary reports `skipped == total_chunks`.
+    /// Asserts:
+    /// - `BloomPrompt.phrase_source` is `"auto"` on every prompt.
+    /// - `BloomPrompt.wake_phrase_count` is 1 on every prompt.
+    /// - --skip is rejected (auto-phrase means engagement is required).
+    /// - 3 wrong guesses reveals the content.
+    /// - Summary reports `needed_help == total_chunks`.
     #[test]
-    fn integration_phraseless_oversized_bloom_walks_via_repeated_skips() {
+    fn integration_phraseless_bloom_walks_via_auto_phrase_engagement() {
         let store = MockStore::new();
-        // P==0: vec![] — zero authored phrases. Conservative default
-        // must keep every chunk skip-typed.
         let bloom = make_large_bloom(72_000, vec![]);
         let bloom_id = bloom.id.clone();
         store
@@ -1614,77 +1641,59 @@ mod tests {
         let cascade = test_cascade(vec![bloom.clone()]);
         let ctx = AgentContext::public_only();
 
-        // Begin. Expect P==0 marker visible on prompt (wake_phrase_count=0,
-        // phrase_source None).
+        // Begin. Expect auto-phrase markers on the prompt.
         let begin_json: serde_json::Value =
             serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
         let total_chunks = begin_json["progress"]["total"].as_u64().unwrap() as u16;
-        assert!(total_chunks >= 3, "need ≥3 chunks; got {}", total_chunks);
+        assert!(total_chunks >= 3, "need >=3 chunks; got {}", total_chunks);
         assert_eq!(
-            begin_json["prompt"]["wake_phrase_count"], 0,
-            "P==0 bloom prompt must declare zero phrases"
+            begin_json["prompt"]["wake_phrase_count"], 1,
+            "auto-phrased bloom must declare 1 phrase"
         );
-        assert!(
-            begin_json["prompt"].get("phrase_source").is_none()
-                || begin_json["prompt"]["phrase_source"].is_null(),
-            "P==0 bloom prompt must not advertise phrase_source; got {:?}",
-            begin_json["prompt"].get("phrase_source")
+        assert_eq!(
+            begin_json["prompt"]["phrase_source"], "auto",
+            "auto-phrased bloom must expose phrase_source='auto'"
         );
 
-        // Walk every chunk via --skip. On each response, assert the flow
-        // stays in skip-mode (no hint, no phrase compare attempted).
+        // Attempt to skip — must be rejected (mx#218 + mx#216 combined).
         let mut token = token_from_response(&begin_json);
-        for chunk_walked in 0..total_chunks {
-            let skip_json: serde_json::Value =
-                serde_json::from_str(&skip_ritual(&store, &ctx, &bloom_id, &token).unwrap())
-                    .unwrap();
-            assert_eq!(skip_json["status"], "skipped");
+        let skip_json: serde_json::Value =
+            serde_json::from_str(&skip_ritual(&store, &ctx, &bloom_id, &token).unwrap())
+                .unwrap();
+        assert_eq!(skip_json["status"], "error");
+        assert_eq!(skip_json["error"], "skip_requires_phraseless_bloom");
 
-            // Skip responses never include a hint field (hints come from
-            // the authored-phrase retry flow). Catches accidental regression
-            // where skip might start suggesting phrases.
-            assert!(
-                skip_json.get("hint").is_none() || skip_json["hint"].is_null(),
-                "skip response must not carry hint; got {:?}",
-                skip_json.get("hint")
-            );
+        // Walk every chunk via 3 wrong guesses → reveal.
+        for _chunk_walked in 0..total_chunks {
+            // 3 wrong guesses.
+            for attempt in 0..3 {
+                let resp_json: serde_json::Value = serde_json::from_str(
+                    &respond_ritual(&store, &ctx, &bloom_id, "totally wrong guess", &token)
+                        .unwrap(),
+                )
+                .unwrap();
 
-            // On all but the last chunk, the `next` prompt must also be
-            // P==0 / skip-compatible.
-            if chunk_walked + 1 < total_chunks {
-                let next = &skip_json["next"];
-                assert!(!next.is_null(), "expected next prompt before completion");
-                assert_eq!(
-                    next["wake_phrase_count"], 0,
-                    "next chunk in P==0 bloom must stay wake_phrase_count=0"
-                );
-                assert!(
-                    next.get("phrase_source").is_none() || next["phrase_source"].is_null(),
-                    "P==0 next prompt must not expose phrase_source"
-                );
+                if attempt < 2 {
+                    assert_eq!(resp_json["status"], "incorrect");
+                    assert!(resp_json.get("hint").is_some());
+                    token = token_from_response(&resp_json);
+                } else {
+                    // 3rd failure → revealed.
+                    assert_eq!(
+                        resp_json["status"], "revealed",
+                        "expected reveal after 3 failures; got {:?}",
+                        resp_json["status"]
+                    );
+                    assert_eq!(
+                        resp_json["bloom"]["phrase_source"], "auto",
+                        "revealed bloom should carry phrase_source='auto'"
+                    );
+                    token = token_from_response(&resp_json);
+                }
             }
-
-            token = token_from_response(&skip_json);
         }
 
-        // After N skips for an N-chunk bloom, ritual completes. Summary
-        // must report total == skipped.
-        {
-            let final_json: serde_json::Value = serde_json::from_str(
-                &skip_ritual(&store, &ctx, &bloom_id, &token)
-                    .err()
-                    .map(|e| format!(r#"{{"error":{:?}}}"#, e.to_string()))
-                    .unwrap_or_else(|| {
-                        // If we ran exactly total_chunks skips above, the
-                        // ritual is already complete. A subsequent skip
-                        // would fail; we don't call it — we check the
-                        // session was deleted instead.
-                        String::new()
-                    }),
-            )
-            .unwrap_or(serde_json::json!({}));
-            let _ = final_json;
-        }
+        // After all chunks are revealed, ritual is complete.
         assert!(
             store.sessions.borrow().is_empty(),
             "session should be deleted on completion; still present: {:?}",
@@ -1896,8 +1905,9 @@ mod tests {
     }
 
     #[test]
-    fn skip_accepts_phraseless_bloom() {
-        // Regression guard: phraseless blooms must still skip normally.
+    fn skip_rejects_phraseless_bloom_with_auto_phrase() {
+        // mx#218: phraseless blooms now have auto-generated phrases and
+        // cannot be skipped. The consumer must use --respond instead.
         let store = MockStore::new();
         let bloom = test_entry(); // no wake_phrases, no wake_phrase
         let bloom_id = bloom.id.clone();
@@ -1916,10 +1926,11 @@ mod tests {
         let skip_json: serde_json::Value =
             serde_json::from_str(&skip_ritual(&store, &ctx, &bloom_id, &token).unwrap()).unwrap();
         assert_eq!(
-            skip_json["status"], "skipped",
-            "phraseless bloom should skip normally; got {:?}",
+            skip_json["status"], "error",
+            "auto-phrased bloom should reject skip; got {:?}",
             skip_json["status"]
         );
+        assert_eq!(skip_json["error"], "skip_requires_phraseless_bloom");
     }
 
     #[test]
@@ -1955,5 +1966,201 @@ mod tests {
             "original token should still work after skip rejection; got {:?}",
             resp_json["status"]
         );
+    }
+
+    // =====================================================================
+    // mx#218 — auto-phrase integration tests
+    // =====================================================================
+
+    /// Test 9: begin_ritual on a phraseless bloom produces a prompt with
+    /// `wake_phrase_count: 1` and `phrase_source: "auto"`.
+    #[test]
+    fn begin_ritual_auto_phrases_for_phraseless_bloom() {
+        let store = MockStore::new();
+        let bloom = test_entry(); // no wake_phrases, no wake_phrase
+        let bloom_id = bloom.id.clone();
+        store
+            .blooms
+            .borrow_mut()
+            .insert(bloom_id.clone(), bloom.clone());
+
+        let cascade = test_cascade(vec![bloom]);
+
+        let begin_json: serde_json::Value =
+            serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
+
+        assert_eq!(
+            begin_json["prompt"]["wake_phrase_count"], 1,
+            "auto-phrased bloom must declare wake_phrase_count=1; got {:?}",
+            begin_json["prompt"]["wake_phrase_count"]
+        );
+        assert_eq!(
+            begin_json["prompt"]["phrase_source"], "auto",
+            "auto-phrased bloom must declare phrase_source='auto'; got {:?}",
+            begin_json["prompt"]["phrase_source"]
+        );
+    }
+
+    /// Test 10: correct guess against an auto-generated phrase returns
+    /// `status: "remembered"`.
+    #[test]
+    fn respond_ritual_accepts_auto_phrase() {
+        let store = MockStore::new();
+        let mut bloom = test_entry();
+        bloom.body = Some("## The Discovery\n\nBody text here.".to_string());
+        let bloom_id = bloom.id.clone();
+        store
+            .blooms
+            .borrow_mut()
+            .insert(bloom_id.clone(), bloom.clone());
+
+        let cascade = test_cascade(vec![bloom]);
+        let ctx = AgentContext::public_only();
+
+        let begin_json: serde_json::Value =
+            serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
+        let token = token_from_response(&begin_json);
+
+        // The auto-phrase for this content should be "The Discovery" (heading tier).
+        let resp_json: serde_json::Value = serde_json::from_str(
+            &respond_ritual(&store, &ctx, &bloom_id, "The Discovery", &token).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            resp_json["status"], "remembered",
+            "correct auto-phrase guess should be accepted; got {:?}",
+            resp_json["status"]
+        );
+        assert_eq!(resp_json["bloom"]["phrase_source"], "auto");
+    }
+
+    /// Test 11: 3 wrong guesses against an auto-phrase → `status: "revealed"`.
+    #[test]
+    fn respond_ritual_reveals_auto_phrase_after_3_failures() {
+        let store = MockStore::new();
+        let mut bloom = test_entry();
+        bloom.body = Some("## Hidden Knowledge\n\nSecret content.".to_string());
+        let bloom_id = bloom.id.clone();
+        store
+            .blooms
+            .borrow_mut()
+            .insert(bloom_id.clone(), bloom.clone());
+
+        let cascade = test_cascade(vec![bloom]);
+        let ctx = AgentContext::public_only();
+
+        let begin_json: serde_json::Value =
+            serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
+        let mut token = token_from_response(&begin_json);
+
+        // 3 wrong guesses.
+        for attempt in 0..3 {
+            let resp_json: serde_json::Value = serde_json::from_str(
+                &respond_ritual(&store, &ctx, &bloom_id, "wrong guess", &token).unwrap(),
+            )
+            .unwrap();
+            if attempt < 2 {
+                assert_eq!(resp_json["status"], "incorrect");
+            } else {
+                assert_eq!(
+                    resp_json["status"], "revealed",
+                    "3rd failure should reveal; got {:?}",
+                    resp_json["status"]
+                );
+                assert_eq!(resp_json["bloom"]["phrase_source"], "auto");
+                assert!(
+                    resp_json["bloom"]["matched_phrase"].is_string(),
+                    "revealed bloom should include the matched_phrase"
+                );
+            }
+            token = token_from_response(&resp_json);
+        }
+    }
+
+    /// Test 12: --skip on an auto-phrased bloom returns error (combines
+    /// mx#218 auto-phrase with mx#216 skip guard).
+    #[test]
+    fn skip_rejected_for_auto_phrase_bloom() {
+        let store = MockStore::new();
+        let bloom = test_entry(); // P==0, gets auto-phrase
+        let bloom_id = bloom.id.clone();
+        store
+            .blooms
+            .borrow_mut()
+            .insert(bloom_id.clone(), bloom.clone());
+
+        let cascade = test_cascade(vec![bloom]);
+        let ctx = AgentContext::public_only();
+
+        let begin_json: serde_json::Value =
+            serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
+        let token = token_from_response(&begin_json);
+
+        let skip_json: serde_json::Value =
+            serde_json::from_str(&skip_ritual(&store, &ctx, &bloom_id, &token).unwrap()).unwrap();
+        assert_eq!(
+            skip_json["status"], "error",
+            "auto-phrased bloom must not be skippable; got {:?}",
+            skip_json["status"]
+        );
+        assert_eq!(skip_json["error"], "skip_requires_phraseless_bloom");
+
+        // Session state must be unchanged — still at step 0.
+        let sessions = store.sessions.borrow();
+        let sess = sessions.values().next().unwrap();
+        assert_eq!(sess.step, 0);
+        assert_eq!(sess.skipped_count, 0);
+    }
+
+    /// mx#218: auto-phrased blooms use tolerant matching (case-insensitive,
+    /// trailing punct stripped, whitespace collapsed) — same as derived.
+    #[test]
+    fn respond_ritual_auto_phrase_tolerant_match() {
+        let store = MockStore::new();
+        let mut bloom = test_entry();
+        bloom.body = Some("## The Discovery\n\nBody text here.".to_string());
+        let bloom_id = bloom.id.clone();
+        store
+            .blooms
+            .borrow_mut()
+            .insert(bloom_id.clone(), bloom.clone());
+
+        let cascade = test_cascade(vec![bloom]);
+        let ctx = AgentContext::public_only();
+
+        let begin_json: serde_json::Value =
+            serde_json::from_str(&begin_ritual(&store, &cascade).unwrap()).unwrap();
+        let token = token_from_response(&begin_json);
+
+        // Case-insensitive guess should work (tolerant match).
+        let resp_json: serde_json::Value = serde_json::from_str(
+            &respond_ritual(&store, &ctx, &bloom_id, "the discovery", &token).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            resp_json["status"], "remembered",
+            "case-insensitive auto-phrase guess should be accepted; got {:?}",
+            resp_json["status"]
+        );
+    }
+
+    /// mx#218: auto_chunks counter in the session rollup tracks auto-phrased
+    /// chunk outcomes.
+    #[test]
+    fn auto_phrase_bloom_rollup_tracks_auto_chunks() {
+        let e = test_entry();
+        let cascade = test_cascade(vec![e.clone()]);
+        let mut session = WakeSession::new(&cascade);
+
+        // Walk through as if it were auto-phrased (PhraseSourceTag::Auto).
+        session.advance_remembered(1, PhraseSourceTag::Auto);
+
+        let mut blooms = HashMap::new();
+        blooms.insert(e.id.clone(), e);
+        let rollups = build_bloom_rollups(&session, &blooms);
+        assert_eq!(rollups[0].auto_chunks, 1);
+        assert_eq!(rollups[0].authored_chunks, 0);
+        assert_eq!(rollups[0].derived_chunks, 0);
+        assert_eq!(rollups[0].remembered, 1);
     }
 }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -539,7 +539,13 @@ pub fn skip_ritual(
     // engagement.
     if !chunk_truncated {
         let chunk_content = plan.chunk(&content, session.current_chunk_index);
-        if phrase_for_chunk(bloom, session.current_chunk_index, plan.total, chunk_content).is_some()
+        if phrase_for_chunk(
+            bloom,
+            session.current_chunk_index,
+            plan.total,
+            chunk_content,
+        )
+        .is_some()
         {
             let response = WakeErrorResponse {
                 status: "error".to_string(),
@@ -1152,8 +1158,17 @@ mod tests {
             let chunk = plan.chunk(&content, idx);
             let (phrase, source) = phrase_for_chunk(&entry, idx, plan.total, chunk)
                 .expect("P==0 bloom should have auto-phrase for every chunk");
-            assert!(!phrase.is_empty(), "auto-phrase must not be empty (chunk {})", idx);
-            assert_eq!(source, PhraseSource::Auto, "P==0 bloom should use Auto source (chunk {})", idx);
+            assert!(
+                !phrase.is_empty(),
+                "auto-phrase must not be empty (chunk {})",
+                idx
+            );
+            assert_eq!(
+                source,
+                PhraseSource::Auto,
+                "P==0 bloom should use Auto source (chunk {})",
+                idx
+            );
         }
     }
 
@@ -1658,8 +1673,7 @@ mod tests {
         // Attempt to skip — must be rejected (mx#218 + mx#216 combined).
         let mut token = token_from_response(&begin_json);
         let skip_json: serde_json::Value =
-            serde_json::from_str(&skip_ritual(&store, &ctx, &bloom_id, &token).unwrap())
-                .unwrap();
+            serde_json::from_str(&skip_ritual(&store, &ctx, &bloom_id, &token).unwrap()).unwrap();
         assert_eq!(skip_json["status"], "error");
         assert_eq!(skip_json["error"], "skip_requires_phraseless_bloom");
 

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -338,11 +338,12 @@ pub fn respond_ritual(
     let chunk_idx = session.current_chunk_index;
     let chunk_content = plan.chunk(&content, chunk_idx);
 
-    // P==0 bloom? Reject respond path — consumer must --skip.
+    // Every chunk now resolves a phrase (authored, derived, or auto). The
+    // None branch is unreachable in normal flow — retained as a defensive guard.
     let (wake_phrase, source) = match phrase_for_chunk(bloom, chunk_idx, plan.total, chunk_content)
     {
         Some(p) => p,
-        None => bail!("This bloom has no wake phrase - use --skip instead"),
+        None => bail!("Internal error: phrase_for_chunk returned None"),
     };
 
     // Compare: first via our tolerant compare_phrase (picks up authored-vs-
@@ -462,7 +463,7 @@ pub fn respond_ritual(
                 // deferred per §6 / §10 Risk 9). Field renamed from
                 // `content_changed_during_ritual` after Diffi's mx#213
                 // review called out the overpromise.
-                let derived_miss = source == PhraseSource::Derived;
+                let derived_miss = matches!(source, PhraseSource::Derived | PhraseSource::Auto);
 
                 let response = WakeRespondResponse {
                     status: "incorrect".to_string(),

--- a/src/wake_token.rs
+++ b/src/wake_token.rs
@@ -541,7 +541,9 @@ pub struct BloomRollup {
     /// Count of chunks this bloom surfaced via authored vs derived phrases.
     /// Dog-fooding signal: high `derived` / low `authored` suggests the bloom
     /// should probably get more authored wake_phrases.
+    #[serde(skip_serializing_if = "is_zero")]
     pub authored_chunks: u32,
+    #[serde(skip_serializing_if = "is_zero")]
     pub derived_chunks: u32,
     /// Count of chunks that used auto-generated phrases (mx#218). High count
     /// means the bloom has no authored phrases and needs them.

--- a/src/wake_token.rs
+++ b/src/wake_token.rs
@@ -70,6 +70,8 @@ pub fn verify_token(token: &str) -> Result<(String, u32), String> {
 pub enum PhraseSourceTag {
     Authored,
     Derived,
+    /// Auto-generated phrase for a phraseless bloom (mx#218).
+    Auto,
     None,
 }
 
@@ -105,6 +107,11 @@ pub struct BloomChunkMeta {
     /// chunk total, the bloom probably wants more authored phrases.
     #[serde(default)]
     pub derived_chunks: u32,
+    /// Count of chunks that matched against an auto-generated phrase (mx#218).
+    /// These are phraseless blooms where the phrase was extracted from content.
+    /// High count signals the bloom needs authored wake phrases.
+    #[serde(default)]
+    pub auto_chunks: u32,
 }
 
 /// Server-side wake ritual session state.
@@ -245,6 +252,7 @@ impl WakeSession {
             match phrase_source {
                 PhraseSourceTag::Authored => meta.authored_chunks += 1,
                 PhraseSourceTag::Derived => meta.derived_chunks += 1,
+                PhraseSourceTag::Auto => meta.auto_chunks += 1,
                 PhraseSourceTag::None => {}
             }
         }
@@ -261,6 +269,7 @@ impl WakeSession {
             match phrase_source {
                 PhraseSourceTag::Authored => meta.authored_chunks += 1,
                 PhraseSourceTag::Derived => meta.derived_chunks += 1,
+                PhraseSourceTag::Auto => meta.auto_chunks += 1,
                 PhraseSourceTag::None => {}
             }
         }
@@ -534,6 +543,15 @@ pub struct BloomRollup {
     /// should probably get more authored wake_phrases.
     pub authored_chunks: u32,
     pub derived_chunks: u32,
+    /// Count of chunks that used auto-generated phrases (mx#218). High count
+    /// means the bloom has no authored phrases and needs them.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub auto_chunks: u32,
+}
+
+/// Helper for `#[serde(skip_serializing_if)]` on u32 fields that default to 0.
+fn is_zero(v: &u32) -> bool {
+    *v == 0
 }
 
 /// Convert KnowledgeEntry to BloomPrompt (non-chunked form — PR 2 wires a


### PR DESCRIPTION
## Summary

- Auto-generate wake phrases for phraseless (P==0) blooms via `extract_auto_phrase` — a four-tier cascade: markdown heading, content-hash-seeded sentence selection, first non-empty line, title fallback
- New `PhraseSource::Auto` variant carries through the entire ritual flow (matching, hints, reveal, rollup counters)
- `--skip` is now rejected for ALL blooms (every chunk has a phrase after this change), extending the mx#216 guard to cover auto-phrased chunks
- Auto-phrases use the same tolerant matching as derived phrases (case-insensitive, trailing punct stripped, whitespace collapsed)

## What changed

**`wake_chunk.rs`**: Added `extract_auto_phrase()`, `extract_sentences()`, and `select_sentence_index()`. The sentence selector uses a content-hash seed so the same content always picks the same sentence, but different blooms pick different sentences (prevents memorization).

**`wake_ritual.rs`**: `phrase_for_chunk()` now returns `Some((phrase, PhraseSource::Auto))` for P==0 blooms instead of `None`. `build_prompt_for_chunk()` sets `wake_phrase_count=1` and `phrase_source="auto"` for auto-phrased chunks. Skip guard updated to check `phrase_for_chunk().is_some()` instead of `authored_phrase_count > 0`.

**`wake_token.rs`**: Added `PhraseSourceTag::Auto`, `BloomChunkMeta.auto_chunks`, and `BloomRollup.auto_chunks` for observability.

## Tests

20 new tests (354 total, 0 failures):
- 8 unit tests for `extract_auto_phrase` (heading, sentence, line, title fallback, never-empty, deterministic, fenced headings, warmth bricks)
- 4 unit tests for `extract_sentences` and `select_sentence_index`
- 6 integration tests (begin_ritual auto-phrases, respond accepts, 3-failure reveal, skip rejected, tolerant match, rollup counter)
- 2 updated existing tests to reflect new P==0 behavior (was `returns_none` / `skip_accepts`, now `returns_auto` / `skip_rejects`)

## Test plan

- [x] `cargo build --release` — clean, no warnings
- [x] `cargo test` — 354 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — clean
- [ ] Manual verification: run `mx memory wake` with a phraseless bloom and confirm auto-phrase engagement flow

Closes #218