### PR TITLE
pin nebuchadnezzar workflows to @v1

### DIFF
--- a/.github/workflows/follow-the-white-rabbit.yml
+++ b/.github/workflows/follow-the-white-rabbit.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    uses: coryzibell/nebuchadnezzar/.github/workflows/follow-the-white-rabbit.yml@main
+    uses: coryzibell/nebuchadnezzar/.github/workflows/follow-the-white-rabbit.yml@v1
     with:
       needs-openssl: false
       # ONNX Runtime doesn't provide prebuilt binaries for musl or FreeBSD targets

--- a/.github/workflows/knock-knock.yml
+++ b/.github/workflows/knock-knock.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   publish:
-    uses: coryzibell/nebuchadnezzar/.github/workflows/knock-knock.yml@main
+    uses: coryzibell/nebuchadnezzar/.github/workflows/knock-knock.yml@v1
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/wake-up.yml
+++ b/.github/workflows/wake-up.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   ci:
-    uses: coryzibell/nebuchadnezzar/.github/workflows/wake-up.yml@main
+    uses: coryzibell/nebuchadnezzar/.github/workflows/wake-up.yml@v1
     with:
       needs-openssl: false
     secrets:


### PR DESCRIPTION
## Summary
- Pin all reusable workflow references from `coryzibell/nebuchadnezzar/...@main` to `@v1`
- Follows the v1.0.0 release and floating `v1` tag creation in nebuchadnezzar

Refs: coryzibell/nebuchadnezzar#8, coryzibell/nebuchadnezzar#6