### PR TITLE
Add codex archive format detection + graph observability endpoints

### DIFF
--- a/src/codex.rs
+++ b/src/codex.rs
@@ -170,7 +170,7 @@ pub fn list_sessions(all: bool, json: bool) -> Result<()> {
     }
 
     // Sort by archived_at (most recent first)
-    archives.sort_by(|a, b| b.manifest.archived_at.cmp(&a.manifest.archived_at));
+    archives.sort_by_key(|a| std::cmp::Reverse(a.manifest.archived_at));
 
     // Filter incremental archives unless --all
     if !all {
@@ -192,7 +192,7 @@ pub fn list_sessions(all: bool, json: bool) -> Result<()> {
         }
 
         archives = latest_map.into_values().collect();
-        archives.sort_by(|a, b| b.manifest.archived_at.cmp(&a.manifest.archived_at));
+        archives.sort_by_key(|a| std::cmp::Reverse(a.manifest.archived_at));
     }
 
     if json {

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -344,18 +344,13 @@ pub fn read_session(
         return Ok(());
     }
 
-    let session_file = archive_dir.join("session.jsonl");
-    let (content, is_clean_md) = if session_file.exists() {
-        (fs::read_to_string(&session_file)?, false)
-    } else {
-        let md = archive_dir.join("conversation.md");
-        if !md.exists() {
-            anyhow::bail!(
-                "No transcript found in archive (expected session.jsonl or conversation.md)"
-            );
-        }
-        (fs::read_to_string(&md)?, true)
-    };
+    let source_file = archive_source(&archive_dir).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No transcript found in archive (expected conversation.md or session.jsonl)"
+        )
+    })?;
+    let is_clean_md = source_file.extension().and_then(|e| e.to_str()) == Some("md");
+    let content = fs::read_to_string(&source_file)?;
 
     if let Some(pattern) = grep_pattern {
         // Filter lines matching pattern — works identically on both formats
@@ -372,7 +367,10 @@ pub fn read_session(
         print!("{}", content);
     }
 
-    // Include agent transcripts if requested
+    // Include agent transcripts if requested.
+    // Agent transcripts are always stored as JSONL (even in clean-mode archives
+    // that use conversation.md for the main session), so we only look for .jsonl
+    // files in the agents/ directory.
     if include_agents {
         let agents_dir = archive_dir.join("agents");
         if agents_dir.exists() {

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -345,24 +345,30 @@ pub fn read_session(
     }
 
     let session_file = archive_dir.join("session.jsonl");
-    if !session_file.exists() {
-        anyhow::bail!("Session file not found in archive");
-    }
-
-    let content = fs::read_to_string(&session_file)?;
+    let (content, is_clean_md) = if session_file.exists() {
+        (fs::read_to_string(&session_file)?, false)
+    } else {
+        let md = archive_dir.join("conversation.md");
+        if !md.exists() {
+            anyhow::bail!(
+                "No transcript found in archive (expected session.jsonl or conversation.md)"
+            );
+        }
+        (fs::read_to_string(&md)?, true)
+    };
 
     if let Some(pattern) = grep_pattern {
-        // Filter lines matching pattern
+        // Filter lines matching pattern — works identically on both formats
         for line in content.lines() {
             if line.contains(&pattern) {
                 println!("{}", line);
             }
         }
-    } else if human {
-        // Pretty-print human-readable format
+    } else if !is_clean_md && human {
+        // Pretty-print human-readable format (JSONL only)
         print_human_readable(&content)?;
     } else {
-        // Raw JSONL
+        // Raw output (JSONL) or clean markdown pass-through
         print!("{}", content);
     }
 
@@ -392,6 +398,21 @@ pub fn read_session(
     Ok(())
 }
 
+/// Pick the canonical transcript source for an archive directory.
+/// Prefers the clean markdown transcript (post-March-31 default), falls back
+/// to the raw JSONL for older archives.  Returns None when neither exists.
+fn archive_source(archive_dir: &Path) -> Option<PathBuf> {
+    let md = archive_dir.join("conversation.md");
+    if md.exists() {
+        return Some(md);
+    }
+    let jsonl = archive_dir.join("session.jsonl");
+    if jsonl.exists() {
+        return Some(jsonl);
+    }
+    None
+}
+
 /// Search all archives for a pattern
 pub fn search_archives(pattern: String, json: bool) -> Result<()> {
     let codex_dir = get_codex_dir()?;
@@ -407,47 +428,87 @@ pub fn search_archives(pattern: String, json: bool) -> Result<()> {
 
     let archives = collect_archives(&codex_dir)?;
 
+    let mut skipped: usize = 0;
+
     if json {
         let mut results = Vec::new();
         for archive in archives {
-            let session_file = codex_dir.join(&archive.dir_name).join("session.jsonl");
-            if let Ok(content) = fs::read_to_string(&session_file)
-                && content.contains(&pattern)
-            {
-                let matching_lines: Vec<serde_json::Value> = content
-                    .lines()
-                    .enumerate()
-                    .filter(|(_, line)| line.contains(&pattern))
-                    .map(|(i, line)| {
-                        serde_json::json!({
-                            "line": i + 1,
-                            "content": line,
-                        })
-                    })
-                    .collect();
-                results.push(serde_json::json!({
-                    "archive_id": archive.short_id,
-                    "file": session_file.display().to_string(),
-                    "matches": matching_lines,
-                }));
+            let archive_dir = codex_dir.join(&archive.dir_name);
+            let source_file = match archive_source(&archive_dir) {
+                Some(p) => p,
+                None => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+            match fs::read_to_string(&source_file) {
+                Ok(content) => {
+                    if content.contains(&pattern) {
+                        let matching_lines: Vec<serde_json::Value> = content
+                            .lines()
+                            .enumerate()
+                            .filter(|(_, line)| line.contains(&pattern))
+                            .map(|(i, line)| {
+                                serde_json::json!({
+                                    "line": i + 1,
+                                    "content": line,
+                                })
+                            })
+                            .collect();
+                        results.push(serde_json::json!({
+                            "archive_id": archive.short_id,
+                            "file": source_file.display().to_string(),
+                            "matches": matching_lines,
+                        }));
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not read {}: {}",
+                        source_file.display(),
+                        e
+                    );
+                }
             }
         }
         println!("{}", serde_json::to_string_pretty(&results)?);
     } else {
         for archive in archives {
-            let session_file = codex_dir.join(&archive.dir_name).join("session.jsonl");
-            if let Ok(content) = fs::read_to_string(&session_file)
-                && content.contains(&pattern)
-            {
-                println!("Match in {}: {}", archive.short_id, session_file.display());
-                // Print matching lines
-                for (i, line) in content.lines().enumerate() {
-                    if line.contains(&pattern) {
-                        println!("  Line {}: {}", i + 1, line);
+            let archive_dir = codex_dir.join(&archive.dir_name);
+            let source_file = match archive_source(&archive_dir) {
+                Some(p) => p,
+                None => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+            match fs::read_to_string(&source_file) {
+                Ok(content) => {
+                    if content.contains(&pattern) {
+                        println!("Match in {}: {}", archive.short_id, source_file.display());
+                        for (i, line) in content.lines().enumerate() {
+                            if line.contains(&pattern) {
+                                println!("  Line {}: {}", i + 1, line);
+                            }
+                        }
                     }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Warning: could not read {}: {}",
+                        source_file.display(),
+                        e
+                    );
                 }
             }
         }
+    }
+
+    if skipped > 0 {
+        eprintln!(
+            "searched archives, skipped {} (no transcript found)",
+            skipped
+        );
     }
 
     Ok(())
@@ -2143,6 +2204,79 @@ mod tests {
         assert!(
             map.is_empty(),
             "map should be empty when subagent_type is missing"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // archive_source: format-detection regression test
+    // Catches the silent-failure mode where clean-mode archives (conversation.md
+    // only) were invisible to search_archives because it only looked for
+    // session.jsonl.  If this test fails, the format-detection helper is broken.
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn archive_source_prefers_clean_md_over_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        let md_path = dir.path().join("conversation.md");
+        let jsonl_path = dir.path().join("session.jsonl");
+
+        // Only conversation.md present (clean-mode archive)
+        std::fs::write(&md_path, "# Conversation\n").unwrap();
+        let result = archive_source(dir.path()).unwrap();
+        assert_eq!(result, md_path, "should prefer conversation.md");
+
+        // Both present — still prefers conversation.md
+        std::fs::write(&jsonl_path, "{}\n").unwrap();
+        let result = archive_source(dir.path()).unwrap();
+        assert_eq!(
+            result, md_path,
+            "should prefer conversation.md when both exist"
+        );
+
+        // Only session.jsonl present (legacy archive)
+        std::fs::remove_file(&md_path).unwrap();
+        let result = archive_source(dir.path()).unwrap();
+        assert_eq!(result, jsonl_path, "should fall back to session.jsonl");
+
+        // Neither present — returns None
+        std::fs::remove_file(&jsonl_path).unwrap();
+        assert!(
+            archive_source(dir.path()).is_none(),
+            "should return None when no transcript exists"
+        );
+    }
+
+    #[test]
+    fn archive_source_real_archives_are_searchable() {
+        // Cross-reference rail: at least one real archive must be in the canonical
+        // format that archive_source can find.  This is the test that would have
+        // caught the asymmetric migration at CI time — the check that clean-mode
+        // archives are actually visible to the search path.
+        let codex_dir = match get_codex_dir() {
+            Ok(d) => d,
+            Err(_) => return, // codex dir not configured in this environment — skip
+        };
+        if !codex_dir.exists() {
+            return; // no archives yet — skip rather than fail
+        }
+        let archives = match collect_archives(&codex_dir) {
+            Ok(a) => a,
+            Err(_) => return,
+        };
+        if archives.is_empty() {
+            return; // nothing to check
+        }
+        let searchable = archives.iter().filter(|a| {
+            let archive_dir = codex_dir.join(&a.dir_name);
+            archive_source(&archive_dir).is_some()
+        });
+        assert!(
+            searchable.count() > 0,
+            "no archives are searchable — archive_source found neither \
+             conversation.md nor session.jsonl in any of the {} archive(s) \
+             under {:?}. search_archives would return zero results.",
+            archives.len(),
+            codex_dir
         );
     }
 }

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -463,11 +463,7 @@ pub fn search_archives(pattern: String, json: bool) -> Result<()> {
                     }
                 }
                 Err(e) => {
-                    eprintln!(
-                        "Warning: could not read {}: {}",
-                        source_file.display(),
-                        e
-                    );
+                    eprintln!("Warning: could not read {}: {}", source_file.display(), e);
                 }
             }
         }
@@ -494,11 +490,7 @@ pub fn search_archives(pattern: String, json: bool) -> Result<()> {
                     }
                 }
                 Err(e) => {
-                    eprintln!(
-                        "Warning: could not read {}: {}",
-                        source_file.display(),
-                        e
-                    );
+                    eprintln!("Warning: could not read {}: {}", source_file.display(), e);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2359,6 +2359,12 @@ fn auto_anchor(
     Ok(())
 }
 
+/// Open the SurrealDB graph database for the given config.
+fn open_surreal(config: &IndexConfig, verbose: bool) -> Result<crate::surreal_db::SurrealDatabase> {
+    let surreal_path = config.db_path.with_extension("surreal");
+    crate::surreal_db::SurrealDatabase::open_with_verbose(surreal_path, verbose)
+}
+
 fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
     let config = IndexConfig::default();
 
@@ -2562,8 +2568,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
         }
 
         MemoryCommands::Health { json } => {
-            let surreal_path = config.db_path.with_extension("surreal");
-            let db = crate::surreal_db::SurrealDatabase::open_with_verbose(surreal_path, verbose)?;
+            let db = open_surreal(&config, verbose)?;
             let health = db.graph_health()?;
 
             if json {
@@ -2582,8 +2587,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
         }
 
         MemoryCommands::Growth { json } => {
-            let surreal_path = config.db_path.with_extension("surreal");
-            let db = crate::surreal_db::SurrealDatabase::open_with_verbose(surreal_path, verbose)?;
+            let db = open_surreal(&config, verbose)?;
             let counts = db.growth_sparkline()?;
 
             if json {
@@ -2600,8 +2604,7 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
         }
 
         MemoryCommands::OpenThreads { json } => {
-            let surreal_path = config.db_path.with_extension("surreal");
-            let db = crate::surreal_db::SurrealDatabase::open_with_verbose(surreal_path, verbose)?;
+            let db = open_surreal(&config, verbose)?;
             let threads = db.open_threads()?;
 
             if json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -548,6 +548,27 @@ enum MemoryCommands {
         json: bool,
     },
 
+    /// Show graph health vitality percentages (embedding coverage, anchor coverage, stale high-res entries)
+    Health {
+        /// Output as JSON (default format for dashboard consumers)
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Show per-week entry growth over the last 8 weeks as a JSON array
+    Growth {
+        /// Output as JSON array of 8 integers (oldest to newest)
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List open threads (category:thread entries with state="open" or no state)
+    OpenThreads {
+        /// Output as JSON array (required for dashboard consumers)
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Delete an entry from the index
     Delete {
         /// Entry ID to delete
@@ -2536,6 +2557,68 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 for cat in categories {
                     let count = db.list_by_category(&cat.id, &ctx, &filter)?.len();
                     println!("  {:12} {}", cat.id, count);
+                }
+            }
+        }
+
+        MemoryCommands::Health { json } => {
+            let surreal_path = config.db_path.with_extension("surreal");
+            let db = crate::surreal_db::SurrealDatabase::open_with_verbose(surreal_path, verbose)?;
+            let health = db.graph_health()?;
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&health)?);
+            } else {
+                let total = health["total"].as_i64().unwrap_or(0);
+                let embedded_pct = health["embedded_pct"].as_i64().unwrap_or(0);
+                let anchored_pct = health["anchored_pct"].as_i64().unwrap_or(0);
+                let stale_pct = health["stale_high_res_pct"].as_i64().unwrap_or(0);
+                println!("Graph Health\n");
+                println!("  Total entries: {}", total);
+                println!("  {:3}% embedded", embedded_pct);
+                println!("  {:3}% anchored", anchored_pct);
+                println!("  {:3}% stale (high-res, >30d)", stale_pct);
+            }
+        }
+
+        MemoryCommands::Growth { json } => {
+            let surreal_path = config.db_path.with_extension("surreal");
+            let db = crate::surreal_db::SurrealDatabase::open_with_verbose(surreal_path, verbose)?;
+            let counts = db.growth_sparkline()?;
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&counts)?);
+            } else {
+                // Human-readable: label + bar
+                println!("Growth (last 8 weeks)");
+                if let Some(arr) = counts.as_array() {
+                    for (i, v) in arr.iter().enumerate() {
+                        println!("  week -{}: {}", 7 - i, v.as_i64().unwrap_or(0));
+                    }
+                }
+            }
+        }
+
+        MemoryCommands::OpenThreads { json } => {
+            let surreal_path = config.db_path.with_extension("surreal");
+            let db = crate::surreal_db::SurrealDatabase::open_with_verbose(surreal_path, verbose)?;
+            let threads = db.open_threads()?;
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&threads)?);
+            } else {
+                let arr = threads.as_array().map(|v| v.as_slice()).unwrap_or(&[]);
+                if arr.is_empty() {
+                    println!("No open threads.");
+                } else {
+                    println!("Open threads ({})\n", arr.len());
+                    for t in arr {
+                        let id = t["id"].as_str().unwrap_or("");
+                        let resonance = t["resonance"].as_i64().unwrap_or(0);
+                        let created_at = t["created_at"].as_str().unwrap_or("");
+                        let body = t["body"].as_str().unwrap_or("").chars().take(80).collect::<String>();
+                        println!("  [r{}] {} {}  {}", resonance, id, created_at, body);
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2616,7 +2616,12 @@ fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         let id = t["id"].as_str().unwrap_or("");
                         let resonance = t["resonance"].as_i64().unwrap_or(0);
                         let created_at = t["created_at"].as_str().unwrap_or("");
-                        let body = t["body"].as_str().unwrap_or("").chars().take(80).collect::<String>();
+                        let body = t["body"]
+                            .as_str()
+                            .unwrap_or("")
+                            .chars()
+                            .take(80)
+                            .collect::<String>();
                         println!("  [r{}] {} {}  {}", resonance, id, created_at, body);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1683,7 +1683,7 @@ fn handle_heartbeat(since: Option<u64>, reset: bool) -> Result<()> {
         }
         Some(ms) => {
             // Calculate BPM: 60000ms / interval = beats per minute
-            let bpm = if ms > 0 { 60000 / ms } else { 999 };
+            let bpm = 60000_u64.checked_div(ms).unwrap_or(999);
 
             let message = match bpm {
                 0..=59 => "Nice and slow. You're safe.",

--- a/src/session.rs
+++ b/src/session.rs
@@ -187,7 +187,7 @@ pub fn find_most_recent_session() -> Result<PathBuf> {
     }
 
     // Sort by modification time (most recent first)
-    sessions.sort_by(|a, b| b.1.cmp(&a.1));
+    sessions.sort_by_key(|s| std::cmp::Reverse(s.1));
 
     Ok(sessions[0].0.clone())
 }

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -2986,9 +2986,9 @@ impl SurrealDatabase {
             db.query(
                 "SELECT
                     count() AS total,
-                    count(embedding IS NOT NONE) AS embedded,
-                    count(anchors IS NOT NONE AND array::len(anchors) > 0) AS anchored,
-                    count(last_activated < time::now() - duration::from::days(30) AND resonance >= 5) AS stale_high_res
+                    math::sum(IF embedding IS NOT NONE THEN 1 ELSE 0 END) AS embedded,
+                    math::sum(IF anchors IS NOT NONE AND array::len(anchors) > 0 THEN 1 ELSE 0 END) AS anchored,
+                    math::sum(IF (last_activated IS NONE OR last_activated < time::now() - duration::from::days(30)) AND resonance >= 5 THEN 1 ELSE 0 END) AS stale_high_res
                 FROM knowledge GROUP ALL",
             )
             .await
@@ -3061,7 +3061,10 @@ impl SurrealDatabase {
             bucket_map.insert(bucket, cnt);
         }
 
-        // Fill 8 contiguous buckets ending at current week
+        // Fill 8 contiguous buckets ending at current week.
+        // Note: dividing unix seconds by 604800 yields epoch-relative weeks
+        // whose boundaries fall on Thursday 00:00 UTC (since the Unix epoch
+        // was a Thursday).  The alignment is arbitrary but consistent.
         let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)
@@ -3141,7 +3144,10 @@ impl SurrealDatabase {
                         .to_string()
                 };
 
-                // After DB-side WHERE filter this should always be "open", but guard anyway
+                // Defensive: the DB-side WHERE already filters to open threads, but
+                // summary can be a raw JSON string that needs client-side parsing
+                // (see the deserialisation dance above), so we re-check here in case
+                // the parsed state diverges from what SurrealQL evaluated.
                 if state != "open" {
                     return None;
                 }
@@ -3181,16 +3187,17 @@ impl SurrealDatabase {
     }
 
     /// Decay-weighted score: resonance * 0.95^weeks_old
+    ///
+    /// If `created_at` cannot be parsed, we treat the entry as maximally old
+    /// (52 weeks) so it sinks to the bottom rather than floating to the top
+    /// with zero decay.
     fn decay_score(resonance: i64, created_at: &str, now_secs: f64) -> f64 {
-        let created_secs = chrono::DateTime::parse_from_rfc3339(&created_at.replace('Z', "+00:00"))
-            .map(|dt| dt.timestamp() as f64)
-            .unwrap_or(0.0);
-
-        let weeks = if created_secs > 0.0 {
-            (now_secs - created_secs) / (7.0 * 86400.0)
-        } else {
-            0.0
-        };
+        let weeks = chrono::DateTime::parse_from_rfc3339(&created_at.replace('Z', "+00:00"))
+            .map(|dt| {
+                let created_secs = dt.timestamp() as f64;
+                (now_secs - created_secs) / (7.0 * 86400.0)
+            })
+            .unwrap_or(52.0);
 
         resonance as f64 * 0.95_f64.powf(weeks)
     }

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -3004,7 +3004,11 @@ impl SurrealDatabase {
         let stale_high_res = row["stale_high_res"].as_i64().unwrap_or(0);
 
         let pct = |n: i64| -> i64 {
-            if total == 0 { 0 } else { (n * 100 + total / 2) / total }
+            if total == 0 {
+                0
+            } else {
+                (n * 100 + total / 2) / total
+            }
         };
 
         Ok(serde_json::json!({
@@ -3049,7 +3053,8 @@ impl SurrealDatabase {
         };
 
         // Build a sorted map from week_bucket -> count
-        let mut bucket_map: std::collections::BTreeMap<i64, i64> = std::collections::BTreeMap::new();
+        let mut bucket_map: std::collections::BTreeMap<i64, i64> =
+            std::collections::BTreeMap::new();
         for row in &results {
             let bucket = row["week_bucket"].as_i64().unwrap_or(0);
             let cnt = row["cnt"].as_i64().unwrap_or(0);
@@ -3120,7 +3125,9 @@ impl SurrealDatabase {
                 }
 
                 let summary_raw = &row["summary"];
-                let state = if summary_raw.is_null() || summary_raw.is_string() && summary_raw.as_str().unwrap_or("").is_empty() {
+                let state = if summary_raw.is_null()
+                    || summary_raw.is_string() && summary_raw.as_str().unwrap_or("").is_empty()
+                {
                     "open".to_string()
                 } else {
                     let s: serde_json::Value = if let Some(s) = summary_raw.as_str() {
@@ -3175,11 +3182,9 @@ impl SurrealDatabase {
 
     /// Decay-weighted score: resonance * 0.95^weeks_old
     fn decay_score(resonance: i64, created_at: &str, now_secs: f64) -> f64 {
-        let created_secs = chrono::DateTime::parse_from_rfc3339(
-            &created_at.replace('Z', "+00:00"),
-        )
-        .map(|dt| dt.timestamp() as f64)
-        .unwrap_or(0.0);
+        let created_secs = chrono::DateTime::parse_from_rfc3339(&created_at.replace('Z', "+00:00"))
+            .map(|dt| dt.timestamp() as f64)
+            .unwrap_or(0.0);
 
         let weeks = if created_secs > 0.0 {
             (now_secs - created_secs) / (7.0 * 86400.0)

--- a/src/surreal_db.rs
+++ b/src/surreal_db.rs
@@ -2966,6 +2966,230 @@ impl SurrealDatabase {
         Ok(count)
     }
 
+    /// Graph health vitality percentages.
+    ///
+    /// Returns a JSON object:
+    ///   { "total": N, "embedded": N, "anchored": N, "stale_high_res": N,
+    ///     "embedded_pct": N, "anchored_pct": N, "stale_high_res_pct": N }
+    ///
+    /// Counts:
+    ///   embedded      — entries with a non-null embedding vector
+    ///   anchored      — entries with at least one anchor relationship
+    ///   stale_high_res — high-resonance entries (resonance >= 5) not activated
+    ///                   in the last 30 days (potentially stale knowledge)
+    pub fn graph_health(&self) -> Result<serde_json::Value> {
+        Self::runtime().block_on(self.graph_health_async())
+    }
+
+    async fn graph_health_async(&self) -> Result<serde_json::Value> {
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT
+                    count() AS total,
+                    count(embedding IS NOT NONE) AS embedded,
+                    count(anchors IS NOT NONE AND array::len(anchors) > 0) AS anchored,
+                    count(last_activated < time::now() - duration::from::days(30) AND resonance >= 5) AS stale_high_res
+                FROM knowledge GROUP ALL",
+            )
+            .await
+            .context("Failed to query graph health")
+        })?;
+
+        let results: Vec<serde_json::Value> = response.take(0)?;
+        let row = results.into_iter().next().unwrap_or_default();
+
+        let total = row["total"].as_i64().unwrap_or(0);
+        let embedded = row["embedded"].as_i64().unwrap_or(0);
+        let anchored = row["anchored"].as_i64().unwrap_or(0);
+        let stale_high_res = row["stale_high_res"].as_i64().unwrap_or(0);
+
+        let pct = |n: i64| -> i64 {
+            if total == 0 { 0 } else { (n * 100 + total / 2) / total }
+        };
+
+        Ok(serde_json::json!({
+            "total": total,
+            "embedded": embedded,
+            "anchored": anchored,
+            "stale_high_res": stale_high_res,
+            "embedded_pct": pct(embedded),
+            "anchored_pct": pct(anchored),
+            "stale_high_res_pct": pct(stale_high_res),
+        }))
+    }
+
+    /// Per-week entry counts over the last 8 weeks (oldest to newest).
+    ///
+    /// Returns a JSON array of up to 8 integers.  Weeks with no entries are
+    /// represented as 0.  The array is always exactly 8 elements, padded with
+    /// leading zeros when fewer than 8 weeks of data exist.
+    pub fn growth_sparkline(&self) -> Result<serde_json::Value> {
+        Self::runtime().block_on(self.growth_sparkline_async())
+    }
+
+    async fn growth_sparkline_async(&self) -> Result<serde_json::Value> {
+        // Aggregated GROUP BY approach.
+        // Uses the same duration syntax as the working recent-facts queries.
+        // GROUP BY on the projected alias.
+        let results: Vec<serde_json::Value> = {
+            let mut response = with_db!(self, db, {
+                db.query(
+                    "SELECT
+                        (<int>time::unix(<datetime>created_at) / 604800) AS week_bucket,
+                        count() AS cnt
+                    FROM knowledge
+                    WHERE created_at > time::now() - duration::from::days(56)
+                    GROUP BY week_bucket
+                    ORDER BY week_bucket",
+                )
+                .await
+                .context("Failed to query growth sparkline")
+            })?;
+            response.take(0).unwrap_or_default()
+        };
+
+        // Build a sorted map from week_bucket -> count
+        let mut bucket_map: std::collections::BTreeMap<i64, i64> = std::collections::BTreeMap::new();
+        for row in &results {
+            let bucket = row["week_bucket"].as_i64().unwrap_or(0);
+            let cnt = row["cnt"].as_i64().unwrap_or(0);
+            bucket_map.insert(bucket, cnt);
+        }
+
+        // Fill 8 contiguous buckets ending at current week
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let current_bucket = now_secs / 604800;
+
+        let counts: Vec<i64> = (0i64..8)
+            .map(|offset| {
+                let bucket = current_bucket - (7 - offset);
+                *bucket_map.get(&bucket).unwrap_or(&0)
+            })
+            .collect();
+
+        Ok(serde_json::json!(counts))
+    }
+
+    /// Open threads: knowledge entries with category:thread that are not closed.
+    ///
+    /// Returns a JSON array sorted by decay-weighted score (resonance * 0.95^weeks_old),
+    /// newest/highest-resonance first.  Each element contains the fields the dashboard
+    /// thread widget needs: id, body, state, created_at, resonance, tags.
+    ///
+    /// Open = summary IS NONE OR summary.state IS NONE OR summary.state = "open"
+    pub fn open_threads(&self) -> Result<serde_json::Value> {
+        Self::runtime().block_on(self.open_threads_async())
+    }
+
+    async fn open_threads_async(&self) -> Result<serde_json::Value> {
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT
+                    meta::id(id) AS id,
+                    body,
+                    summary,
+                    <string>created_at AS created_at,
+                    resonance,
+                    ->tagged_with->tag.name AS tags
+                FROM knowledge
+                WHERE category = category:thread
+                  AND (summary IS NONE OR summary.state IS NONE OR summary.state = 'open')
+                ORDER BY created_at DESC",
+            )
+            .await
+            .context("Failed to query open threads")
+        })?;
+
+        let rows: Vec<serde_json::Value> = response.take(0).unwrap_or_default();
+
+        // Parse state from summary JSON; build output with stable shape
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as f64)
+            .unwrap_or(0.0);
+
+        let mut threads: Vec<serde_json::Value> = rows
+            .into_iter()
+            .filter_map(|row| {
+                let id = row["id"].as_str().unwrap_or("").to_string();
+                if id.is_empty() {
+                    return None;
+                }
+
+                let summary_raw = &row["summary"];
+                let state = if summary_raw.is_null() || summary_raw.is_string() && summary_raw.as_str().unwrap_or("").is_empty() {
+                    "open".to_string()
+                } else {
+                    let s: serde_json::Value = if let Some(s) = summary_raw.as_str() {
+                        serde_json::from_str(s).unwrap_or(serde_json::Value::Null)
+                    } else {
+                        summary_raw.clone()
+                    };
+                    s.get("state")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("open")
+                        .to_string()
+                };
+
+                // After DB-side WHERE filter this should always be "open", but guard anyway
+                if state != "open" {
+                    return None;
+                }
+
+                let resonance = row["resonance"].as_i64().unwrap_or(0);
+                let created_at = row["created_at"].as_str().unwrap_or("").to_string();
+                let tags = row["tags"].clone();
+
+                Some(serde_json::json!({
+                    "id": format!("kn-{}", id),
+                    "body": row["body"],
+                    "state": state,
+                    "created_at": created_at,
+                    "resonance": resonance,
+                    "tags": tags,
+                    // Include decay score for client-side sort verification
+                    "_score": Self::decay_score(resonance, &created_at, now_secs),
+                }))
+            })
+            .collect();
+
+        // Sort by decay-weighted score descending
+        threads.sort_by(|a, b| {
+            let sa = a["_score"].as_f64().unwrap_or(0.0);
+            let sb = b["_score"].as_f64().unwrap_or(0.0);
+            sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Strip the internal _score field before returning
+        for t in &mut threads {
+            if let Some(obj) = t.as_object_mut() {
+                obj.remove("_score");
+            }
+        }
+
+        Ok(serde_json::json!(threads))
+    }
+
+    /// Decay-weighted score: resonance * 0.95^weeks_old
+    fn decay_score(resonance: i64, created_at: &str, now_secs: f64) -> f64 {
+        let created_secs = chrono::DateTime::parse_from_rfc3339(
+            &created_at.replace('Z', "+00:00"),
+        )
+        .map(|dt| dt.timestamp() as f64)
+        .unwrap_or(0.0);
+
+        let weeks = if created_secs > 0.0 {
+            (now_secs - created_secs) / (7.0 * 86400.0)
+        } else {
+            0.0
+        };
+
+        resonance as f64 * 0.95_f64.powf(weeks)
+    }
+
     /// List all knowledge entries
     pub fn list_all(&self, ctx: &crate::store::AgentContext) -> Result<Vec<KnowledgeEntry>> {
         Self::runtime().block_on(self.list_all_async(ctx))


### PR DESCRIPTION
## Summary

Two feature areas that were in-flight, stashed, and forgotten. Finishing the landing.

### Codex archive format detection
- `read_session` and `search_archives` now handle both `session.jsonl` (legacy) and `conversation.md` (post-March-31 clean-mode archives)
- Adds `archive_source()` helper
- Two tests including a real-archive cross-reference rail

### Graph observability endpoints
- `mx memory health` — embedding/anchor/stale-high-res vitality percentages
- `mx memory growth` — 8-week entry growth sparkline array
- `mx memory open-threads` — thread-category entries with decay-weighted scoring
- Plus `decay_score()` helper

## Test plan

- [ ] `mx memory health` returns vitality percentages
- [ ] `mx memory growth` returns 8-week sparkline array
- [ ] `mx memory open-threads` returns thread entries with decay scoring
- [ ] `mx codex read-session` works on both jsonl and md archives
- [ ] Existing tests still pass