### PR TITLE
refactor: source dejavu marker from a single constant (closes #263)

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -6,7 +6,7 @@
 //! - Footer: Compression algorithm hint
 //!
 //! Dejavu detection: When both title and body randomly get the same
-//! dictionary, we add "whoa." to the footer.
+//! dictionary, we add the `DEJAVU_MARKER` to the footer.
 
 use anyhow::{Context, Result, bail};
 use base_d::prelude::*;
@@ -216,7 +216,7 @@ pub(crate) fn parse_body_dict(footer: &str) -> Option<String> {
     let colon_pos = after_pipe.find(':')?;
     let after_colon = &after_pipe[colon_pos + 1..];
 
-    // Strip trailing ']' and anything after (e.g., newline + "whoa.")
+    // Strip trailing ']' and anything after (e.g., newline + `DEJAVU_MARKER`)
     let dict_name = after_colon.split(']').next()?;
 
     if dict_name.is_empty() {

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -16,6 +16,15 @@ use std::process::Command;
 /// Each attempt re-rolls the random dictionary selection.
 const MAX_ENCODE_ATTEMPTS: usize = 5;
 
+/// Marker line appended to the footer when title and body randomly land
+/// on the same encoding dictionary (the dejavu easter egg).
+///
+/// Single source of truth: the encoder writes this exact line, and the
+/// `mx log` rendering filter in `handlers::try_decode_commit_body`
+/// strips this exact line from displayed bodies. Both sides import
+/// this constant -- if the spelling ever changes, both update together.
+pub(crate) const DEJAVU_MARKER: &str = "whoa.";
+
 /// Get the staged diff from git
 pub fn get_staged_diff() -> Result<String> {
     let output = Command::new("git")
@@ -384,7 +393,15 @@ pub fn encode_commit(title_text: &str, body_text: &str) -> Result<EncodedCommit>
 
         // Footer: [hash_algo:title_dict|compress_algo:body_dict]
         let footer_tag = format_footer_tag(&hash_algo, &title_dict, &compress_algo, &body_dict);
-        let footer = format!("{}{}", footer_tag, if dejavu { "\nwhoa." } else { "" });
+        let footer = format!(
+            "{}{}",
+            footer_tag,
+            if dejavu {
+                format!("\n{}", DEJAVU_MARKER)
+            } else {
+                String::new()
+            }
+        );
 
         // Validate all parts for unsafe characters
         let title_check = validate_encoded_output(&title, "title");
@@ -660,7 +677,7 @@ mod tests {
         EncodedCommit {
             title: "TTTT-title-glyphs".to_string(),
             body: "BBBB-body-glyphs".to_string(),
-            footer: "[sha384:base62|lzma:base62]\nwhoa.".to_string(),
+            footer: format!("[sha384:base62|lzma:base62]\n{}", DEJAVU_MARKER),
             dejavu: true,
             title_dict: "base62".to_string(),
             body_dict: "base62".to_string(),
@@ -742,10 +759,13 @@ mod tests {
         // different whitespace would have passed the old substring check.
         let encoded = sample_encoded_with_dejavu();
         let out = format_encoded_commit(&encoded, true);
-        let expected = "Title:  TTTT-title-glyphs\n\
-                        Body:   BBBB-body-glyphs\n\
-                        Dejavu: true (both used base62)\n\
-                        Footer: [sha384:base62|lzma:base62]\nwhoa.";
+        let expected = format!(
+            "Title:  TTTT-title-glyphs\n\
+             Body:   BBBB-body-glyphs\n\
+             Dejavu: true (both used base62)\n\
+             Footer: [sha384:base62|lzma:base62]\n{}",
+            DEJAVU_MARKER
+        );
         assert_eq!(out, expected);
     }
 
@@ -781,10 +801,8 @@ mod tests {
     #[test]
     fn test_parse_body_dict_dejavu_footer() {
         // Footer may have trailing content after ']' on next lines
-        assert_eq!(
-            parse_body_dict("[sha384:base62|lzma:base62]\nwhoa."),
-            Some("base62".to_string())
-        );
+        let footer = format!("[sha384:base62|lzma:base62]\n{}", DEJAVU_MARKER);
+        assert_eq!(parse_body_dict(&footer), Some("base62".to_string()));
     }
 
     #[test]

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -485,9 +485,11 @@ pub(crate) fn try_decode_commit_body(body: &str) -> DecodedCommit {
     // Encoded body = every line strictly above the footer, with the
     // dejavu marker filtered out (it can in principle appear in older
     // formats above the footer; current encoder writes it after).
+    // Marker spelling is sourced from the encoder so the writer and
+    // this filter never drift apart.
     let body_lines: Vec<&str> = lines[..footer_idx]
         .iter()
-        .filter(|l| l.trim() != "whoa.")
+        .filter(|l| l.trim() != commit::DEJAVU_MARKER)
         .copied()
         .collect();
 
@@ -776,8 +778,11 @@ mod try_decode_commit_body_tests {
         // text is exactly what `git cat-file -p` returned (everything
         // after the title line). If the decoder ever stops handling
         // this shape, this test catches it.
-        let body = "8NO48P3FCDPIGSJ5C5I6QP9978G76R39DKG46RRECPKMETBIC5Q6IRRE41Q6U83141Q6AOBJCLP20R39DPLMIRJ741Q6U834DTHN6BRGC5Q6GSPEDLI0====\n\n[blake2s:base32hex|snappy:base32hex]\nwhoa.";
-        let result = try_decode_commit_body(body);
+        let body = format!(
+            "8NO48P3FCDPIGSJ5C5I6QP9978G76R39DKG46RRECPKMETBIC5Q6IRRE41Q6U83141Q6AOBJCLP20R39DPLMIRJ741Q6U834DTHN6BRGC5Q6GSPEDLI0====\n\n[blake2s:base32hex|snappy:base32hex]\n{}",
+            commit::DEJAVU_MARKER
+        );
+        let result = try_decode_commit_body(&body);
         assert!(result.was_decoded);
         assert_eq!(
             result.subject,


### PR DESCRIPTION
Closes #263

## Summary

The dejavu marker spelling now lives in a single `pub(crate) const DEJAVU_MARKER` exported by `src/commit.rs`. Encoder (writer) and `src/handlers/mod.rs` filter (stripper) both consume the constant instead of duplicate string literals. Test fixtures interpolate via `format!()` so they track the constant too.

## Files affected

- `src/commit.rs`
- `src/handlers/mod.rs`

5 call-sites total: 1 encoder write, 1 handler filter, 3 test fixtures.

## Test plan

- `cargo build` clean
- `cargo test` 520 passed / 0 failed / 3 ignored
- `cargo clippy` clean

## Notes

Pre-existing `surreal_db::tests::test_open_with_path` flake did not fire this run (3-shift pattern broken -- possibly random luck, possibly deflaked; not in scope here).