### PR TITLE
refactor(codex): paths.rs helpers + index/ skeleton + manifest v2→v5 (PR 1/5 of #254)

### DIFF
--- a/src/codex/archive.rs
+++ b/src/codex/archive.rs
@@ -10,7 +10,7 @@ use super::transcript::{
     build_agent_type_map, generate_clean_transcript, generate_clean_transcript_with_agents,
     resolve_agent_display_name, resolve_assistant_name, resolve_user_name,
 };
-use super::{AgentInfo, ArchiveEntry, Manifest};
+use super::{AgentInfo, ArchiveEntry, MANIFEST_WRITE_VERSION, Manifest};
 
 /// Archive the current session to the codex
 pub(crate) fn save_session(
@@ -150,7 +150,7 @@ fn archive_session(session_path: &Path, clean: bool, include_agents: bool) -> Re
         let archive_size_bytes = md_size + images_size;
 
         let manifest = Manifest {
-            version: 2,
+            version: MANIFEST_WRITE_VERSION,
             session_id: session_id.clone(),
             archived_at: Utc::now(),
             session_start,
@@ -166,6 +166,13 @@ fn archive_session(session_path: &Path, clean: bool, include_agents: bool) -> Re
             has_clean_transcript: Some(true),
             user_name: Some(user_name.clone()),
             assistant_name: Some(assistant_name.clone()),
+            // v5 sidecars not written yet (PR 2 wires these). Foundation
+            // PR bumps the version number only; payload is otherwise
+            // identical to a v2 manifest.
+            tool_output_count: None,
+            mcp_log_count: None,
+            history_lines: None,
+            source_breakdown: None,
         };
 
         let manifest_json = serde_json::to_string_pretty(&manifest)?;
@@ -225,10 +232,11 @@ fn archive_session(session_path: &Path, clean: bool, include_agents: bool) -> Re
         }
     }
 
-    // Create manifest (v2 with image support)
+    // Create manifest (schema v5; payload identical to v2 plus a higher
+    // version number until PR 2 wires the new sidecars).
     let image_count = all_images.len();
     let manifest = Manifest {
-        version: 2,
+        version: MANIFEST_WRITE_VERSION,
         session_id: session_id.clone(),
         archived_at: Utc::now(),
         session_start,
@@ -244,6 +252,11 @@ fn archive_session(session_path: &Path, clean: bool, include_agents: bool) -> Re
         has_clean_transcript: None,
         user_name: Some(user_name),
         assistant_name: Some(assistant_name),
+        // v5 sidecars not written yet (PR 2 wires these).
+        tool_output_count: None,
+        mcp_log_count: None,
+        history_lines: None,
+        source_breakdown: None,
     };
 
     let manifest_json = serde_json::to_string_pretty(&manifest)?;

