### PR TITLE
Fix session linkage edges + relationship CLI tooling (+ kn- prefix bridge fix)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3443,7 +3443,21 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     "session_id: {:?} -> {}",
                     entry.session_id, normalized
                 ));
-                entry.session_id = Some(normalized);
+                entry.session_id = Some(normalized.clone());
+
+                // Create EXTRACTED_FROM edge, mirroring the add path logic.
+                // The for-session query traverses the relates_to edge, so we
+                // need both the field AND the edge for consistency.
+                let session_ref = normalized;
+                let edge_ctx = crate::store::AgentContext::public_only();
+                if db.get(&session_ref, &edge_ctx)?.is_none() {
+                    eprintln!(
+                        "Warning: Session {} not found - EXTRACTED_FROM edge not created",
+                        session_ref
+                    );
+                } else {
+                    db.add_relationship(&id, &session_ref, "extracted_from")?;
+                }
             }
 
             // Update timestamp

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -452,6 +452,13 @@ macro_rules! with_db {
     };
 }
 
+/// Helper for SELECT-based existence checks on `relates_to` edges.
+/// Used by both `delete_relationship_by_id_async` and `delete_relationship_async`.
+#[derive(Debug, Deserialize)]
+struct ExistsRow {
+    id: String,
+}
+
 impl SurrealDatabase {}
 
 impl SurrealDatabase {
@@ -2550,7 +2557,7 @@ impl SurrealDatabase {
         let rel_type_thing = Thing::from(("relationship_type", rel_type));
 
         with_db!(self, db, {
-            db.query("RELATE $from->relates_to->$to SET relationship_type = $rel_type")
+            db.query("RELATE $from->relates_to->$to SET relationship_type = $rel_type, created_at = time::now()")
                 .bind(("from", from_thing))
                 .bind(("to", to_thing))
                 .bind(("rel_type", rel_type_thing))
@@ -2580,7 +2587,8 @@ impl SurrealDatabase {
             from_entry_id: String,
             to_entry_id: String,
             relationship_type: String,
-            created_at: String,
+            #[serde(default)]
+            created_at: Option<String>,
         }
 
         let mut response = with_db!(self, db, {
@@ -2607,7 +2615,7 @@ impl SurrealDatabase {
                 from_entry_id: format!("kn-{}", row.from_entry_id),
                 to_entry_id: format!("kn-{}", row.to_entry_id),
                 relationship_type: row.relationship_type,
-                created_at: row.created_at,
+                created_at: row.created_at.unwrap_or_else(|| "unknown".to_string()),
             })
             .collect();
 
@@ -2628,11 +2636,10 @@ impl SurrealDatabase {
         // SurrealDB's RETURN BEFORE yields Thing-typed fields that serde_json cannot
         // round-trip. Instead: SELECT with meta::id() to check existence, then DELETE
         // without a RETURN clause (which is safe to take as Vec<Value> empty).
-        #[derive(Debug, Deserialize)]
-        struct ExistsRow {
-            id: String,
-        }
-
+        //
+        // NOTE: There is a TOCTOU window between the SELECT and DELETE — the edge
+        // could be deleted by another caller between the two queries.  This is
+        // acceptable for a single-user CLI tool where concurrent mutation is rare.
         let mut check = with_db!(self, db, {
             db.query("SELECT meta::id(id) AS id FROM relates_to WHERE meta::id(id) = $id LIMIT 1")
                 .bind(("id", id.to_string()))
@@ -2671,11 +2678,6 @@ impl SurrealDatabase {
         // SurrealDB's RETURN BEFORE yields Thing-typed fields that serde_json cannot
         // round-trip. Check existence with meta::id() SELECT first, then DELETE without
         // a RETURN clause to avoid the deserialization error.
-        #[derive(Debug, Deserialize)]
-        struct ExistsRow {
-            id: String,
-        }
-
         let mut check = with_db!(self, db, {
             db.query(
                 "SELECT meta::id(id) AS id FROM relates_to


### PR DESCRIPTION
## Summary

Four coherent fixes to session linkage, relationship tooling, and a separate bridge query bug.

## Commits

- **`371a857`** — fix: preserve kn- prefix in wake cascade bridge query anchor IDs
  - Bridge layer was stripping `kn-` prefix before building anchor IDs, causing `array::intersect` to always return zero. Bridge has never returned results before this fix.

- **`4276d2f`** — Fix session linkage edges and relationship CLI tooling
  - `delete_relationship` trait was a dead stub — wired up
  - `list_relationships` threw Thing serialization errors via `serde_json::Value` — fixed
  - `mx memory update` had no `--session-id` flag — added (blocked retrofitting session links)
  - Standard-mode `add --session-id` set the field but never created the `EXTRACTED_FROM` edge, making most adds invisible to for-session graph traversal — fixed

- **`bfce716`** — chore: apply cargo fmt (trailing comma in list_relationships query)

- **`021b7cd`** — Fix delete relationship Thing serialization
  - Follow-on to 4276d2f. `DELETE...RETURN BEFORE` returns Thing-typed fields serde can't deserialize. Switched to SELECT-then-DELETE pattern for both `delete_relationship_by_id_async` and `delete_relationship_async`.

## Test plan

- [ ] `mx memory add --category decision --session-id <id>` creates the entry AND the EXTRACTED_FROM edge
- [ ] `mx memory update <id> --session-id <id>` works for retrofitting
- [ ] `mx relationships delete <id>` works end-to-end without Thing serialization errors
- [ ] `mx relationships list` works without Thing serialization errors
- [ ] Wake cascade bridge returns non-zero intersections for known-linked anchors