### PR TITLE
kv: add optional memory pointers to history, list, and state keys

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1529,6 +1529,10 @@ pub enum KvCommands {
     Get {
         /// Key name
         key: String,
+
+        /// Resolve and display linked memory entry (kn- reference)
+        #[arg(long)]
+        memory: bool,
     },
 
     /// Set a value (string/counter), or set a field on a state type
@@ -1537,10 +1541,14 @@ pub enum KvCommands {
         key: String,
 
         /// Value to set (for string/counter), or field name (for state type)
-        value: String,
+        value: Option<String>,
 
         /// Field value (only for state type: mx kv set <key> <field> <value>)
         field_value: Option<String>,
+
+        /// Link a memory entry (kn- ID) to this key, or "" to clear
+        #[arg(long)]
+        memory: Option<String>,
     },
 
     /// Increment a counter
@@ -1586,6 +1594,10 @@ pub enum KvCommands {
         /// Number of entries (default: 1)
         #[arg(long, default_value = "1")]
         count: usize,
+
+        /// Resolve and display linked memory entry (kn- reference)
+        #[arg(long)]
+        memory: bool,
     },
 
     /// Get history entries since a time reference (ISO-8601 or relative: 1h, 7d, 2w, 30m)
@@ -1595,6 +1607,10 @@ pub enum KvCommands {
 
         /// Time reference (e.g., "1h", "7d", "2w", "30m", or ISO-8601)
         timeref: String,
+
+        /// Resolve and display linked memory entry (kn- reference)
+        #[arg(long)]
+        memory: bool,
     },
 
     /// Dump all state
@@ -1602,6 +1618,10 @@ pub enum KvCommands {
         /// Output format: compact or json
         #[arg(long, default_value = "json", value_enum)]
         format: DumpFormat,
+
+        /// Resolve and display linked memory entries (kn- references)
+        #[arg(long)]
+        memory: bool,
     },
 
     /// Reset a key to its schema default
@@ -1634,6 +1654,10 @@ pub enum KvCommands {
 
         /// Search query (case-insensitive substring)
         query: String,
+
+        /// Resolve and display linked memory entry (kn- reference)
+        #[arg(long)]
+        memory: bool,
     },
 
     /// Count entries in a list/history, optionally filtered

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -29,8 +29,73 @@ fn handle_kv_err(err: KvError) -> Result<i32> {
     }
 }
 
+/// Resolve and display a memory pointer for a key.
+/// Connects to SurrealDB, fetches the kn- entry, and prints it.
+/// Failures are non-fatal: KV data is primary.
+fn resolve_memory(store: &KvStore, key: &str, verbose: bool) {
+    let mem = match store.get_memory(key) {
+        Ok(Some(m)) => m.to_string(),
+        Ok(None) => return,
+        Err(_) => return, // type mismatch or not found — silently skip
+    };
+
+    print_resolved_memory(&mem, verbose);
+}
+
+/// Fetch and display a single memory entry by kn- ID.
+fn print_resolved_memory(kn_id: &str, verbose: bool) {
+    use crate::index::IndexConfig;
+    use crate::store::{self, AgentContext};
+
+    let config = IndexConfig::default();
+    let db = match store::create_store_with_verbose(&config.db_path, verbose) {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!("Warning: could not connect to memory store: {}", e);
+            return;
+        }
+    };
+
+    let ctx = match std::env::var("MX_CURRENT_AGENT") {
+        Ok(agent) if !agent.is_empty() => AgentContext::for_agent(agent),
+        _ => AgentContext::public_only(),
+    };
+
+    match db.get(kn_id, &ctx) {
+        Ok(Some(entry)) => {
+            println!();
+            println!("Memory ({}):", kn_id);
+            println!("  Title:    {}", entry.title);
+            println!("  Category: {}", entry.category_id);
+            if let Some(body) = &entry.body {
+                // Indent body content
+                for line in body.lines() {
+                    println!("  {}", line);
+                }
+            }
+        }
+        Ok(None) => {
+            eprintln!("Warning: memory entry {} not found", kn_id);
+        }
+        Err(e) => {
+            eprintln!("Warning: failed to fetch memory entry {}: {}", kn_id, e);
+        }
+    }
+}
+
+/// Resolve memory pointers for all keys in a dump.
+fn resolve_dump_memories(store: &KvStore, verbose: bool) {
+    for (key, _vtype) in store.keys() {
+        if let Ok(Some(mem)) = store.get_memory(key) {
+            println!();
+            println!("--- {} ---", key);
+            print_resolved_memory(mem, verbose);
+        }
+    }
+}
+
 /// Handle all `mx kv` subcommands. Returns the exit code directly.