--- a/src/codex/index/mod.rs
+++ b/src/codex/index/mod.rs
@@ -1,0 +1,136 @@
+//! By-project index for the codex.
+//!
+//! Maintains a `~/.wonka/codex/by-project/<basename-slug>/` directory of
+//! pointers (symlinks or files — implementer's choice; this PR stubs the
+//! API only) into the time-indexed flat session storage.
+//!
+//! The index is regenerable from manifests on every archive run; readers
+//! must stale-check before trusting it. PR 2 will integrate write paths;
+//! PR 3 will integrate read paths.
+
+use anyhow::Result;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// In-memory handle to the on-disk by-project index.
+///
+/// Constructed via [`ProjectIndex::open`]. Stays empty in this PR; the
+/// internal layout is intentionally private so PR 2 can choose between a
+/// symlink-based or pointer-file-based representation without churning
+/// callers.
+#[derive(Debug, Default)]
+pub struct ProjectIndex {
+    /// Cached entries, populated by `rebuild_from_manifests`. Empty in PR 1.
+    entries: Vec<ProjectEntry>,
+}
+
+/// One project's entry in the index: its absolute path on disk, its
+/// basename-slug (the human-friendly key used by `--project mx`), and the
+/// time-indexed codex directories that archive sessions for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectEntry {
+    /// The absolute path of the project on disk (matches `manifest.project_path`).
+    pub absolute_path: PathBuf,
+    /// The basename-slug (e.g. `mx`, `wonka`) — last segment of `absolute_path`.
+    pub basename_slug: String,
+    /// Paths into `~/.wonka/codex/<YYYY-MM-DD-HHMMSS>-<short-uuid>/` for
+    /// every archived session belonging to this project.
+    pub session_archive_paths: Vec<PathBuf>,
+}
+
+impl ProjectIndex {
+    /// Open the index at `~/.wonka/codex/by-project/`, creating it if absent.
+    ///
+    /// PR 2 will integrate this when archive writes the index.
+    pub fn open() -> Result<Self> {
+        unimplemented!("PR 2: integrated when archive writes index")
+    }
+
+    /// Regenerate the index from all manifests under codex/. Call after archive runs.
+    ///
+    /// PR 2 will integrate this when archive writes the index.
+    pub fn rebuild_from_manifests(&mut self) -> Result<()> {
+        unimplemented!("PR 2: integrated when archive writes index")
+    }
+
+    /// Look up a project by absolute path, raw slug, or basename. Returns
+    /// the matched entry, or an [`IndexError::AmbiguousProject`] error if a
+    /// basename matches multiple absolute paths.
+    ///
+    /// PR 3 will integrate this when export reads the index.
+    pub fn lookup(&self, _query: &str) -> Result<ProjectEntry> {
+        unimplemented!("PR 3: integrated when export reads index")
+    }
+
+    /// Returns true if the on-disk index is stale relative to the manifest
+    /// timestamps. Readers MUST call this before trusting the index.
+    ///
+    /// PR 3 will integrate this when export reads the index.
+    pub fn is_stale(&self) -> Result<bool> {
+        unimplemented!("PR 3: integrated when export reads index")
+    }
+
+    /// Number of entries currently held in memory. Provided as a smoke-test
+    /// hook so PR 1 can assert the type is constructable without touching
+    /// any of the `unimplemented!()` methods.
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Errors raised by the by-project index.
+///
+/// Only `AmbiguousProject` is enumerated in PR 1; PRs 2 and 3 will extend
+/// this enum as concrete failure modes are wired up. The variant payload is
+/// stable and ready for `--project` disambiguation messages.
+#[derive(Debug, Error)]
+pub enum IndexError {
+    #[error("ambiguous project query '{query}' matches multiple paths: {matches:?}")]
+    AmbiguousProject {
+        query: String,
+        matches: Vec<PathBuf>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------------
+    // Smoke tests: confirm the module compiles, the public types are
+    // constructable, and the `unimplemented!()` methods are reachable from
+    // the public API surface (i.e. no `pub` was forgotten). Actual behavior
+    // lands in PRs 2 and 3.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn project_index_default_is_empty() {
+        let idx = ProjectIndex::default();
+        assert_eq!(idx.entry_count(), 0);
+    }
+
+    #[test]
+    fn project_entry_constructable() {
+        let entry = ProjectEntry {
+            absolute_path: PathBuf::from("/home/charlie/recipes/coryzibell/mx"),
+            basename_slug: "mx".to_string(),
+            session_archive_paths: vec![PathBuf::from(
+                "/home/charlie/.wonka/codex/2026-04-29-143022-c3744b8d",
+            )],
+        };
+        assert_eq!(entry.basename_slug, "mx");
+        assert_eq!(entry.session_archive_paths.len(), 1);
+    }
+
+    #[test]
+    fn index_error_ambiguous_renders_query_and_matches() {
+        let err = IndexError::AmbiguousProject {
+            query: "mx".to_string(),
+            matches: vec![PathBuf::from("/home/a/mx"), PathBuf::from("/home/b/mx")],
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("'mx'"), "rendered message: {}", msg);
+        assert!(msg.contains("/home/a/mx"), "rendered message: {}", msg);
+        assert!(msg.contains("/home/b/mx"), "rendered message: {}", msg);
+    }
+}

--- a/src/codex/index/mod.rs
+++ b/src/codex/index/mod.rs
@@ -41,38 +41,46 @@ pub struct ProjectEntry {
 impl ProjectIndex {
     /// Open the index at `~/.wonka/codex/by-project/`, creating it if absent.
     ///
-    /// PR 2 will integrate this when archive writes the index.
+    /// PR 2 will integrate this when archive writes the index. Until then,
+    /// this returns [`IndexError::NotImplemented`] so a stray production
+    /// caller surfaces as a typed error rather than a panic.
     pub fn open() -> Result<Self> {
-        unimplemented!("PR 2: integrated when archive writes index")
+        Err(IndexError::NotImplemented { method: "open" }.into())
     }
 
     /// Regenerate the index from all manifests under codex/. Call after archive runs.
     ///
-    /// PR 2 will integrate this when archive writes the index.
+    /// PR 2 will integrate this when archive writes the index. Until then,
+    /// this returns [`IndexError::NotImplemented`].
     pub fn rebuild_from_manifests(&mut self) -> Result<()> {
-        unimplemented!("PR 2: integrated when archive writes index")
+        Err(IndexError::NotImplemented {
+            method: "rebuild_from_manifests",
+        }
+        .into())
     }
 
     /// Look up a project by absolute path, raw slug, or basename. Returns
     /// the matched entry, or an [`IndexError::AmbiguousProject`] error if a
     /// basename matches multiple absolute paths.
     ///
-    /// PR 3 will integrate this when export reads the index.
+    /// PR 3 will integrate this when export reads the index. Until then,
+    /// this returns [`IndexError::NotImplemented`].
     pub fn lookup(&self, _query: &str) -> Result<ProjectEntry> {
-        unimplemented!("PR 3: integrated when export reads index")
+        Err(IndexError::NotImplemented { method: "lookup" }.into())
     }
 
     /// Returns true if the on-disk index is stale relative to the manifest
     /// timestamps. Readers MUST call this before trusting the index.
     ///
-    /// PR 3 will integrate this when export reads the index.
+    /// PR 3 will integrate this when export reads the index. Until then,
+    /// this returns [`IndexError::NotImplemented`].
     pub fn is_stale(&self) -> Result<bool> {
-        unimplemented!("PR 3: integrated when export reads index")
+        Err(IndexError::NotImplemented { method: "is_stale" }.into())
     }
 
     /// Number of entries currently held in memory. Provided as a smoke-test
-    /// hook so PR 1 can assert the type is constructable without touching
-    /// any of the `unimplemented!()` methods.
+    /// hook so PR 1 can assert the type is constructable without exercising
+    /// the not-yet-implemented methods.
     pub fn entry_count(&self) -> usize {
         self.entries.len()
     }
@@ -80,9 +88,11 @@ impl ProjectIndex {
 
 /// Errors raised by the by-project index.
 ///
-/// Only `AmbiguousProject` is enumerated in PR 1; PRs 2 and 3 will extend
-/// this enum as concrete failure modes are wired up. The variant payload is
-/// stable and ready for `--project` disambiguation messages.
+/// `AmbiguousProject` and `NotImplemented` are enumerated in PR 1; PRs 2 and
+/// 3 will extend this enum as concrete failure modes are wired up. The
+/// variant payloads are stable and ready for `--project` disambiguation
+/// messages and for surfacing stub-call sites as typed errors instead of
+/// panics.
 #[derive(Debug, Error)]
 pub enum IndexError {
     #[error("ambiguous project query '{query}' matches multiple paths: {matches:?}")]
@@ -90,6 +100,8 @@ pub enum IndexError {
         query: String,
         matches: Vec<PathBuf>,
     },
+    #[error("ProjectIndex::{method} is not yet implemented (wired up in a later PR)")]
+    NotImplemented { method: &'static str },
 }
 
 #[cfg(test)]

--- a/src/codex/migrate.rs
+++ b/src/codex/migrate.rs
@@ -4,9 +4,22 @@ use std::fs;
 use super::images::{count_images_in_jsonl, extract_images_from_jsonl};
 use super::transcript::migrate_clean_transcripts;
 
+use super::MANIFEST_WRITE_VERSION;
 use super::archive::{collect_archives, get_codex_dir};
 
-/// Migrate all v1 archives to v2 (extract images to files)
+/// Migrate all archives below the current write version up to it.
+///
+/// Today this means v1 → v5 in one shot:
+///   - v1 → v2 extracts images out of the JSONLs into per-archive `images/`
+///     and records counts (this is the only step that touches bytes on disk).
+///   - v2 → v5 is a metadata-only bump: the v3/v4/v5 fields (`has_clean_transcript`,
+///     `user_name`, `assistant_name`, `tool_output_count`, `mcp_log_count`,
+///     `history_lines`, `source_breakdown`) are all `Option`, so existing
+///     archives keep deserializing and the migration just rewrites the
+///     manifest with the higher version number plus `None` defaults for
+///     anything missing. The new sidecars (`mcp/`, `tool-output/`, `history/`)
+///     do not exist on disk for these archives — that's fine; absent
+///     sidecars are represented by `None` counts.
 pub(crate) fn migrate_archives(
     dry_run: bool,
     verbose: bool,
@@ -32,20 +45,36 @@ pub(crate) fn migrate_archives(
         return migrate_clean_transcripts(&codex_dir, archives, dry_run, verbose, include_agents);
     }
 
-    // Find archives that need migration (version < 2 or missing version)
-    let mut to_migrate = Vec::new();
+    // Split archives into two buckets:
+    //   - Pre-v2 archives need image extraction *and* a metadata bump.
+    //   - v2..v(MANIFEST_WRITE_VERSION-1) archives just need the metadata bump.
+    let mut to_extract_images = Vec::new();
+    let mut metadata_only_bumps = Vec::new();
     for archive in archives {
         if archive.manifest.version < 2 {
-            to_migrate.push(archive);
+            to_extract_images.push(archive);
+        } else if archive.manifest.version < MANIFEST_WRITE_VERSION {
+            metadata_only_bumps.push(archive);
         }
     }
 
-    if to_migrate.is_empty() {
-        println!("All archives are already v2! Nothing to migrate.");
+    if to_extract_images.is_empty() && metadata_only_bumps.is_empty() {
+        println!(
+            "All archives are already at schema v{}! Nothing to migrate.",
+            MANIFEST_WRITE_VERSION
+        );
         return Ok(());
     }
 
-    println!("Found {} archive(s) to migrate", to_migrate.len());
+    println!(
+        "Found {} archive(s) needing image extraction and {} archive(s) needing metadata bump",
+        to_extract_images.len(),
+        metadata_only_bumps.len()
+    );
+
+    // The image-extracting path below mutates manifests; rebind so the rest
+    // of the function can keep its existing variable name.
+    let to_migrate = to_extract_images;
 
     if dry_run {
         println!("\n[DRY RUN MODE - No changes will be made]\n");
@@ -129,9 +158,11 @@ pub(crate) fn migrate_archives(
             let bytes_saved: u64 = all_images.iter().map(|img| img.size_bytes).sum();
             total_bytes_saved += bytes_saved;
 
-            // Update manifest to v2
+            // Update manifest to current write version. The image fields
+            // are the v1→v2 step; the version bump folds in v3/v4/v5
+            // (which are all-Option, so no field defaults change here).
             let mut manifest = archive.manifest.clone();
-            manifest.version = 2;
+            manifest.version = MANIFEST_WRITE_VERSION;
             manifest.image_count = Some(all_images.len());
             manifest.images = Some(all_images.clone());
 
@@ -182,8 +213,31 @@ pub(crate) fn migrate_archives(
         total_migrated += 1;
     }
 
+    // Metadata-only bump for v2/v3/v4 archives → MANIFEST_WRITE_VERSION (v5).
+    // No bytes-on-disk change; just rewrite the manifest with the higher
+    // version number. The new v5 fields are Option-defaulted so they stay
+    // None for archives that don't have the new sidecars yet.
+    let mut metadata_bumped = 0;
+    for archive in metadata_only_bumps {
+        let archive_dir = codex_dir.join(&archive.dir_name);
+        if verbose {
+            println!(
+                "Metadata bump: {} (v{} -> v{})",
+                archive.short_id, archive.manifest.version, MANIFEST_WRITE_VERSION
+            );
+        }
+        if !dry_run {
+            let mut manifest = archive.manifest.clone();
+            manifest.version = MANIFEST_WRITE_VERSION;
+            let manifest_json = serde_json::to_string_pretty(&manifest)?;
+            fs::write(archive_dir.join("manifest.json"), manifest_json)?;
+        }
+        metadata_bumped += 1;
+    }
+
     println!("\n--- Migration Summary ---");
     println!("Archives migrated: {}", total_migrated);
+    println!("Archives metadata-bumped: {}", metadata_bumped);
     println!("Total images extracted: {}", total_images);
 
     if !dry_run {

--- a/src/codex/migrate.rs
+++ b/src/codex/migrate.rs
@@ -9,17 +9,23 @@ use super::archive::{collect_archives, get_codex_dir};
 
 /// Migrate all archives below the current write version up to it.
 ///
-/// Today this means v1 → v5 in one shot:
-///   - v1 → v2 extracts images out of the JSONLs into per-archive `images/`
-///     and records counts (this is the only step that touches bytes on disk).
-///   - v2 → v5 is a metadata-only bump: the v3/v4/v5 fields (`has_clean_transcript`,
-///     `user_name`, `assistant_name`, `tool_output_count`, `mcp_log_count`,
-///     `history_lines`, `source_breakdown`) are all `Option`, so existing
-///     archives keep deserializing and the migration just rewrites the
-///     manifest with the higher version number plus `None` defaults for
-///     anything missing. The new sidecars (`mcp/`, `tool-output/`, `history/`)
-///     do not exist on disk for these archives — that's fine; absent
-///     sidecars are represented by `None` counts.
+/// v1 archives are upgraded in two phases:
+///   1. Image extraction (v1 → v2) pulls images out of the JSONLs into a
+///      per-archive `images/` directory and records counts. This is the
+///      only phase that touches bytes on disk.
+///   2. A metadata-only bump (v2 → v5) folds in the v3/v4/v5 fields
+///      (`has_clean_transcript`, `user_name`, `assistant_name`,
+///      `tool_output_count`, `mcp_log_count`, `history_lines`,
+///      `source_breakdown`). Both phases are applied to the same manifest
+///      write, so v1 archives end up at v5 in a single pass.
+///
+/// v2/v3/v4 archives skip the image-extraction phase and receive only the
+/// metadata-only bump up to v5. All the new fields are `Option`, so older
+/// archives keep deserializing and the bump just rewrites the manifest with
+/// the higher version number plus `None` defaults for anything missing. The
+/// new sidecars (`mcp/`, `tool-output/`, `history/`) do not exist on disk
+/// for these archives — that's fine; absent sidecars are represented by
+/// `None` counts.
 pub(crate) fn migrate_archives(
     dry_run: bool,
     verbose: bool,
@@ -72,10 +78,6 @@ pub(crate) fn migrate_archives(
         metadata_only_bumps.len()
     );
 
-    // The image-extracting path below mutates manifests; rebind so the rest
-    // of the function can keep its existing variable name.
-    let to_migrate = to_extract_images;
-
     if dry_run {
         println!("\n[DRY RUN MODE - No changes will be made]\n");
     }
@@ -84,7 +86,7 @@ pub(crate) fn migrate_archives(
     let mut total_images = 0;
     let mut total_bytes_saved = 0u64;
 
-    for archive in to_migrate {
+    for archive in to_extract_images {
         let archive_dir = codex_dir.join(&archive.dir_name);
         let session_file = archive_dir.join("session.jsonl");
 

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -36,12 +36,12 @@ pub struct Manifest {
     pub size_bytes: u64,
     pub checksum: String,
     // v2 fields
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_count: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub images: Option<Vec<ImageInfo>>,
     // v3 fields
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub has_clean_transcript: Option<bool>,
     // v4 fields - configurable speaker names
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -1,5 +1,6 @@
 mod archive;
 mod images;
+pub mod index;
 mod migrate;
 mod read;
 mod transcript;
@@ -11,6 +12,14 @@ use serde::{Deserialize, Serialize};
 pub(crate) use archive::save_session;
 pub(crate) use migrate::migrate_archives;
 pub(crate) use read::{list_sessions, read_session, search_archives};
+
+/// Current manifest write version. Bumped from `2` to `5` in the codex
+/// foundation PR: v3 (`has_clean_transcript`) and v4 (`user_name`,
+/// `assistant_name`) had been declared as latent optional fields without a
+/// matching writer bump, and v5 adds the source-breakdown / sidecar-count
+/// fields needed by the unified ingestion flow. All new fields are
+/// `Option`, so v2/v3/v4 archives still deserialize cleanly.
+pub(crate) const MANIFEST_WRITE_VERSION: u32 = 5;
 
 /// Manifest metadata for an archived session
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,6 +48,41 @@ pub struct Manifest {
     pub user_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assistant_name: Option<String>,
+    // v5 fields - new sidecar counts and per-source byte breakdown.
+    // Defaulted to None in this PR; populated by PR 2 when archive starts
+    // writing the new sidecars (mcp/, tool-output/, history/).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_output_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_log_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_lines: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_breakdown: Option<SourceBreakdown>,
+}
+
+/// Per-sidecar byte counts. Captured at archive time so `mx codex export`
+/// and downstream tooling can reason about disk usage without re-stat-ing
+/// every file.
+///
+/// All fields default to `0` rather than `Option<u64>` because the
+/// breakdown as a whole is `Option`-wrapped on the manifest — a present
+/// `SourceBreakdown` means "we measured everything," and an absent sidecar
+/// is naturally represented by a zero count.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceBreakdown {
+    #[serde(default)]
+    pub session_jsonl_bytes: u64,
+    #[serde(default)]
+    pub agents_bytes: u64,
+    #[serde(default)]
+    pub images_bytes: u64,
+    #[serde(default)]
+    pub mcp_bytes: u64,
+    #[serde(default)]
+    pub tool_output_bytes: u64,
+    #[serde(default)]
+    pub history_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -96,6 +140,109 @@ mod tests {
         assert_eq!(manifest.assistant_name, None);
         assert_eq!(manifest.has_clean_transcript, None);
         assert_eq!(manifest.image_count, None);
+        // v5 additions must also default to None for back-compat.
+        assert_eq!(manifest.tool_output_count, None);
+        assert_eq!(manifest.mcp_log_count, None);
+        assert_eq!(manifest.history_lines, None);
+        assert_eq!(manifest.source_breakdown, None);
+    }
+
+    #[test]
+    fn manifest_v2_round_trips_through_v5() {
+        // A v2 manifest from the wild deserializes into the v5 struct, and
+        // re-serializing it as v5 (after a metadata-only version bump)
+        // round-trips back into an equivalent struct. The v5 fields stay
+        // None throughout — that's the whole point of "metadata-only bump."
+        let v2_json = r#"{
+            "version": 2,
+            "session_id": "abc123",
+            "archived_at": "2026-01-01T00:00:00Z",
+            "session_start": "2026-01-01T00:00:00Z",
+            "session_end": "2026-01-01T00:00:00Z",
+            "project_path": "/home/test/project",
+            "message_count": 42,
+            "agent_count": 1,
+            "agents": [{"id": "ag-1", "file": "agents/agent-1.jsonl", "messages": 7}],
+            "size_bytes": 99999,
+            "checksum": "sha256:deadbeef",
+            "image_count": 3,
+            "images": [{"hash": "h1", "media_type": "image/png", "size_bytes": 100}]
+        }"#;
+
+        let mut manifest: Manifest = serde_json::from_str(v2_json).unwrap();
+        assert_eq!(manifest.version, 2);
+        assert_eq!(manifest.image_count, Some(3));
+        assert_eq!(manifest.tool_output_count, None);
+        assert_eq!(manifest.source_breakdown, None);
+
+        // Simulate the migration: bump version, leave new fields None.
+        manifest.version = MANIFEST_WRITE_VERSION;
+
+        let v5_json = serde_json::to_string_pretty(&manifest).unwrap();
+        let round_tripped: Manifest = serde_json::from_str(&v5_json).unwrap();
+        assert_eq!(round_tripped.version, MANIFEST_WRITE_VERSION);
+        assert_eq!(round_tripped.session_id, "abc123");
+        assert_eq!(round_tripped.message_count, 42);
+        assert_eq!(round_tripped.image_count, Some(3));
+        assert_eq!(round_tripped.tool_output_count, None);
+        assert_eq!(round_tripped.mcp_log_count, None);
+        assert_eq!(round_tripped.history_lines, None);
+        assert_eq!(round_tripped.source_breakdown, None);
+
+        // The skip_serializing_if guards mean the serialized v5 of a
+        // metadata-only bump should not contain the new field names at all.
+        assert!(!v5_json.contains("tool_output_count"));
+        assert!(!v5_json.contains("mcp_log_count"));
+        assert!(!v5_json.contains("history_lines"));
+        assert!(!v5_json.contains("source_breakdown"));
+    }
+
+    #[test]
+    fn manifest_v5_with_new_fields_round_trips() {
+        // When the new fields *are* populated (PR 2 territory), they
+        // serialize and deserialize symmetrically.
+        let breakdown = SourceBreakdown {
+            session_jsonl_bytes: 1024,
+            agents_bytes: 512,
+            images_bytes: 2048,
+            mcp_bytes: 256,
+            tool_output_bytes: 128,
+            history_bytes: 64,
+        };
+        let manifest = Manifest {
+            version: MANIFEST_WRITE_VERSION,
+            session_id: "v5-test".to_string(),
+            archived_at: "2026-04-29T00:00:00Z".parse().unwrap(),
+            session_start: "2026-04-29T00:00:00Z".parse().unwrap(),
+            session_end: "2026-04-29T01:00:00Z".parse().unwrap(),
+            project_path: None,
+            message_count: 0,
+            agent_count: 0,
+            agents: vec![],
+            size_bytes: 0,
+            checksum: "sha256:zero".to_string(),
+            image_count: None,
+            images: None,
+            has_clean_transcript: None,
+            user_name: None,
+            assistant_name: None,
+            tool_output_count: Some(5),
+            mcp_log_count: Some(2),
+            history_lines: Some(17),
+            source_breakdown: Some(breakdown.clone()),
+        };
+        let s = serde_json::to_string(&manifest).unwrap();
+        let back: Manifest = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.tool_output_count, Some(5));
+        assert_eq!(back.mcp_log_count, Some(2));
+        assert_eq!(back.history_lines, Some(17));
+        assert_eq!(back.source_breakdown, Some(breakdown));
+    }
+
+    #[test]
+    fn manifest_write_version_is_five() {
+        // Pinning constant matches the design doc.
+        assert_eq!(MANIFEST_WRITE_VERSION, 5);
     }
 
     // ---------------------------------------------------------------------------

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -259,19 +259,112 @@ pub fn codex_dir() -> PathBuf {
 // External Claude data (read-only ingest sources, owned by another tool)
 // ---------------------------------------------------------------------------
 
+/// Internal helper: the resolved `~/` for use by Claude-data path builders.
+///
+/// Centralizing this means the codex source-walker helpers below all share a
+/// single failure mode if `dirs::home_dir()` ever returns `None` (which only
+/// happens in pathologically misconfigured environments).
+fn claude_home_root() -> PathBuf {
+    dirs::home_dir().expect("Could not determine home directory")
+}
+
+/// `~/.claude/` -- the root of Claude's per-user data directory.
+///
+/// Use this as the join base when adding new Claude-owned subpaths. Prefer
+/// the more specific helpers below when one already exists; reach for the
+/// root only when adding a new sibling that doesn't yet have its own helper.
+pub fn claude_dir() -> PathBuf {
+    claude_home_root().join(".claude")
+}
+
 /// `~/.claude/projects/` -- read-only by convention.
 pub fn claude_projects_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("Could not determine home directory")
-        .join(".claude")
-        .join("projects")
+    claude_dir().join("projects")
 }
 
 /// `~/.claude.json` -- read-only by convention.
 pub fn claude_config_path() -> PathBuf {
-    dirs::home_dir()
-        .expect("Could not determine home directory")
-        .join(".claude.json")
+    claude_home_root().join(".claude.json")
+}
+
+/// `~/.claude/projects/<project_slug>/<session_id>/subagents/`
+///
+/// Claude writes subagent JSONLs (`agent-*.jsonl`) into a `subagents/`
+/// directory that lives next to the parent session JSONL, nested under the
+/// cwd-encoded project slug. The slug is the same encoding Claude uses
+/// elsewhere (e.g. `-home-charlie-recipes-coryzibell-mx`); callers are
+/// responsible for supplying it because the session UUID alone does not
+/// uniquely identify the project directory.
+///
+/// PR 2 of the codex unification will wire this into the archive source
+/// walker (replacing the open-coded join in `archive.rs::find_agent_sessions`).
+pub fn claude_subagents_dir(project_slug: &str, session_id: &str) -> PathBuf {
+    claude_projects_dir()
+        .join(project_slug)
+        .join(session_id)
+        .join("subagents")
+}
+
+/// `~/.claude/sessions/` -- per-pid liveness JSONs.
+///
+/// Used as a liveness signal only (not ingested). The codex archive flow
+/// will consult this directory to resolve "the most recent session" without
+/// relying on mtime heuristics.
+pub fn claude_sessions_dir() -> PathBuf {
+    claude_dir().join("sessions")
+}
+
+/// `~/.claude/history.jsonl` -- the slash-command / prompt history file.
+///
+/// Sliced by session timestamp window into a `history/` sidecar by the codex
+/// archive flow (PR 2).
+pub fn claude_history_jsonl() -> PathBuf {
+    claude_dir().join("history.jsonl")
+}
+
+/// `~/.cache/claude-cli-nodejs/<cwd-encoded>/` -- the *parent* directory
+/// containing per-MCP-server log subdirs (`mcp-logs-<server>/`).
+///
+/// Returns the parent because the per-server `mcp-logs-*` subdirs are
+/// enumerated at call time (their names depend on which MCP servers were
+/// active for the cwd). The `cwd` argument is the same cwd-encoded slug
+/// Claude uses (`-home-charlie-recipes-...`).
+pub fn claude_mcp_logs_dir(cwd_encoded: &str) -> PathBuf {
+    claude_home_root()
+        .join(".cache")
+        .join("claude-cli-nodejs")
+        .join(cwd_encoded)
+}
+
+/// `/tmp/claude-<uid>/-home-<user>/<session_uuid>/tasks/`
+///
+/// Per-uid scratch directory for Claude task outputs. The `user` segment is
+/// the encoded form of the user's home directory (matching Claude's slug
+/// convention), and `session_uuid` is the full session UUID.
+///
+/// These files are disposable by design (cleared on reboot or `/tmp`
+/// cleanup); the codex archive flow snapshots them at run time. Callers
+/// must supply all three components because none can be derived from the
+/// uid alone.
+pub fn tmp_claude_tasks_dir(uid: u32, user_slug: &str, session_uuid: &str) -> PathBuf {
+    PathBuf::from(format!("/tmp/claude-{}", uid))
+        .join(user_slug)
+        .join(session_uuid)
+        .join("tasks")
+}
+
+/// `~/.wonka/vault/archives/` -- the legacy vault snapshot directory.
+///
+/// Walked by `mx codex archive --backfill` (PR 5) to ingest the existing
+/// vault snapshots into the codex. Note the literal `~/.wonka/` prefix:
+/// the wonka vault is a *separate* root from `MX_HOME` and intentionally
+/// does not derive from it. If the user has a wonka home override in the
+/// future, this helper will need updating; for v1 the path is fixed.
+pub fn wonka_vault_archives_dir() -> PathBuf {
+    claude_home_root()
+        .join(".wonka")
+        .join("vault")
+        .join("archives")
 }
 
 // ---------------------------------------------------------------------------
@@ -482,6 +575,78 @@ mod tests {
         let home = dirs::home_dir().unwrap();
         assert_eq!(claude_projects_dir(), home.join(".claude").join("projects"));
         assert_eq!(claude_config_path(), home.join(".claude.json"));
+    }
+
+    #[test]
+    fn claude_dir_is_dot_claude() {
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(claude_dir(), home.join(".claude"));
+    }
+
+    #[test]
+    fn claude_subagents_dir_layout() {
+        let home = dirs::home_dir().unwrap();
+        let p = claude_subagents_dir("-home-charlie-recipes-coryzibell-mx", "abc-123");
+        let expected = home
+            .join(".claude")
+            .join("projects")
+            .join("-home-charlie-recipes-coryzibell-mx")
+            .join("abc-123")
+            .join("subagents");
+        assert_eq!(p, expected);
+    }
+
+    #[test]
+    fn claude_sessions_dir_layout() {
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(claude_sessions_dir(), home.join(".claude").join("sessions"));
+    }
+
+    #[test]
+    fn claude_history_jsonl_layout() {
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(
+            claude_history_jsonl(),
+            home.join(".claude").join("history.jsonl")
+        );
+    }
+
+    #[test]
+    fn claude_mcp_logs_dir_layout() {
+        let home = dirs::home_dir().unwrap();
+        let p = claude_mcp_logs_dir("-home-charlie-recipes-coryzibell-mx");
+        let expected = home
+            .join(".cache")
+            .join("claude-cli-nodejs")
+            .join("-home-charlie-recipes-coryzibell-mx");
+        assert_eq!(p, expected);
+        // Per-server `mcp-logs-*` subdirs are walked at call time, not joined here.
+        assert!(!p.to_string_lossy().contains("mcp-logs-"));
+    }
+
+    #[test]
+    fn tmp_claude_tasks_dir_layout() {
+        let p = tmp_claude_tasks_dir(
+            1002,
+            "-home-charlie",
+            "c3744b8d-5719-4df2-924f-707945438494",
+        );
+        let expected = PathBuf::from("/tmp/claude-1002")
+            .join("-home-charlie")
+            .join("c3744b8d-5719-4df2-924f-707945438494")
+            .join("tasks");
+        assert_eq!(p, expected);
+    }
+
+    #[test]
+    fn wonka_vault_archives_dir_layout() {
+        // wonka_vault_archives_dir is rooted at ~/.wonka, not $MX_HOME.
+        // Match against the home dir directly (per the doc comment).
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(
+            wonka_vault_archives_dir(),
+            home.join(".wonka").join("vault").join("archives")
+        );
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
**Part of:** #254

**Architecture context:** https://github.com/coryzibell/mx/issues/254#issuecomment-4349828527

## Summary

Foundation PR for the codex unification series (PR 1 of 5). Adds new path helpers in `src/paths.rs` (no callers yet — PR 2 wires them), the `src/codex/index/` module skeleton with `ProjectIndex` / `ProjectEntry` / `IndexError` types behind `unimplemented!()` stubs (PR 2 implements writes; PR 3 implements reads), and bumps the manifest write version from 2 to 5 with optional new fields (`tool_output_count`, `mcp_log_count`, `history_lines`, `source_breakdown`).

The version bump is intentional — v5 manifests from this PR contain the same bytes as v2 plus a higher version number, since archive does not yet write the new sidecars.

## Files affected

- `src/paths.rs` — +7 helpers, +7 unit tests
- `src/codex/index/mod.rs` — new file: `ProjectIndex`, `ProjectEntry`, `IndexError`, 3 smoke tests
- `src/codex/mod.rs` — new optional fields + `SourceBreakdown` struct + `pub mod index;`
- `src/codex/archive.rs` — write version 2 → 5 at two sites; uses new `MANIFEST_WRITE_VERSION` constant
- `src/codex/migrate.rs` — v2 → v5 metadata-only migration path; pairwise to match existing v1 → v2 image-extraction migration shape

## Behavior

**No behavior change.** No new CLI surface. No new flags. Existing `mx codex archive` and `mx codex migrate` invocations produce identical outputs (modulo the version field being `5` instead of `2`).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 533 passed / 0 failed / 3 ignored (+13 from the 520 baseline on main)
- [x] `cargo clippy --all-targets` clean
- [x] v2 → v5 round-trip test confirms existing v2 manifests still deserialize and re-serialize as v5 with new fields elided

## Notes

- The known `surreal_db::tests::test_open_with_path` flake did not fire this run (now broken twice in three loopas — possibly luck, possibly latent fix; not in scope here).
- Two minor parameterization decisions documented in the report: `claude_subagents_dir(project_slug, session_id)` and `tmp_claude_tasks_dir(uid, user_slug, session_uuid)` — both took the multi-arg form because path components beyond the entry point are required to build the path.