-pub(crate) fn handle_kv(cmd: KvCommands) -> Result<i32> {
+pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
     let mut store = match KvStore::from_env() {
         Ok(s) => s,
         Err(e) => {
@@ -44,9 +109,12 @@ pub(crate) fn handle_kv(cmd: KvCommands) -> Result<i32> {
     };
 
     match cmd {
-        KvCommands::Get { key } => match store.get(&key) {
+        KvCommands::Get { key, memory } => match store.get(&key) {
             Ok(val) => {
                 println!("{}", kv::format_value(val));
+                if memory {
+                    resolve_memory(&store, &key, verbose);
+                }
                 Ok(kv::EXIT_OK)
             }
             Err(e) => handle_kv_err(e),
@@ -56,23 +124,66 @@ pub(crate) fn handle_kv(cmd: KvCommands) -> Result<i32> {
             key,
             value,
             field_value,
+            memory,
         } => {
-            // For state types: mx kv set <key> <field> <value>
-            // value = field name, field_value = actual value
-            // For string/counter: mx kv set <key> <value>
-            let result = if let Some(fv) = &field_value {
-                store.set(&key, fv, Some(&value))
-            } else {
-                store.set(&key, &value, None)
-            };
+            let mut did_something = false;
 
-            match result {
-                Ok(()) => {
-                    store.save()?;
-                    Ok(kv::EXIT_OK)
+            // Handle the value set (if a value was provided)
+            if let Some(ref val) = value {
+                // For state types: mx kv set <key> <field> <value>
+                // value = field name, field_value = actual value
+                // For string/counter: mx kv set <key> <value>
+                let result = if let Some(fv) = &field_value {
+                    store.set(&key, fv, Some(val))
+                } else {
+                    store.set(&key, val, None)
+                };
+
+                match result {
+                    Ok(()) => {
+                        did_something = true;
+                    }
+                    Err(e) => {
+                        // If --memory was also provided, still try the memory set
+                        // only if the type mismatch is because it's a history/list
+                        // (set doesn't normally work on those). Otherwise, propagate error.
+                        if memory.is_none() {
+                            return handle_kv_err(e);
+                        }
+                        // Type mismatch on history/list is expected when only --memory is provided
+                        match &e {
+                            KvError::TypeMismatch { .. } => {
+                                // Allow falling through to memory-only set
+                            }
+                            _ => return handle_kv_err(e),
+                        }
+                    }
                 }
-                Err(e) => handle_kv_err(e),
             }
+
+            // Handle the memory pointer (if --memory was provided)
+            if let Some(mem_val) = memory {
+                let mem = if mem_val.is_empty() {
+                    None
+                } else {
+                    Some(mem_val)
+                };
+                match store.set_memory(&key, mem) {
+                    Ok(()) => {
+                        did_something = true;
+                    }
+                    Err(e) => return handle_kv_err(e),
+                }
+            }
+
+            if !did_something {
+                // Neither value nor memory was set — need at least one
+                eprintln!("Error: provide a value or --memory");
+                return Ok(kv::EXIT_KEY_NOT_FOUND);
+            }
+
+            store.save()?;
+            Ok(kv::EXIT_OK)
         }
 
         KvCommands::Inc { key, by } => match store.inc(&key, by) {
@@ -118,27 +229,37 @@ pub(crate) fn handle_kv(cmd: KvCommands) -> Result<i32> {
             Err(e) => handle_kv_err(e),
         },
 
-        KvCommands::Last { key, count } => match store.last(&key, count) {
+        KvCommands::Last { key, count, memory } => match store.last(&key, count) {
             Ok(items) => {
                 for item in &items {
                     println!("{}", item);
                 }
-                Ok(kv::EXIT_OK)
-            }
-            Err(e) => handle_kv_err(e),
-        },
-
-        KvCommands::Since { key, timeref } => match store.since(&key, &timeref) {
-            Ok(entries) => {
-                for entry in &entries {
-                    println!("{}: {} ({})", entry.id, entry.value, entry.ts);
+                if memory {
+                    resolve_memory(&store, &key, verbose);
                 }
                 Ok(kv::EXIT_OK)
             }
             Err(e) => handle_kv_err(e),
         },
 
-        KvCommands::Dump { format } => {
+        KvCommands::Since {
+            key,
+            timeref,
+            memory,
+        } => match store.since(&key, &timeref) {
+            Ok(entries) => {
+                for entry in &entries {
+                    println!("{}: {} ({})", entry.id, entry.value, entry.ts);
+                }
+                if memory {
+                    resolve_memory(&store, &key, verbose);
+                }
+                Ok(kv::EXIT_OK)
+            }
+            Err(e) => handle_kv_err(e),
+        },
+
+        KvCommands::Dump { format, memory } => {
             match format {
                 DumpFormat::Compact => {
                     println!("{}", store.dump_compact());
@@ -146,6 +267,9 @@ pub(crate) fn handle_kv(cmd: KvCommands) -> Result<i32> {
                 DumpFormat::Json => {
                     println!("{}", store.dump_json()?);
                 }
+            }
+            if memory {
+                resolve_dump_memories(&store, verbose);
             }
             Ok(kv::EXIT_OK)
         }
@@ -186,7 +310,11 @@ pub(crate) fn handle_kv(cmd: KvCommands) -> Result<i32> {
             }
         }
 
-        KvCommands::Search { key, query } => match store.search(&key, &query) {
+        KvCommands::Search {
+            key,
+            query,
+            memory,
+        } => match store.search(&key, &query) {
             Ok(hits) => {
                 if hits.is_empty() {
                     eprintln!("No matching entries");
@@ -198,6 +326,9 @@ pub(crate) fn handle_kv(cmd: KvCommands) -> Result<i32> {
                         } else {
                             println!("{}: {} ({})", hit.id, hit.value, hit.ts);
                         }
+                    }
+                    if memory {
+                        resolve_memory(&store, &key, verbose);
                     }
                     Ok(kv::EXIT_OK)
                 }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -310,11 +310,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             }
         }
 
-        KvCommands::Search {
-            key,
-            query,
-            memory,
-        } => match store.search(&key, &query) {
+        KvCommands::Search { key, query, memory } => match store.search(&key, &query) {
             Ok(hits) => {
                 if hits.is_empty() {
                     eprintln!("No matching entries");

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -154,6 +154,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         match &e {
                             KvError::TypeMismatch { .. } => {
                                 // Allow falling through to memory-only set
+                                eprintln!("Warning: value not set (type does not support set); memory pointer updated");
                             }
                             _ => return handle_kv_err(e),
                         }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -154,7 +154,9 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         match &e {
                             KvError::TypeMismatch { .. } => {
                                 // Allow falling through to memory-only set
-                                eprintln!("Warning: value not set (type does not support set); memory pointer updated");
+                                eprintln!(
+                                    "Warning: value not set (type does not support set); memory pointer updated"
+                                );
                             }
                             _ => return handle_kv_err(e),
                         }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -152,9 +152,21 @@ pub struct DataFile {
 pub enum DataValue {
     Counter { value: i64 },
     String { value: String },
-    History { entries: Vec<HistoryEntry> },
-    State { fields: BTreeMap<String, String> },
-    List { items: Vec<ListEntry> },
+    History {
+        entries: Vec<HistoryEntry>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        memory: Option<String>,
+    },
+    State {
+        fields: BTreeMap<String, String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        memory: Option<String>,
+    },
+    List {
+        items: Vec<ListEntry>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        memory: Option<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -174,9 +186,21 @@ enum RawListItem {
 #[serde(untagged)]
 enum DataValueDe {
     Counter { value: i64 },
-    History { entries: Vec<HistoryEntry> },
-    State { fields: BTreeMap<String, String> },
-    List { items: Vec<RawListItem> },
+    History {
+        entries: Vec<HistoryEntry>,
+        #[serde(default)]
+        memory: Option<String>,
+    },
+    State {
+        fields: BTreeMap<String, String>,
+        #[serde(default)]
+        memory: Option<String>,
+    },
+    List {
+        items: Vec<RawListItem>,
+        #[serde(default)]
+        memory: Option<String>,
+    },
     // String must be last in untagged — it's the broadest match
     String { value: String },
 }
@@ -190,7 +214,7 @@ impl<'de> Deserialize<'de> for DataValue {
         Ok(match raw {
             DataValueDe::Counter { value } => DataValue::Counter { value },
             DataValueDe::String { value } => DataValue::String { value },
-            DataValueDe::History { entries } => {
+            DataValueDe::History { entries, memory } => {
                 // Back-fill IDs for history entries loaded with id=0 (old data)
                 let mut max_id = entries.iter().map(|e| e.id).max().unwrap_or(0);
                 let entries = entries
@@ -203,10 +227,10 @@ impl<'de> Deserialize<'de> for DataValue {
                         e
                     })
                     .collect();
-                DataValue::History { entries }
+                DataValue::History { entries, memory }
             }
-            DataValueDe::State { fields } => DataValue::State { fields },
-            DataValueDe::List { items } => {
+            DataValueDe::State { fields, memory } => DataValue::State { fields, memory },
+            DataValueDe::List { items, memory } => {
                 let mut next_id = 0u64;
                 let entries: Vec<ListEntry> = items
                     .into_iter()
@@ -227,7 +251,7 @@ impl<'de> Deserialize<'de> for DataValue {
                         }
                     })
                     .collect();
-                DataValue::List { items: entries }
+                DataValue::List { items: entries, memory }
             }
         })
     }
@@ -421,6 +445,7 @@ impl KvStore {
             },
             ValueType::History => DataValue::History {
                 entries: Vec::new(),
+                memory: None,
             },
             ValueType::State => {
                 let fields = def
@@ -428,9 +453,9 @@ impl KvStore {
                     .as_ref()
                     .map(|fs| fs.iter().map(|f| (f.clone(), String::new())).collect())
                     .unwrap_or_default();
-                DataValue::State { fields }
+                DataValue::State { fields, memory: None }
             }
-            ValueType::List => DataValue::List { items: Vec::new() },
+            ValueType::List => DataValue::List { items: Vec::new(), memory: None },
         }
     }
 
@@ -499,7 +524,7 @@ impl KvStore {
                     .or_insert_with(|| Self::default_value(&def));
 
                 match entry {
-                    DataValue::State { fields } => {
+                    DataValue::State { fields, .. } => {
                         fields.insert(field_name.to_string(), value.to_string());
                     }
                     _ => {
@@ -589,7 +614,7 @@ impl KvStore {
                     .or_insert_with(|| Self::default_value(&def));
 
                 match entry {
-                    DataValue::History { entries } => {
+                    DataValue::History { entries, .. } => {
                         let next_id = entries.iter().map(|e| e.id).max().unwrap_or(0) + 1;
                         entries.insert(
                             0,
@@ -620,7 +645,7 @@ impl KvStore {
                     .or_insert_with(|| Self::default_value(&def));
 
                 match entry {
-                    DataValue::List { items } => {
+                    DataValue::List { items, .. } => {
                         let next_id = items.iter().map(|e| e.id).max().unwrap_or(0) + 1;
                         items.push(ListEntry {
                             id: next_id,
@@ -659,7 +684,7 @@ impl KvStore {
         self.assert_type(key, ValueType::List)?;
 
         match self.data.entries.get_mut(key) {
-            Some(DataValue::List { items }) => Ok(items.pop()),
+            Some(DataValue::List { items, .. }) => Ok(items.pop()),
             Some(_) => Err(KvError::Other(anyhow::anyhow!(
                 "Data corruption: key '{}' has wrong runtime type",
                 key
@@ -674,7 +699,7 @@ impl KvStore {
 
         match def.value_type {
             ValueType::History => match self.data.entries.get(key) {
-                Some(DataValue::History { entries }) => Ok(entries
+                Some(DataValue::History { entries, .. }) => Ok(entries
                     .iter()
                     .take(count)
                     .map(|e| format!("{}: {} ({})", e.id, e.value, e.ts))
@@ -682,7 +707,7 @@ impl KvStore {
                 _ => Ok(vec![]),
             },
             ValueType::List => match self.data.entries.get(key) {
-                Some(DataValue::List { items }) => {
+                Some(DataValue::List { items, .. }) => {
                     let start = items.len().saturating_sub(count);
                     Ok(items[start..]
                         .iter()
@@ -712,7 +737,7 @@ impl KvStore {
         let cutoff = parse_timeref(timeref).map_err(KvError::Other)?;
 
         match self.data.entries.get(key) {
-            Some(DataValue::History { entries }) => Ok(entries
+            Some(DataValue::History { entries, .. }) => Ok(entries
                 .iter()
                 .filter(|e| {
                     DateTime::parse_from_rfc3339(&e.ts)
@@ -760,7 +785,7 @@ impl KvStore {
         let mut removed = Vec::new();
 
         match self.data.entries.get_mut(key) {
-            Some(DataValue::History { entries }) => {
+            Some(DataValue::History { entries, .. }) => {
                 if let Some(id) = by_id {
                     if let Some(pos) = entries.iter().position(|e| e.id == id) {
                         removed.push(entries.remove(pos).value);
@@ -778,7 +803,7 @@ impl KvStore {
                     });
                 }
             }
-            Some(DataValue::List { items }) => {
+            Some(DataValue::List { items, .. }) => {
                 if let Some(id) = by_id {
                     if let Some(pos) = items.iter().position(|e| e.id == id) {
                         removed.push(items.remove(pos).value);
@@ -820,7 +845,7 @@ impl KvStore {
         let mut hits = Vec::new();
 
         match self.data.entries.get(key) {
-            Some(DataValue::History { entries }) => {
+            Some(DataValue::History { entries, .. }) => {
                 for e in entries {
                     if e.value.to_lowercase().contains(&query_lower) {
                         hits.push(SearchHit {
@@ -831,7 +856,7 @@ impl KvStore {
                     }
                 }
             }
-            Some(DataValue::List { items }) => {
+            Some(DataValue::List { items, .. }) => {
                 for e in items {
                     if e.value.to_lowercase().contains(&query_lower) {
                         hits.push(SearchHit {
@@ -867,7 +892,7 @@ impl KvStore {
         let mut latest_ts: Option<String> = None;
 
         match self.data.entries.get(key) {
-            Some(DataValue::History { entries }) => {
+            Some(DataValue::History { entries, .. }) => {
                 for e in entries {
                     let matches = match &query_lower {
                         Some(q) => e.value.to_lowercase().contains(q),
@@ -881,7 +906,7 @@ impl KvStore {
                     }
                 }
             }
-            Some(DataValue::List { items }) => {
+            Some(DataValue::List { items, .. }) => {
                 for e in items {
                     let matches = match &query_lower {
                         Some(q) => e.value.to_lowercase().contains(q),
@@ -933,6 +958,64 @@ impl KvStore {
     }
 
     // -----------------------------------------------------------------------
+    // Memory pointer operations
+    // -----------------------------------------------------------------------
+
+    /// Set the memory pointer (kn- reference) on a history, list, or state key.
+    /// Pass `None` to clear the pointer.
+    pub fn set_memory(&mut self, key: &str, memory: Option<String>) -> Result<(), KvError> {
+        let def = self.key_def(key)?;
+        match def.value_type {
+            ValueType::History | ValueType::List | ValueType::State => {}
+            _ => {
+                return Err(KvError::TypeMismatch {
+                    key: key.to_string(),
+                    expected: "history, list, or state".to_string(),
+                    got: def.value_type.to_string(),
+                });
+            }
+        }
+
+        let def = def.clone();
+        let entry = self
+            .data
+            .entries
+            .entry(key.to_string())
+            .or_insert_with(|| Self::default_value(&def));
+
+        // Normalize empty string to None (clearing the link)
+        let memory = memory.filter(|s| !s.is_empty());
+
+        match entry {
+            DataValue::History { memory: mem, .. } => *mem = memory,
+            DataValue::List { memory: mem, .. } => *mem = memory,
+            DataValue::State { memory: mem, .. } => *mem = memory,
+            _ => unreachable!(),
+        }
+
+        Ok(())
+    }
+
+    /// Get the memory pointer for a key, if set.
+    pub fn get_memory(&self, key: &str) -> Result<Option<&str>, KvError> {
+        self.key_def(key)?; // validate key exists in schema
+
+        match self.data.entries.get(key) {
+            Some(DataValue::History { memory, .. }) => Ok(memory.as_deref()),
+            Some(DataValue::List { memory, .. }) => Ok(memory.as_deref()),
+            Some(DataValue::State { memory, .. }) => Ok(memory.as_deref()),
+            Some(DataValue::Counter { .. } | DataValue::String { .. }) => {
+                Err(KvError::TypeMismatch {
+                    key: key.to_string(),
+                    expected: "history, list, or state".to_string(),
+                    got: "counter or string".to_string(),
+                })
+            }
+            None => Ok(None),
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
 
@@ -956,7 +1039,7 @@ fn format_compact(key: &str, value: &DataValue, def: &KeyDef) -> String {
     match value {
         DataValue::Counter { value } => format!("{}={}", key, value),
         DataValue::String { value } => format!("{}={}", key, value),
-        DataValue::History { entries } => {
+        DataValue::History { entries, memory, .. } => {
             let items: Vec<String> = entries
                 .iter()
                 .map(|e| {
@@ -966,9 +1049,13 @@ fn format_compact(key: &str, value: &DataValue, def: &KeyDef) -> String {
                     format!("{}@{}", e.value, time_part)
                 })
                 .collect();
-            format!("{}=[{}]", key, items.join(","))
+            let base = format!("{}=[{}]", key, items.join(","));
+            match memory {
+                Some(m) if !m.is_empty() => format!("{}({})", base, m),
+                _ => base,
+            }
         }
-        DataValue::State { fields } => {
+        DataValue::State { fields, memory, .. } => {
             // Values only, ordered by schema field order
             let values: Vec<String> = def
                 .fields
@@ -980,9 +1067,13 @@ fn format_compact(key: &str, value: &DataValue, def: &KeyDef) -> String {
                         .collect()
                 })
                 .unwrap_or_else(|| fields.values().cloned().collect());
-            format!("{}={{{}}}", key, values.join(","))
+            let base = format!("{}={{{}}}", key, values.join(","));
+            match memory {
+                Some(m) if !m.is_empty() => format!("{}({})", base, m),
+                _ => base,
+            }
         }
-        DataValue::List { items } => {
+        DataValue::List { items, memory, .. } => {
             let formatted: Vec<String> = items
                 .iter()
                 .map(|e| {
@@ -996,7 +1087,11 @@ fn format_compact(key: &str, value: &DataValue, def: &KeyDef) -> String {
                     }
                 })
                 .collect();
-            format!("{}=[{}]", key, formatted.join(","))
+            let base = format!("{}=[{}]", key, formatted.join(","));
+            match memory {
+                Some(m) if !m.is_empty() => format!("{}({})", base, m),
+                _ => base,
+            }
         }
     }
 }
@@ -1052,15 +1147,15 @@ pub fn format_value(value: &DataValue) -> String {
     match value {
         DataValue::Counter { value } => value.to_string(),
         DataValue::String { value } => value.clone(),
-        DataValue::History { entries } => entries
+        DataValue::History { entries, .. } => entries
             .iter()
             .map(|e| format!("{}: {} ({})", e.id, e.value, e.ts))
             .collect::<Vec<_>>()
             .join("\n"),
-        DataValue::State { fields } => {
+        DataValue::State { fields, .. } => {
             serde_json::to_string_pretty(fields).unwrap_or_else(|_| "{}".to_string())
         }
-        DataValue::List { items } => items
+        DataValue::List { items, .. } => items
             .iter()
             .map(|e| {
                 if e.ts.is_empty() {
@@ -1224,7 +1319,7 @@ max_entries = 5
         store.set("tensor", "0.75", Some("temperature")).unwrap();
         store.set("tensor", "0.30", Some("entropy")).unwrap();
         match store.get("tensor").unwrap() {
-            DataValue::State { fields } => {
+            DataValue::State { fields, .. } => {
                 assert_eq!(fields["temperature"], "0.75");
                 assert_eq!(fields["entropy"], "0.30");
             }
@@ -1275,7 +1370,7 @@ max_entries = 5
         store.push("flavor_history", "d").unwrap();
 
         match store.get("flavor_history").unwrap() {
-            DataValue::History { entries } => {
+            DataValue::History { entries, .. } => {
                 assert_eq!(entries.len(), 3);
                 assert_eq!(entries[0].value, "d"); // newest first
                 assert_eq!(entries[2].value, "b"); // oldest kept
@@ -1332,7 +1427,7 @@ max_entries = 5
             store.push("tags", &format!("item_{}", i)).unwrap();
         }
         match store.get("tags").unwrap() {
-            DataValue::List { items } => {
+            DataValue::List { items, .. } => {
                 assert_eq!(items.len(), 5);
                 assert_eq!(items[0].value, "item_3"); // oldest kept
                 assert_eq!(items[4].value, "item_7"); // newest
@@ -1403,7 +1498,7 @@ max_entries = 5
         store.push("flavor_history", "test").unwrap();
         store.reset("flavor_history").unwrap();
         match store.get("flavor_history").unwrap() {
-            DataValue::History { entries } => assert!(entries.is_empty()),
+            DataValue::History { entries, .. } => assert!(entries.is_empty()),
             _ => panic!("Expected history"),
         }
     }
@@ -1587,7 +1682,7 @@ max_entries = 5
 
         // alpha-2 should still be there
         match store.get("tags").unwrap() {
-            DataValue::List { items } => {
+            DataValue::List { items, .. } => {
                 assert_eq!(items.len(), 2);
                 assert_eq!(items[0].value, "beta");
                 assert_eq!(items[1].value, "alpha-2");
@@ -1607,7 +1702,7 @@ max_entries = 5
         assert_eq!(result.removed.len(), 2);
 
         match store.get("tags").unwrap() {
-            DataValue::List { items } => {
+            DataValue::List { items, .. } => {
                 assert_eq!(items.len(), 1);
                 assert_eq!(items[0].value, "beta");
             }
@@ -1624,7 +1719,7 @@ max_entries = 5
 
         // Get the ID of "beta"
         let beta_id = match store.get("tags").unwrap() {
-            DataValue::List { items } => items[1].id,
+            DataValue::List { items, .. } => items[1].id,
             _ => panic!("Expected list"),
         };
 
@@ -1646,7 +1741,7 @@ max_entries = 5
         assert_eq!(result.removed.len(), 1);
 
         match store.get("flavor_history").unwrap() {
-            DataValue::History { entries } => {
+            DataValue::History { entries, .. } => {
                 assert_eq!(entries.len(), 2);
             }
             _ => panic!("Expected history"),
@@ -1802,7 +1897,7 @@ max_entries = 5
         store.push("flavor_history", "c").unwrap();
 
         match store.get("flavor_history").unwrap() {
-            DataValue::History { entries } => {
+            DataValue::History { entries, .. } => {
                 // Each push should get a unique ID
                 let ids: Vec<u64> = entries.iter().map(|e| e.id).collect();
                 assert_eq!(ids.len(), 3);
@@ -1824,7 +1919,7 @@ max_entries = 5
         store.push("tags", "c").unwrap();
 
         match store.get("tags").unwrap() {
-            DataValue::List { items } => {
+            DataValue::List { items, .. } => {
                 assert_eq!(items[0].id, 1);
                 assert_eq!(items[1].id, 2);
                 assert_eq!(items[2].id, 3);
@@ -1847,7 +1942,7 @@ max_entries = 5
         store.push("tags", "d").unwrap();
 
         match store.get("tags").unwrap() {
-            DataValue::List { items } => {
+            DataValue::List { items, .. } => {
                 assert_eq!(items.len(), 3);
                 assert_eq!(items[0].id, 1); // a
                 assert_eq!(items[1].id, 3); // c
@@ -1879,7 +1974,7 @@ max_entries = 5
         let store = KvStore::load(&schema_path, &data_path).unwrap();
 
         match store.get("tags").unwrap() {
-            DataValue::List { items } => {
+            DataValue::List { items, .. } => {
                 assert_eq!(items.len(), 3);
                 assert_eq!(items[0].value, "alpha");
                 assert_eq!(items[1].value, "beta");
@@ -1919,7 +2014,7 @@ max_entries = 5
         let store = KvStore::load(&schema_path, &data_path).unwrap();
 
         match store.get("flavor_history").unwrap() {
-            DataValue::History { entries } => {
+            DataValue::History { entries, .. } => {
                 assert_eq!(entries.len(), 2);
                 assert_eq!(entries[0].value, "bergamot");
                 // Should have auto-assigned IDs
@@ -1943,7 +2038,7 @@ max_entries = 5
         store.push_with_ts("tags", "focus", ts).unwrap();
 
         match store.get("tags").unwrap() {
-            DataValue::List { items } => {
+            DataValue::List { items, .. } => {
                 assert_eq!(items.len(), 1);
                 assert!(items[0].ts.contains("2026-04-22"));
                 assert_eq!(items[0].value, "focus");
@@ -1996,4 +2091,304 @@ max_entries = 5
     }
 
     use chrono::Datelike as _;
+
+    // -- Memory pointer operations --
+
+    #[test]
+    fn set_get_memory_on_history() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "bergamot").unwrap();
+
+        // Initially no memory pointer
+        assert_eq!(store.get_memory("flavor_history").unwrap(), None);
+
+        // Set a memory pointer
+        store
+            .set_memory("flavor_history", Some("kn-abc123".to_string()))
+            .unwrap();
+        assert_eq!(
+            store.get_memory("flavor_history").unwrap(),
+            Some("kn-abc123")
+        );
+
+        // Verify it persists through save/reload
+        store.data.schema_id = "test".to_string();
+        store.save().unwrap();
+        let data_str = fs::read_to_string(&store.data_path).unwrap();
+        assert!(data_str.contains("kn-abc123"));
+    }
+
+    #[test]
+    fn set_get_memory_on_list() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha").unwrap();
+
+        store
+            .set_memory("tags", Some("kn-def456".to_string()))
+            .unwrap();
+        assert_eq!(store.get_memory("tags").unwrap(), Some("kn-def456"));
+    }
+
+    #[test]
+    fn set_get_memory_on_state() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.set("tensor", "0.5", Some("temperature")).unwrap();
+
+        store
+            .set_memory("tensor", Some("kn-789ghi".to_string()))
+            .unwrap();
+        assert_eq!(store.get_memory("tensor").unwrap(), Some("kn-789ghi"));
+    }
+
+    #[test]
+    fn set_memory_on_counter_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_memory("warmth", Some("kn-abc".to_string()));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Type mismatch"));
+    }
+
+    #[test]
+    fn set_memory_on_string_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_memory("current_mood", Some("kn-abc".to_string()));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Type mismatch"));
+    }
+
+    #[test]
+    fn get_memory_on_counter_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.inc("warmth", 1).unwrap();
+        let result = store.get_memory("warmth");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Type mismatch"));
+    }
+
+    #[test]
+    fn clear_memory_with_empty_string() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "bergamot").unwrap();
+
+        // Set then clear
+        store
+            .set_memory("flavor_history", Some("kn-abc123".to_string()))
+            .unwrap();
+        assert_eq!(
+            store.get_memory("flavor_history").unwrap(),
+            Some("kn-abc123")
+        );
+
+        // Clear with empty string
+        store
+            .set_memory("flavor_history", Some("".to_string()))
+            .unwrap();
+        assert_eq!(store.get_memory("flavor_history").unwrap(), None);
+    }
+
+    #[test]
+    fn clear_memory_with_none() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha").unwrap();
+
+        store
+            .set_memory("tags", Some("kn-abc123".to_string()))
+            .unwrap();
+        store.set_memory("tags", None).unwrap();
+        assert_eq!(store.get_memory("tags").unwrap(), None);
+    }
+
+    #[test]
+    fn memory_not_serialized_when_none() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "bergamot").unwrap();
+        store.data.schema_id = "test".to_string();
+        store.save().unwrap();
+
+        let data_str = fs::read_to_string(&store.data_path).unwrap();
+        // "memory" should NOT appear in JSON when it's None
+        assert!(!data_str.contains("\"memory\""));
+    }
+
+    #[test]
+    fn backward_compat_old_data_without_memory() {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        // Old-format data file without memory field
+        let old_data = r#"{
+            "_schema": "test",
+            "_updated": "2026-04-20T00:00:00Z",
+            "flavor_history": {
+                "entries": [
+                    {"id": 1, "value": "bergamot", "ts": "2026-04-22T19:13:00Z"}
+                ]
+            },
+            "tags": {
+                "items": [
+                    {"id": 1, "value": "focus", "ts": "2026-04-22T10:30:00Z"}
+                ]
+            },
+            "tensor": {
+                "fields": {"temperature": "0.55", "entropy": "0.35", "agency": "0.70"}
+            }
+        }"#;
+        fs::write(&data_path, old_data).unwrap();
+
+        let store = KvStore::load(&schema_path, &data_path).unwrap();
+
+        // All should deserialize cleanly with no memory pointer
+        assert_eq!(store.get_memory("flavor_history").unwrap(), None);
+        assert_eq!(store.get_memory("tags").unwrap(), None);
+        assert_eq!(store.get_memory("tensor").unwrap(), None);
+
+        // Data should still be accessible
+        match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].value, "bergamot");
+            }
+            _ => panic!("Expected history"),
+        }
+    }
+
+    #[test]
+    fn backward_compat_data_with_memory() {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        // Data file WITH memory field
+        let data = r#"{
+            "_schema": "test",
+            "_updated": "2026-04-20T00:00:00Z",
+            "flavor_history": {
+                "entries": [
+                    {"id": 1, "value": "bergamot", "ts": "2026-04-22T19:13:00Z"}
+                ],
+                "memory": "kn-abc123"
+            },
+            "tags": {
+                "items": [
+                    {"id": 1, "value": "focus", "ts": "2026-04-22T10:30:00Z"}
+                ],
+                "memory": "kn-def456"
+            }
+        }"#;
+        fs::write(&data_path, data).unwrap();
+
+        let store = KvStore::load(&schema_path, &data_path).unwrap();
+
+        assert_eq!(
+            store.get_memory("flavor_history").unwrap(),
+            Some("kn-abc123")
+        );
+        assert_eq!(store.get_memory("tags").unwrap(), Some("kn-def456"));
+    }
+
+    // -- Compact dump with memory pointers --
+
+    #[test]
+    fn compact_dump_with_memory_pointer() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let ts = DateTime::parse_from_rfc3339("2026-04-22T19:13:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        store
+            .push_with_ts("flavor_history", "bergamot", ts)
+            .unwrap();
+        store
+            .set_memory("flavor_history", Some("kn-def456".to_string()))
+            .unwrap();
+
+        store.set("tensor", "0.55", Some("temperature")).unwrap();
+        store.set("tensor", "0.35", Some("entropy")).unwrap();
+        store.set("tensor", "0.70", Some("agency")).unwrap();
+        store
+            .set_memory("tensor", Some("kn-789ghi".to_string()))
+            .unwrap();
+
+        let compact = store.dump_compact();
+        assert!(compact.contains("flavor_history=[bergamot@19:13](kn-def456)"));
+        assert!(compact.contains("tensor={0.55,0.35,0.70}(kn-789ghi)"));
+    }
+
+    #[test]
+    fn compact_dump_without_memory_pointer() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let ts = DateTime::parse_from_rfc3339("2026-04-22T19:13:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        store
+            .push_with_ts("flavor_history", "bergamot", ts)
+            .unwrap();
+        // No memory pointer set
+
+        let compact = store.dump_compact();
+        assert!(compact.contains("flavor_history=[bergamot@19:13]"));
+        // Should NOT contain parenthetical
+        assert!(!compact.contains("flavor_history=[bergamot@19:13]("));
+    }
+
+    #[test]
+    fn set_memory_on_nonexistent_data_creates_default() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        // No data for flavor_history yet, but set memory should initialize it
+        store
+            .set_memory("flavor_history", Some("kn-abc123".to_string()))
+            .unwrap();
+        assert_eq!(
+            store.get_memory("flavor_history").unwrap(),
+            Some("kn-abc123")
+        );
+
+        // Should have created default empty history
+        match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => assert!(entries.is_empty()),
+            _ => panic!("Expected history"),
+        }
+    }
+
+    #[test]
+    fn memory_survives_push() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "bergamot").unwrap();
+        store
+            .set_memory("flavor_history", Some("kn-abc123".to_string()))
+            .unwrap();
+
+        // Push another entry
+        store.push("flavor_history", "lapsang").unwrap();
+
+        // Memory pointer should still be set
+        assert_eq!(
+            store.get_memory("flavor_history").unwrap(),
+            Some("kn-abc123")
+        );
+    }
+
+    #[test]
+    fn memory_survives_reset() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "bergamot").unwrap();
+        store
+            .set_memory("flavor_history", Some("kn-abc123".to_string()))
+            .unwrap();
+
+        // Reset clears data to default — memory pointer should be cleared too
+        store.reset("flavor_history").unwrap();
+
+        // After reset, memory is gone (default_value has memory: None)
+        assert_eq!(store.get_memory("flavor_history").unwrap(), None);
+    }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -150,8 +150,12 @@ pub struct DataFile {
 #[derive(Debug, Serialize, Clone)]
 #[serde(untagged)]
 pub enum DataValue {
-    Counter { value: i64 },
-    String { value: String },
+    Counter {
+        value: i64,
+    },
+    String {
+        value: String,
+    },
     History {
         entries: Vec<HistoryEntry>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -185,7 +189,9 @@ enum RawListItem {
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum DataValueDe {
-    Counter { value: i64 },
+    Counter {
+        value: i64,
+    },
     History {
         entries: Vec<HistoryEntry>,
         #[serde(default)]
@@ -202,7 +208,9 @@ enum DataValueDe {
         memory: Option<String>,
     },
     // String must be last in untagged — it's the broadest match
-    String { value: String },
+    String {
+        value: String,
+    },
 }
 
 impl<'de> Deserialize<'de> for DataValue {
@@ -251,7 +259,10 @@ impl<'de> Deserialize<'de> for DataValue {
                         }
                     })
                     .collect();
-                DataValue::List { items: entries, memory }
+                DataValue::List {
+                    items: entries,
+                    memory,
+                }
             }
         })
     }
@@ -453,9 +464,15 @@ impl KvStore {
                     .as_ref()
                     .map(|fs| fs.iter().map(|f| (f.clone(), String::new())).collect())
                     .unwrap_or_default();
-                DataValue::State { fields, memory: None }
+                DataValue::State {
+                    fields,
+                    memory: None,
+                }
             }
-            ValueType::List => DataValue::List { items: Vec::new(), memory: None },
+            ValueType::List => DataValue::List {
+                items: Vec::new(),
+                memory: None,
+            },
         }
     }
 
@@ -1039,7 +1056,9 @@ fn format_compact(key: &str, value: &DataValue, def: &KeyDef) -> String {
     match value {
         DataValue::Counter { value } => format!("{}={}", key, value),
         DataValue::String { value } => format!("{}={}", key, value),
-        DataValue::History { entries, memory, .. } => {
+        DataValue::History {
+            entries, memory, ..
+        } => {
             let items: Vec<String> = entries
                 .iter()
                 .map(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
         Commands::Log { count, full, args } => handle_log(count, full, args),
         Commands::State { command } => handle_state(command),
         Commands::Kv { command } => {
-            let code = handle_kv(command)?;
+            let code = handle_kv(command, cli.verbose)?;
             if code != 0 {
                 std::process::exit(code);
             }


### PR DESCRIPTION
## Summary

- Adds optional `memory: Option<String>` field to `History`, `List`, and `State` variants of `DataValue` with backward-compatible serde attributes (`#[serde(default, skip_serializing_if)]`)
- Adds `set_memory` / `get_memory` engine methods to `KvStore` with type validation (counter/string rejected)
- Adds `--memory <kn-id>` write flag on `set` command -- works alongside normal set, or standalone for memory-only updates on any supported type
- Adds `--memory` read flag on `get`, `last`, `since`, `search`, `dump` -- resolves kn- reference via SurrealDB and displays entry content below KV output
- Updates compact dump format to append `(kn-...)` suffix when a memory pointer exists
- Updates custom `Deserialize` impl (`DataValueDe`) to carry the `memory` field through backward-compat deserialization
- Passes `verbose` through to `handle_kv` for SurrealDB connection logging
- 20 new tests covering set/get/clear memory, type mismatch rejection, backward compat (old data without field, new data with field), compact dump with/without pointers, memory survival across push/reset

## Test plan

- [x] `cargo test` -- 462 passed, 0 failed
- [x] `cargo clippy` -- zero warnings
- [x] `cargo fmt -- --check` -- clean
- [x] Backward compat: old data files without `memory` field deserialize cleanly
- [x] Memory pointer not serialized when `None` (verified via JSON output check)
- [ ] Manual: `mx kv set <key> --memory kn-xxx` on a live agent schema
- [ ] Manual: `mx kv get <key> --memory` with SurrealDB available
- [ ] Manual: `mx kv dump --format compact` shows `(kn-...)` suffix

Closes #244
Closes #243