### PR TITLE
feat(codex): mx codex export + detection warning + index reads (PR 3/5 of #254)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1231,6 +1231,11 @@ pub enum CodexCommands {
         date: Option<String>,
 
         /// Output format. `markdown` (default), `json`, or `both`.
+        ///
+        /// `both` requires `--output`: JSON is written to the supplied
+        /// path and markdown is written to a sibling sidecar file
+        /// (`<out>.json` + `<out>.md`, with the operator-supplied
+        /// extension preserved if it's already `.json` or `.md`).
         #[arg(long, default_value = "markdown")]
         format: String,
 
@@ -1247,8 +1252,9 @@ pub enum CodexCommands {
         #[arg(long)]
         archive_first: bool,
 
-        /// Output file path. Default: stdout (markdown / json) or stdout
-        /// + stderr (both).
+        /// Output file path. Default: stdout (markdown / json).
+        /// Required when `--format both` (writes `<out>.json` and
+        /// `<out>.md` sidecar files).
         #[arg(short, long)]
         output: Option<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1208,6 +1208,51 @@ pub enum CodexCommands {
         include: String,
     },
 
+    /// Export an archived session as Markdown or structured JSON.
+    ///
+    /// The default with no flags is "the most recent codex session, as
+    /// markdown to stdout, with sub-agent transcripts inlined and
+    /// everything else stripped." Selectors are mutually exclusive: at
+    /// most one of `--session`, `--project`, `--date` may be passed.
+    Export {
+        /// Session UUID (full or unique prefix).
+        #[arg(long, group = "selector")]
+        session: Option<String>,
+
+        /// Project to filter by: absolute path, raw cwd-encoded slug
+        /// (`-home-charlie-...`), or basename (`mx`). Ambiguous basenames
+        /// list every colliding absolute path and exit non-zero.
+        #[arg(long, group = "selector")]
+        project: Option<String>,
+
+        /// Date selector. Accepts `YYYY-MM-DD`, `YYYY-MM-DD..YYYY-MM-DD`,
+        /// or `YYYY-MM`.
+        #[arg(long, group = "selector")]
+        date: Option<String>,
+
+        /// Output format. `markdown` (default), `json`, or `both`.
+        #[arg(long, default_value = "markdown")]
+        format: String,
+
+        /// Comma-separated list of optional content to render. Default:
+        /// `subagents`. Recognized: `subagents`, `tools`,
+        /// `system-reminders`, `mcp`, `tool-output`, `history`, `all`,
+        /// `none`.
+        #[arg(long, default_value = "subagents")]
+        include: String,
+
+        /// Run `mx codex archive --all` before exporting and skip the
+        /// unarchived-data warning. Useful when you know live
+        /// `~/.claude/projects/` data hasn't been ingested yet.
+        #[arg(long)]
+        archive_first: bool,
+
+        /// Output file path. Default: stdout (markdown / json) or stdout
+        /// + stderr (both).
+        #[arg(short, long)]
+        output: Option<String>,
+    },
+
     /// List archived sessions
     List {
         /// Show all archives including incremental saves

--- a/src/codex/export/detect.rs
+++ b/src/codex/export/detect.rs
@@ -160,34 +160,34 @@ pub fn detect_unarchived_in(projects_dir: &Path, codex_dir: &Path) -> Result<Det
 /// to zero (used by tests that want the legacy "sessions only" warning
 /// shape without depending on disk state).
 fn count_unarchived_tool_outputs(archived: &HashSet<String>) -> usize {
-    if let Ok(override_path) = std::env::var("MX_CLAUDE_TMP_TASKS_DIR") {
-        if override_path == "__SKIP__" {
-            return 0;
+    let root: PathBuf = match std::env::var("MX_CLAUDE_TMP_TASKS_DIR") {
+        Ok(override_path) => {
+            if override_path == "__SKIP__" {
+                return 0;
+            }
+            PathBuf::from(override_path)
         }
-        let root = PathBuf::from(override_path);
-        if !root.exists() {
-            return 0;
+        Err(_) => {
+            #[cfg(unix)]
+            {
+                // SAFETY: getuid(2) is infallible per POSIX.
+                unsafe extern "C" {
+                    fn getuid() -> u32;
+                }
+                let uid = unsafe { getuid() };
+                PathBuf::from(format!("/tmp/claude-{}", uid))
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = archived;
+                return 0;
+            }
         }
-        return count_in_tmp_root(&root, archived);
+    };
+    if !root.exists() {
+        return 0;
     }
-    #[cfg(unix)]
-    {
-        // SAFETY: getuid(2) is infallible per POSIX.
-        unsafe extern "C" {
-            fn getuid() -> u32;
-        }
-        let uid = unsafe { getuid() };
-        let root = PathBuf::from(format!("/tmp/claude-{}", uid));
-        if !root.exists() {
-            return 0;
-        }
-        return count_in_tmp_root(&root, archived);
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = archived;
-        0
-    }
+    count_in_tmp_root(&root, archived)
 }
 
 /// Inner walker for [`count_unarchived_tool_outputs`]. Pulled out so the
@@ -200,7 +200,7 @@ fn count_in_tmp_root(root: &Path, archived: &HashSet<String>) -> usize {
             return 0;
         }
         let mut count = 0usize;
-        let user_dirs = match fs::read_dir(&root) {
+        let user_dirs = match fs::read_dir(root) {
             Ok(rd) => rd,
             Err(_) => return 0,
         };

--- a/src/codex/export/detect.rs
+++ b/src/codex/export/detect.rs
@@ -1,0 +1,337 @@
+//! Detect live Claude data that has not yet been archived into the codex.
+//!
+//! Runs at the start of `mx codex export`. Two scans:
+//!
+//! 1. `~/.claude/projects/<project-slug>/<session-uuid>.jsonl` — every
+//!    session JSONL Claude has on disk.
+//! 2. `/tmp/claude-<uid>/<user-slug>/<session-uuid>/tasks/` — per-uid
+//!    scratch with tool outputs.
+//!
+//! Each session UUID is checked against the codex by walking
+//! `<codex_dir>/<archive_dir>/manifest.json` once and building a set of
+//! archived `session_id`s. The detection report counts unarchived
+//! sessions in each source, plus a few sample UUIDs for the warning.
+//!
+//! **Important:** this module reads `~/.claude/` ONLY for detection — it
+//! never reads session content for rendering. Export's content path goes
+//! through the codex archive directory exclusively.
+
+use anyhow::Result;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Maximum sample UUIDs to include in the warning. Keeps stderr noise
+/// bounded even when hundreds of sessions are unarchived.
+const SAMPLE_CAP: usize = 5;
+
+/// Result of scanning the live Claude data sources for unarchived
+/// sessions.
+#[derive(Debug, Clone, Default)]
+pub struct DetectionReport {
+    /// Sessions present under `~/.claude/projects/` but not in the codex.
+    pub unarchived_session_count: usize,
+    /// Sessions whose `/tmp/claude-<uid>/.../tasks/` dir exists but the
+    /// session itself has no codex manifest. Subset signal that's
+    /// useful when the user just stopped a tool-using session.
+    pub unarchived_tool_output_count: usize,
+    /// Up to `SAMPLE_CAP` short UUIDs (first 8 chars) for the warning.
+    pub sample_unarchived_uuids: Vec<String>,
+}
+
+impl DetectionReport {
+    /// True iff anything unarchived was found.
+    pub fn has_unarchived(&self) -> bool {
+        self.unarchived_session_count > 0
+    }
+
+    /// Render the operator-facing warning text. Returns `None` when
+    /// nothing is unarchived.
+    pub fn warning_text(&self) -> Option<String> {
+        if !self.has_unarchived() {
+            return None;
+        }
+        let mut msg = format!(
+            "note: {} unarchived session(s) detected in ~/.claude/. \
+             Run `mx codex archive --all` to ingest, or rerun with --archive-first.",
+            self.unarchived_session_count
+        );
+        if !self.sample_unarchived_uuids.is_empty() {
+            msg.push_str("\n       Sample: ");
+            msg.push_str(&self.sample_unarchived_uuids.join(", "));
+        }
+        Some(msg)
+    }
+}
+
+/// Override hook for tests: redirect the `~/.claude/projects` scan to a
+/// custom directory. Production callers just use `detect_unarchived()`.
+pub fn detect_unarchived() -> Result<DetectionReport> {
+    let projects_dir = match std::env::var("MX_CLAUDE_PROJECTS_DIR") {
+        Ok(p) if !p.is_empty() => PathBuf::from(p),
+        _ => crate::paths::claude_projects_dir(),
+    };
+    detect_unarchived_in(&projects_dir, &crate::paths::codex_dir())
+}
+
+/// Pure: scan `projects_dir` and `codex_dir` and report unarchived sessions.
+///
+/// Extracted so unit tests can run against tempdirs without process-wide
+/// env mutation. The /tmp tasks scan is always done against the live
+/// `/tmp/claude-<uid>/...` tree because it's keyed off the running uid;
+/// for unit testing we keep that scan separate (see
+/// `count_unarchived_tool_outputs`).
+pub fn detect_unarchived_in(projects_dir: &Path, codex_dir: &Path) -> Result<DetectionReport> {
+    let archived = collect_archived_session_ids(codex_dir)?;
+    let mut report = DetectionReport::default();
+    let mut samples: Vec<String> = Vec::new();
+
+    if projects_dir.exists() {
+        for proj in fs::read_dir(projects_dir)? {
+            let proj = proj?;
+            let proj_dir = proj.path();
+            if !proj_dir.is_dir() {
+                continue;
+            }
+            for entry in fs::read_dir(&proj_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                    Some(s) => s,
+                    None => continue,
+                };
+                // Skip agent files: those mirror their parent session and
+                // aren't independently archivable.
+                if stem.starts_with("agent-") {
+                    continue;
+                }
+                if archived.contains(stem) {
+                    continue;
+                }
+                report.unarchived_session_count += 1;
+                if samples.len() < SAMPLE_CAP {
+                    let short = stem.chars().take(8).collect::<String>();
+                    samples.push(short);
+                }
+            }
+        }
+    }
+
+    report.sample_unarchived_uuids = samples;
+    report.unarchived_tool_output_count = count_unarchived_tool_outputs(&archived);
+    Ok(report)
+}
+
+/// Count session UUIDs under `/tmp/claude-<uid>/<user_slug>/` that don't
+/// have a matching codex manifest. Best-effort — silently returns 0 if
+/// the tmp tree is missing or unreadable.
+fn count_unarchived_tool_outputs(archived: &HashSet<String>) -> usize {
+    // The tmp layout encodes uid + user_slug at build time, so we walk
+    // every <session_uuid>/tasks under any user-slug subdirectory we
+    // can find. For non-Unix targets, return 0.
+    #[cfg(unix)]
+    {
+        // SAFETY: getuid(2) is infallible per POSIX.
+        unsafe extern "C" {
+            fn getuid() -> u32;
+        }
+        let uid = unsafe { getuid() };
+        let root = PathBuf::from(format!("/tmp/claude-{}", uid));
+        if !root.exists() {
+            return 0;
+        }
+        let mut count = 0usize;
+        let user_dirs = match fs::read_dir(&root) {
+            Ok(rd) => rd,
+            Err(_) => return 0,
+        };
+        for user_entry in user_dirs.flatten() {
+            let user_dir = user_entry.path();
+            if !user_dir.is_dir() {
+                continue;
+            }
+            let session_dirs = match fs::read_dir(&user_dir) {
+                Ok(rd) => rd,
+                Err(_) => continue,
+            };
+            for sess_entry in session_dirs.flatten() {
+                let sess_dir = sess_entry.path();
+                let session_uuid = match sess_dir.file_name().and_then(|n| n.to_str()) {
+                    Some(s) => s.to_string(),
+                    None => continue,
+                };
+                let tasks_dir = sess_dir.join("tasks");
+                if !tasks_dir.exists() {
+                    continue;
+                }
+                if !archived.contains(&session_uuid) {
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = archived;
+        0
+    }
+}
+
+/// Walk the codex directory once and return every session_id present in
+/// a manifest. Skips the `by-project*` accessory dirs.
+fn collect_archived_session_ids(codex_dir: &Path) -> Result<HashSet<String>> {
+    let mut ids = HashSet::new();
+    if !codex_dir.exists() {
+        return Ok(ids);
+    }
+    for entry in fs::read_dir(codex_dir)? {
+        let entry = entry?;
+        let p = entry.path();
+        if !p.is_dir() {
+            continue;
+        }
+        let name = match p.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if matches!(name, "by-project" | "by-project.staging" | "by-project.old") {
+            continue;
+        }
+        let manifest_path = p.join("manifest.json");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let raw = match fs::read_to_string(&manifest_path) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let manifest: crate::codex::Manifest = match serde_json::from_str(&raw) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        ids.insert(manifest.session_id);
+    }
+    Ok(ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn write_manifest(archive_dir: &Path, session_id: &str) {
+        fs::create_dir_all(archive_dir).unwrap();
+        let manifest = crate::codex::Manifest {
+            version: crate::codex::MANIFEST_WRITE_VERSION,
+            session_id: session_id.to_string(),
+            archived_at: Utc::now(),
+            session_start: Utc::now(),
+            session_end: Utc::now(),
+            project_path: Some("/home/test/proj".to_string()),
+            message_count: 0,
+            agent_count: 0,
+            agents: vec![],
+            size_bytes: 0,
+            checksum: "sha256:zero".to_string(),
+            image_count: None,
+            images: None,
+            has_clean_transcript: None,
+            user_name: None,
+            assistant_name: None,
+            tool_output_count: None,
+            mcp_log_count: None,
+            history_lines: None,
+            source_breakdown: None,
+        };
+        fs::write(
+            archive_dir.join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_session_jsonl(projects_dir: &Path, project_slug: &str, session_uuid: &str) {
+        let dir = projects_dir.join(project_slug);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{}.jsonl", session_uuid));
+        fs::write(&path, "{}\n").unwrap();
+    }
+
+    #[test]
+    fn detect_zero_when_everything_archived() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join("projects");
+        let codex = tmp.path().join("codex");
+        write_session_jsonl(&projects, "-home-charlie-mx", "aaaaaaaa-1111");
+        write_manifest(&codex.join("2026-04-29-100000-aaaaaaaa"), "aaaaaaaa-1111");
+
+        let report = detect_unarchived_in(&projects, &codex).unwrap();
+        assert_eq!(report.unarchived_session_count, 0);
+        assert!(!report.has_unarchived());
+        assert!(report.warning_text().is_none());
+    }
+
+    #[test]
+    fn detect_some_unarchived() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join("projects");
+        let codex = tmp.path().join("codex");
+        write_session_jsonl(&projects, "-home-charlie-mx", "aaaaaaaa-1111");
+        write_session_jsonl(&projects, "-home-charlie-mx", "bbbbbbbb-2222");
+        write_session_jsonl(&projects, "-home-charlie-wonka", "cccccccc-3333");
+        // Only one of three is archived.
+        write_manifest(&codex.join("2026-04-29-100000-aaaaaaaa"), "aaaaaaaa-1111");
+
+        let report = detect_unarchived_in(&projects, &codex).unwrap();
+        assert_eq!(report.unarchived_session_count, 2);
+        assert!(report.has_unarchived());
+        assert_eq!(report.sample_unarchived_uuids.len(), 2);
+        let warn = report.warning_text().unwrap();
+        assert!(warn.contains("2 unarchived"), "got: {warn}");
+    }
+
+    #[test]
+    fn detect_many_unarchived_caps_sample_at_five() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join("projects");
+        let codex = tmp.path().join("codex");
+        for i in 0..12 {
+            write_session_jsonl(
+                &projects,
+                "-home-charlie-mx",
+                &format!("{:08x}-1111", i + 1),
+            );
+        }
+        let report = detect_unarchived_in(&projects, &codex).unwrap();
+        assert_eq!(report.unarchived_session_count, 12);
+        assert_eq!(report.sample_unarchived_uuids.len(), SAMPLE_CAP);
+    }
+
+    #[test]
+    fn detect_skips_agent_files() {
+        // agent-*.jsonl mirrors the parent and is not independently
+        // archivable — must not count toward unarchived_session_count.
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join("projects");
+        let codex = tmp.path().join("codex");
+        let dir = projects.join("-home-charlie-mx");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("agent-1234567890ab.jsonl"), "{}\n").unwrap();
+
+        let report = detect_unarchived_in(&projects, &codex).unwrap();
+        assert_eq!(report.unarchived_session_count, 0);
+    }
+
+    #[test]
+    fn detect_handles_missing_projects_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join("does-not-exist");
+        let codex = tmp.path().join("codex");
+        let report = detect_unarchived_in(&projects, &codex).unwrap();
+        assert_eq!(report.unarchived_session_count, 0);
+    }
+}

--- a/src/codex/export/detect.rs
+++ b/src/codex/export/detect.rs
@@ -40,21 +40,45 @@ pub struct DetectionReport {
 }
 
 impl DetectionReport {
-    /// True iff anything unarchived was found.
+    /// True iff anything unarchived was found in either source
+    /// (~/.claude/ or /tmp/claude-<uid>/).
     pub fn has_unarchived(&self) -> bool {
-        self.unarchived_session_count > 0
+        self.unarchived_session_count > 0 || self.unarchived_tool_output_count > 0
     }
 
     /// Render the operator-facing warning text. Returns `None` when
     /// nothing is unarchived.
+    ///
+    /// S3: surfaces both `unarchived_session_count` (~/.claude/) and
+    /// `unarchived_tool_output_count` (/tmp/claude-<uid>/) when nonzero.
+    /// Either count alone is enough to print the warning; printing only
+    /// the nonzero source keeps the noise focused.
     pub fn warning_text(&self) -> Option<String> {
         if !self.has_unarchived() {
             return None;
         }
-        let mut msg = format!(
-            "note: {} unarchived session(s) detected in ~/.claude/. \
-             Run `mx codex archive --all` to ingest, or rerun with --archive-first.",
-            self.unarchived_session_count
+        let head = match (
+            self.unarchived_session_count,
+            self.unarchived_tool_output_count,
+        ) {
+            (0, 0) => unreachable!("has_unarchived() guards this branch"),
+            (sessions, 0) => format!(
+                "note: {} unarchived session(s) detected in ~/.claude/.",
+                sessions
+            ),
+            (0, tools) => format!(
+                "note: {} session(s) with tool output in /tmp/ not yet archived.",
+                tools
+            ),
+            (sessions, tools) => format!(
+                "note: {} unarchived session(s) detected in ~/.claude/, \
+                 and {} session(s) with tool output in /tmp/.",
+                sessions, tools
+            ),
+        };
+        let mut msg = head;
+        msg.push_str(
+            "\n       Run `mx codex archive --all` to ingest, or rerun with --archive-first.",
         );
         if !self.sample_unarchived_uuids.is_empty() {
             msg.push_str("\n       Sample: ");
@@ -128,10 +152,24 @@ pub fn detect_unarchived_in(projects_dir: &Path, codex_dir: &Path) -> Result<Det
 /// Count session UUIDs under `/tmp/claude-<uid>/<user_slug>/` that don't
 /// have a matching codex manifest. Best-effort — silently returns 0 if
 /// the tmp tree is missing or unreadable.
+///
+/// **Test hook:** the env var `MX_CLAUDE_TMP_TASKS_DIR` overrides the
+/// scan root entirely. Tests set it to an empty tempdir so the count is
+/// deterministic regardless of what's actually in `/tmp/claude-<uid>/`
+/// on the test runner. Setting it to `__SKIP__` short-circuits the scan
+/// to zero (used by tests that want the legacy "sessions only" warning
+/// shape without depending on disk state).
 fn count_unarchived_tool_outputs(archived: &HashSet<String>) -> usize {
-    // The tmp layout encodes uid + user_slug at build time, so we walk
-    // every <session_uuid>/tasks under any user-slug subdirectory we
-    // can find. For non-Unix targets, return 0.
+    if let Ok(override_path) = std::env::var("MX_CLAUDE_TMP_TASKS_DIR") {
+        if override_path == "__SKIP__" {
+            return 0;
+        }
+        let root = PathBuf::from(override_path);
+        if !root.exists() {
+            return 0;
+        }
+        return count_in_tmp_root(&root, archived);
+    }
     #[cfg(unix)]
     {
         // SAFETY: getuid(2) is infallible per POSIX.
@@ -140,6 +178,24 @@ fn count_unarchived_tool_outputs(archived: &HashSet<String>) -> usize {
         }
         let uid = unsafe { getuid() };
         let root = PathBuf::from(format!("/tmp/claude-{}", uid));
+        if !root.exists() {
+            return 0;
+        }
+        return count_in_tmp_root(&root, archived);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = archived;
+        0
+    }
+}
+
+/// Inner walker for [`count_unarchived_tool_outputs`]. Pulled out so the
+/// env-var override and the production /tmp branch share one
+/// implementation.
+fn count_in_tmp_root(root: &Path, archived: &HashSet<String>) -> usize {
+    #[cfg(unix)]
+    {
         if !root.exists() {
             return 0;
         }
@@ -222,6 +278,45 @@ fn collect_archived_session_ids(codex_dir: &Path) -> Result<HashSet<String>> {
 mod tests {
     use super::*;
     use chrono::Utc;
+    use serial_test::serial;
+    use std::sync::Mutex;
+
+    // Process-wide lock so tests that twiddle MX_CLAUDE_TMP_TASKS_DIR
+    // don't interleave with each other. Pairs with `#[serial]`.
+    static TMP_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard: sets `MX_CLAUDE_TMP_TASKS_DIR=__SKIP__` for the
+    /// lifetime of the guard. Most detect-tests want a deterministic
+    /// zero from the /tmp scan regardless of what's actually in
+    /// `/tmp/claude-<uid>/` on the runner.
+    struct SkipTmpScan {
+        prev: Option<String>,
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+    impl SkipTmpScan {
+        fn new() -> Self {
+            let guard = TMP_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var("MX_CLAUDE_TMP_TASKS_DIR").ok();
+            // SAFETY: env mutation guarded by TMP_ENV_LOCK + #[serial].
+            unsafe {
+                std::env::set_var("MX_CLAUDE_TMP_TASKS_DIR", "__SKIP__");
+            }
+            Self {
+                prev,
+                _guard: guard,
+            }
+        }
+    }
+    impl Drop for SkipTmpScan {
+        fn drop(&mut self) {
+            unsafe {
+                match self.prev.take() {
+                    Some(v) => std::env::set_var("MX_CLAUDE_TMP_TASKS_DIR", v),
+                    None => std::env::remove_var("MX_CLAUDE_TMP_TASKS_DIR"),
+                }
+            }
+        }
+    }
 
     fn write_manifest(archive_dir: &Path, session_id: &str) {
         fs::create_dir_all(archive_dir).unwrap();
@@ -262,7 +357,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn detect_zero_when_everything_archived() {
+        let _skip = SkipTmpScan::new();
         let tmp = tempfile::tempdir().unwrap();
         let projects = tmp.path().join("projects");
         let codex = tmp.path().join("codex");
@@ -276,7 +373,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn detect_some_unarchived() {
+        let _skip = SkipTmpScan::new();
         let tmp = tempfile::tempdir().unwrap();
         let projects = tmp.path().join("projects");
         let codex = tmp.path().join("codex");
@@ -295,7 +394,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn detect_many_unarchived_caps_sample_at_five() {
+        let _skip = SkipTmpScan::new();
         let tmp = tempfile::tempdir().unwrap();
         let projects = tmp.path().join("projects");
         let codex = tmp.path().join("codex");
@@ -312,7 +413,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn detect_skips_agent_files() {
+        let _skip = SkipTmpScan::new();
         // agent-*.jsonl mirrors the parent and is not independently
         // archivable — must not count toward unarchived_session_count.
         let tmp = tempfile::tempdir().unwrap();
@@ -327,11 +430,114 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn detect_handles_missing_projects_dir() {
+        let _skip = SkipTmpScan::new();
         let tmp = tempfile::tempdir().unwrap();
         let projects = tmp.path().join("does-not-exist");
         let codex = tmp.path().join("codex");
         let report = detect_unarchived_in(&projects, &codex).unwrap();
         assert_eq!(report.unarchived_session_count, 0);
+    }
+
+    // ---- S3: warning surfaces tool-output count ----
+
+    #[test]
+    fn warning_text_combines_both_counts_when_both_nonzero() {
+        let report = DetectionReport {
+            unarchived_session_count: 23,
+            unarchived_tool_output_count: 7,
+            sample_unarchived_uuids: vec!["c3744b8d".to_string(), "a1b2c3d4".to_string()],
+        };
+        let warn = report.warning_text().expect("should produce warning");
+        assert!(
+            warn.contains("23 unarchived"),
+            "missing session count: {warn}"
+        );
+        assert!(
+            warn.contains("7 session(s) with tool output"),
+            "missing tool-output count: {warn}"
+        );
+        assert!(warn.contains("/tmp/"), "should mention /tmp source: {warn}");
+        assert!(
+            warn.contains("mx codex archive --all"),
+            "should keep the remediation hint: {warn}"
+        );
+        assert!(
+            warn.contains("c3744b8d"),
+            "should keep sample uuids: {warn}"
+        );
+    }
+
+    #[test]
+    fn warning_text_tool_output_only_still_prints() {
+        // /tmp/claude-<uid>/ has unarchived sessions but ~/.claude/ is
+        // clean. Operator should still see the warning so the tool
+        // outputs aren't lost.
+        let report = DetectionReport {
+            unarchived_session_count: 0,
+            unarchived_tool_output_count: 3,
+            sample_unarchived_uuids: vec![],
+        };
+        assert!(report.has_unarchived());
+        let warn = report.warning_text().expect("tool-output-only must warn");
+        assert!(warn.contains("3 session(s) with tool output"));
+        assert!(!warn.contains("unarchived session(s) detected in ~/.claude/"));
+    }
+
+    #[test]
+    #[serial]
+    fn detect_counts_unarchived_tool_outputs_via_override() {
+        // Exercise the env-var override path: a fixture /tmp tree with
+        // two sessions, one of which IS in the codex. Expect a count of
+        // exactly 1 unarchived tool-output session.
+        let guard = TMP_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join("projects");
+        let codex = tmp.path().join("codex");
+        let tmp_root = tmp.path().join("tmp_claude");
+        std::fs::create_dir_all(&projects).unwrap();
+
+        // Codex has one archived session.
+        write_manifest(&codex.join("2026-04-29-100000-aaaaaaaa"), "aaaaaaaa-1111");
+
+        // /tmp fixture: two sessions, each with a `tasks/` dir.
+        let user_slug = tmp_root.join("user-charlie");
+        std::fs::create_dir_all(user_slug.join("aaaaaaaa-1111").join("tasks")).unwrap();
+        std::fs::create_dir_all(user_slug.join("zzzzzzzz-9999").join("tasks")).unwrap();
+
+        let prev = std::env::var("MX_CLAUDE_TMP_TASKS_DIR").ok();
+        unsafe {
+            std::env::set_var("MX_CLAUDE_TMP_TASKS_DIR", &tmp_root);
+        }
+        let report = detect_unarchived_in(&projects, &codex).unwrap();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_CLAUDE_TMP_TASKS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_TMP_TASKS_DIR"),
+            }
+        }
+        drop(guard);
+
+        // aaaaaaaa is archived → not counted; zzzzzzzz is not → counted.
+        assert_eq!(report.unarchived_tool_output_count, 1);
+        // Has-unarchived should fire on tool-output count alone.
+        assert!(report.has_unarchived());
+    }
+
+    #[test]
+    fn warning_text_sessions_only_omits_tool_output_phrase() {
+        // Backwards-compatible shape when the /tmp source is clean.
+        let report = DetectionReport {
+            unarchived_session_count: 2,
+            unarchived_tool_output_count: 0,
+            sample_unarchived_uuids: vec!["aaaaaaaa".to_string()],
+        };
+        let warn = report.warning_text().unwrap();
+        assert!(warn.contains("2 unarchived"));
+        assert!(
+            !warn.contains("tool output"),
+            "no tool-output phrase when count is zero: {warn}"
+        );
     }
 }

--- a/src/codex/export/filter.rs
+++ b/src/codex/export/filter.rs
@@ -1,0 +1,389 @@
+//! Selection and resolution for `mx codex export`.
+//!
+//! Three things live here:
+//!
+//! 1. `Selector` — what the caller asked for (single session, project,
+//!    date range, or "latest").
+//! 2. `SessionRef` / `DateRange` — the parameter shapes selectors carry.
+//! 3. The resolution functions that turn a selector into the concrete
+//!    list of codex archive directories to render.
+//!
+//! Resolution is read-only: it walks `<codex_dir>/<archive_dir>/manifest.json`,
+//! never `~/.claude/projects/`. (The architecture is explicit: export must
+//! NOT read live Claude data — only the codex.)
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use std::path::{Path, PathBuf};
+
+use crate::codex::Manifest;
+
+/// What to export.
+#[derive(Debug, Clone)]
+pub enum Selector {
+    /// A specific session by full UUID or short prefix.
+    Session(SessionRef),
+    /// Every session for a project (path / slug / basename).
+    Project(String),
+    /// Every session whose `session_start` falls in the range.
+    Date(DateRange),
+    /// The most recent codex session — default when no other selector
+    /// is supplied.
+    Latest,
+}
+
+/// Reference to a session by ID. Either the full UUID or a unique prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionRef(pub String);
+
+impl SessionRef {
+    /// True if `id` matches this ref. Prefix match: `c3744b8d` matches
+    /// `c3744b8d-5719-4df2-924f-707945438494`.
+    pub fn matches(&self, id: &str) -> bool {
+        id.starts_with(&self.0)
+    }
+}
+
+/// Inclusive date range for `Selector::Date`. Both ends are UTC midnights.
+///
+/// Parser accepts:
+/// - `YYYY-MM-DD` → that single day, midnight to next-midnight
+/// - `YYYY-MM-DD..YYYY-MM-DD` → inclusive day range
+/// - `YYYY-MM` → the whole month
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DateRange {
+    pub start: DateTime<Utc>,
+    /// Exclusive end so we can use `< end` semantics. The CLI form is
+    /// inclusive at the day level — for `2026-04-29..2026-04-30` end
+    /// is `2026-05-01T00:00:00Z`.
+    pub end: DateTime<Utc>,
+}
+
+impl DateRange {
+    /// True iff `ts` is in `[start, end)`.
+    pub fn contains(&self, ts: DateTime<Utc>) -> bool {
+        ts >= self.start && ts < self.end
+    }
+
+    /// Parse a CLI date expression.
+    pub fn parse(s: &str) -> Result<Self> {
+        let s = s.trim();
+        if s.is_empty() {
+            anyhow::bail!("empty --date value");
+        }
+
+        // Range form: `YYYY-MM-DD..YYYY-MM-DD`.
+        if let Some((lhs, rhs)) = s.split_once("..") {
+            let start_day = parse_ymd(lhs.trim())
+                .with_context(|| format!("--date range start '{}' is not YYYY-MM-DD", lhs))?;
+            let end_day = parse_ymd(rhs.trim())
+                .with_context(|| format!("--date range end '{}' is not YYYY-MM-DD", rhs))?;
+            if end_day < start_day {
+                anyhow::bail!(
+                    "--date range '{}' is inverted (start {} is after end {})",
+                    s,
+                    start_day,
+                    end_day
+                );
+            }
+            return Ok(Self {
+                start: midnight_utc(start_day),
+                end: midnight_utc(end_day + chrono::Duration::days(1)),
+            });
+        }
+
+        // Single day: `YYYY-MM-DD`.
+        if s.len() == 10
+            && let Ok(day) = parse_ymd(s)
+        {
+            return Ok(Self {
+                start: midnight_utc(day),
+                end: midnight_utc(day + chrono::Duration::days(1)),
+            });
+        }
+
+        // Month: `YYYY-MM`.
+        if s.len() == 7
+            && let Some((y, m)) = s.split_once('-')
+        {
+            let year: i32 = y
+                .parse()
+                .with_context(|| format!("--date '{}' has non-numeric year", s))?;
+            let month: u32 = m
+                .parse()
+                .with_context(|| format!("--date '{}' has non-numeric month", s))?;
+            if !(1..=12).contains(&month) {
+                anyhow::bail!("--date '{}' month out of range (1..=12)", s);
+            }
+            let start_day = NaiveDate::from_ymd_opt(year, month, 1)
+                .with_context(|| format!("--date '{}' is not a valid year-month", s))?;
+            let end_day = if month == 12 {
+                NaiveDate::from_ymd_opt(year + 1, 1, 1)
+            } else {
+                NaiveDate::from_ymd_opt(year, month + 1, 1)
+            }
+            .context("internal date overflow")?;
+            return Ok(Self {
+                start: midnight_utc(start_day),
+                end: midnight_utc(end_day),
+            });
+        }
+
+        anyhow::bail!(
+            "--date '{}' is not a recognized form (expected YYYY-MM-DD, \
+             YYYY-MM-DD..YYYY-MM-DD, or YYYY-MM)",
+            s
+        );
+    }
+}
+
+fn parse_ymd(s: &str) -> Result<NaiveDate> {
+    NaiveDate::parse_from_str(s, "%Y-%m-%d").with_context(|| format!("'{}' is not YYYY-MM-DD", s))
+}
+
+fn midnight_utc(date: NaiveDate) -> DateTime<Utc> {
+    Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0).expect("00:00:00 is valid"))
+}
+
+/// One archive directory the export will render. Pairs the directory
+/// path with the deserialized manifest so emitters don't re-read it.
+#[derive(Debug, Clone)]
+pub struct ResolvedArchive {
+    pub archive_dir: PathBuf,
+    pub manifest: Manifest,
+}
+
+/// Walk `<codex_dir>/` and return every archive whose manifest parses.
+/// Skips the by-project / staging / .old subdirs.
+pub fn collect_codex_archives(codex_dir: &Path) -> Result<Vec<ResolvedArchive>> {
+    let mut out = Vec::new();
+    if !codex_dir.exists() {
+        return Ok(out);
+    }
+    for entry in std::fs::read_dir(codex_dir)? {
+        let entry = entry?;
+        let archive_dir = entry.path();
+        if !archive_dir.is_dir() {
+            continue;
+        }
+        let name = match archive_dir.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if matches!(name, "by-project" | "by-project.staging" | "by-project.old") {
+            continue;
+        }
+        let manifest_path = archive_dir.join("manifest.json");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let raw = match std::fs::read_to_string(&manifest_path) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let manifest: Manifest = match serde_json::from_str(&raw) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        out.push(ResolvedArchive {
+            archive_dir,
+            manifest,
+        });
+    }
+    Ok(out)
+}
+
+/// Pick a single archive for a `Selector::Session` query.
+///
+/// - Exact match wins.
+/// - Otherwise prefix match; multiple prefix matches → error listing IDs.
+pub fn resolve_session(
+    archives: Vec<ResolvedArchive>,
+    sref: &SessionRef,
+) -> Result<ResolvedArchive> {
+    let exact: Vec<ResolvedArchive> = archives
+        .iter()
+        .filter(|a| a.manifest.session_id == sref.0)
+        .cloned()
+        .collect();
+    if exact.len() == 1 {
+        return Ok(exact.into_iter().next().unwrap());
+    }
+    if exact.len() > 1 {
+        let ids: Vec<String> = exact
+            .iter()
+            .map(|a| a.manifest.session_id.clone())
+            .collect();
+        anyhow::bail!(
+            "session ID '{}' is duplicated in the codex (matched {}). \
+             This usually means a manifest has been edited; re-archive to disambiguate.",
+            sref.0,
+            ids.join(", ")
+        );
+    }
+    let prefix: Vec<ResolvedArchive> = archives
+        .into_iter()
+        .filter(|a| sref.matches(&a.manifest.session_id))
+        .collect();
+    match prefix.len() {
+        0 => anyhow::bail!(
+            "no archived session matches '{}' (full UUID or unique prefix)",
+            sref.0
+        ),
+        1 => Ok(prefix.into_iter().next().unwrap()),
+        _ => {
+            let ids: Vec<String> = prefix
+                .iter()
+                .map(|a| a.manifest.session_id.clone())
+                .collect();
+            anyhow::bail!(
+                "session prefix '{}' is ambiguous; matches {}. \
+                 Use a longer prefix or the full UUID.",
+                sref.0,
+                ids.join(", ")
+            );
+        }
+    }
+}
+
+/// Filter archives down to those belonging to the specified project.
+///
+/// `query` accepts the same three forms as `ProjectIndex::lookup`. Hits
+/// the index when possible and falls back to a manifest walk on its
+/// own filtered scan.
+pub fn resolve_project(
+    archives: Vec<ResolvedArchive>,
+    query: &str,
+) -> Result<Vec<ResolvedArchive>> {
+    // For projects we always re-filter the manifests directly — the
+    // index gives us the canonical project_path(s) but we still need
+    // the loaded manifests here so the caller doesn't double-read.
+    let idx = crate::codex::index::ProjectIndex::open()?;
+    let entry = idx.lookup(query)?;
+    let project_paths: Vec<String> = entry
+        .absolute_paths
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    let mut matched: Vec<ResolvedArchive> = archives
+        .into_iter()
+        .filter(|a| {
+            a.manifest
+                .project_path
+                .as_ref()
+                .map(|p| project_paths.iter().any(|pp| pp == p))
+                .unwrap_or(false)
+        })
+        .collect();
+    matched.sort_by_key(|a| a.manifest.session_start);
+    if matched.is_empty() {
+        anyhow::bail!(
+            "project '{}' resolved to {:?} but no archived sessions reference it",
+            query,
+            project_paths
+        );
+    }
+    Ok(matched)
+}
+
+/// Filter archives down to those whose `session_start` lies in `range`.
+pub fn resolve_date(archives: Vec<ResolvedArchive>, range: &DateRange) -> Vec<ResolvedArchive> {
+    let mut matched: Vec<ResolvedArchive> = archives
+        .into_iter()
+        .filter(|a| range.contains(a.manifest.session_start))
+        .collect();
+    matched.sort_by_key(|a| a.manifest.session_start);
+    matched
+}
+
+/// The most recent archive (greatest `session_start`).
+pub fn resolve_latest(archives: Vec<ResolvedArchive>) -> Result<ResolvedArchive> {
+    archives
+        .into_iter()
+        .max_by_key(|a| a.manifest.session_start)
+        .context("no archived sessions in codex (run `mx codex archive --all`)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(s: &str) -> DateTime<Utc> {
+        s.parse().unwrap()
+    }
+
+    // ------------------------------------------------------------------
+    // DateRange::parse
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn date_range_parses_single_day() {
+        let r = DateRange::parse("2026-04-29").unwrap();
+        assert_eq!(r.start, date("2026-04-29T00:00:00Z"));
+        assert_eq!(r.end, date("2026-04-30T00:00:00Z"));
+        assert!(r.contains(date("2026-04-29T12:00:00Z")));
+        assert!(!r.contains(date("2026-04-30T00:00:00Z")));
+    }
+
+    #[test]
+    fn date_range_parses_inclusive_day_range() {
+        let r = DateRange::parse("2026-04-01..2026-04-30").unwrap();
+        assert_eq!(r.start, date("2026-04-01T00:00:00Z"));
+        // End is exclusive at the next day's midnight, so 2026-04-30 is in range.
+        assert!(r.contains(date("2026-04-30T23:59:59Z")));
+        assert!(!r.contains(date("2026-05-01T00:00:00Z")));
+    }
+
+    #[test]
+    fn date_range_parses_whole_month() {
+        let r = DateRange::parse("2026-04").unwrap();
+        assert_eq!(r.start, date("2026-04-01T00:00:00Z"));
+        assert_eq!(r.end, date("2026-05-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn date_range_parses_december_month_rolls_year() {
+        let r = DateRange::parse("2026-12").unwrap();
+        assert_eq!(r.start, date("2026-12-01T00:00:00Z"));
+        assert_eq!(r.end, date("2027-01-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn date_range_rejects_inverted_range() {
+        let err = DateRange::parse("2026-04-30..2026-04-01").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("inverted"), "got: {msg}");
+    }
+
+    #[test]
+    fn date_range_rejects_garbage() {
+        assert!(DateRange::parse("yesterday").is_err());
+        assert!(DateRange::parse("").is_err());
+        assert!(DateRange::parse("2026-13").is_err());
+    }
+
+    #[test]
+    fn date_range_rejects_invalid_calendar_day() {
+        // Feb 30 isn't a calendar day — must error rather than silently
+        // sliding to March 2.
+        assert!(DateRange::parse("2026-02-30").is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // SessionRef::matches
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn session_ref_prefix_match() {
+        let r = SessionRef("c3744b8d".to_string());
+        assert!(r.matches("c3744b8d-5719-4df2-924f-707945438494"));
+        assert!(!r.matches("d3744b8d-5719-4df2-924f-707945438494"));
+    }
+
+    #[test]
+    fn session_ref_exact_match() {
+        let full = "c3744b8d-5719-4df2-924f-707945438494";
+        let r = SessionRef(full.to_string());
+        assert!(r.matches(full));
+    }
+}

--- a/src/codex/export/format/json.rs
+++ b/src/codex/export/format/json.rs
@@ -1,0 +1,251 @@
+//! Structured-JSON emitter for `mx codex export`.
+//!
+//! Schema (top-level object):
+//!
+//! ```jsonc
+//! {
+//!   "manifest":   { ...the codex manifest verbatim... },
+//!   "events":     [ ...parsed session events, filtered by include flags... ],
+//!   "agents":     [ { "name": "...", "events": [...] }, ... ],
+//!   "sidecars": {
+//!     "mcp_logs":     [ { "name": "...", "content": "..." }, ... ],
+//!     "tool_outputs": [ { "name": "...", "content": "..." }, ... ],
+//!     "history":      [ ...lines as JSON values, when parseable... ]
+//!   }
+//! }
+//! ```
+//!
+//! Events keep their raw shape from the JSONL — we don't transform them
+//! beyond filtering based on the include flags. This is the form tool
+//! consumers want; humans should pick the markdown emitter.
+
+use anyhow::Result;
+use serde_json::{Value, json};
+
+use crate::codex::Manifest;
+use crate::codex::export::include::ExportIncludeSet;
+use crate::codex::export::read::LoadedArchive;
+
+/// Render a loaded archive to a JSON string.
+pub fn render(
+    archive: &LoadedArchive,
+    manifest: &Manifest,
+    include: &ExportIncludeSet,
+) -> Result<String> {
+    let manifest_json = serde_json::to_value(manifest)?;
+    let events = filter_events(&archive.session_jsonl, include);
+    let agents = render_agents(archive, include);
+    let sidecars = render_sidecars(archive, include);
+
+    let doc = json!({
+        "manifest": manifest_json,
+        "events": events,
+        "agents": agents,
+        "sidecars": sidecars,
+    });
+    Ok(serde_json::to_string_pretty(&doc)?)
+}
+
+fn filter_events(content: &Option<String>, include: &ExportIncludeSet) -> Vec<Value> {
+    let mut out = Vec::new();
+    let content = match content {
+        Some(c) => c,
+        None => return out,
+    };
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let mut value: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // Strip `tool_use` blocks from assistant content if tools are off.
+        if !include.tools
+            && value["type"].as_str() == Some("assistant")
+            && let Some(blocks) = value["message"]["content"].as_array()
+        {
+            let kept: Vec<Value> = blocks
+                .iter()
+                .filter(|b| b["type"].as_str() != Some("tool_use"))
+                .cloned()
+                .collect();
+            value["message"]["content"] = Value::Array(kept);
+        }
+        // Strip `<system-reminder>...</system-reminder>` from text fields
+        // if system_reminders are off.
+        if !include.system_reminders {
+            scrub_system_reminders(&mut value);
+        }
+        out.push(value);
+    }
+    out
+}
+
+fn scrub_system_reminders(value: &mut Value) {
+    use crate::codex::export::format::markdown::system_reminder_re_for_export;
+    match value {
+        Value::String(s) => {
+            *s = system_reminder_re_for_export()
+                .replace_all(s, "")
+                .to_string();
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                scrub_system_reminders(v);
+            }
+        }
+        Value::Object(map) => {
+            for (_, v) in map.iter_mut() {
+                scrub_system_reminders(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn render_agents(archive: &LoadedArchive, include: &ExportIncludeSet) -> Vec<Value> {
+    if !include.subagents {
+        return Vec::new();
+    }
+    archive
+        .agents
+        .iter()
+        .map(|(name, content)| {
+            let events = filter_events(&Some(content.clone()), include);
+            json!({ "name": name, "events": events })
+        })
+        .collect()
+}
+
+fn render_sidecars(archive: &LoadedArchive, include: &ExportIncludeSet) -> Value {
+    let mcp = if include.mcp {
+        archive
+            .mcp_logs
+            .iter()
+            .map(|p| {
+                let name = p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("(unnamed)")
+                    .to_string();
+                let content = std::fs::read_to_string(p).unwrap_or_default();
+                json!({ "name": name, "content": content })
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let tool_outputs = if include.tool_output {
+        archive
+            .tool_outputs
+            .iter()
+            .map(|p| {
+                let name = p
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("(unnamed)")
+                    .to_string();
+                let content = std::fs::read_to_string(p).unwrap_or_default();
+                json!({ "name": name, "content": content })
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let history = if include.history
+        && let Some(content) = &archive.history_jsonl
+    {
+        content
+            .lines()
+            .filter_map(|l| serde_json::from_str::<Value>(l.trim()).ok())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    json!({
+        "mcp_logs": mcp,
+        "tool_outputs": tool_outputs,
+        "history": history,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codex::MANIFEST_WRITE_VERSION;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    fn fixture_manifest() -> Manifest {
+        Manifest {
+            version: MANIFEST_WRITE_VERSION,
+            session_id: "test".to_string(),
+            archived_at: Utc::now(),
+            session_start: "2026-04-29T10:00:00Z".parse().unwrap(),
+            session_end: "2026-04-29T10:30:00Z".parse().unwrap(),
+            project_path: Some("/home/charlie/work/mx".to_string()),
+            message_count: 0,
+            agent_count: 0,
+            agents: vec![],
+            size_bytes: 0,
+            checksum: "sha256:zero".to_string(),
+            image_count: None,
+            images: None,
+            has_clean_transcript: None,
+            user_name: None,
+            assistant_name: None,
+            tool_output_count: None,
+            mcp_log_count: None,
+            history_lines: None,
+            source_breakdown: None,
+        }
+    }
+
+    fn empty_archive(jsonl: &str) -> LoadedArchive {
+        LoadedArchive {
+            archive_dir: PathBuf::from("/nonexistent"),
+            session_jsonl: Some(jsonl.to_string()),
+            conversation_md: None,
+            agents: vec![],
+            mcp_logs: vec![],
+            tool_outputs: vec![],
+            history_jsonl: None,
+        }
+    }
+
+    #[test]
+    fn render_top_level_keys() {
+        let m = fixture_manifest();
+        let arc = empty_archive("");
+        let out = render(&arc, &m, &ExportIncludeSet::default_clean()).unwrap();
+        let parsed: Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed.get("manifest").is_some());
+        assert!(parsed.get("events").is_some());
+        assert!(parsed.get("agents").is_some());
+        assert!(parsed.get("sidecars").is_some());
+    }
+
+    #[test]
+    fn render_strips_tool_use_when_tools_disabled() {
+        let jsonl = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"a","name":"Bash"},{"type":"text","text":"ok"}]}}"#;
+        let m = fixture_manifest();
+        let arc = empty_archive(jsonl);
+        let out = render(&arc, &m, &ExportIncludeSet::default_clean()).unwrap();
+        assert!(!out.contains("tool_use"));
+        assert!(out.contains("\"ok\""));
+    }
+
+    #[test]
+    fn render_keeps_tool_use_when_tools_enabled() {
+        let jsonl = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"a","name":"Bash"},{"type":"text","text":"ok"}]}}"#;
+        let m = fixture_manifest();
+        let arc = empty_archive(jsonl);
+        let mut inc = ExportIncludeSet::default_clean();
+        inc.tools = true;
+        let out = render(&arc, &m, &inc).unwrap();
+        assert!(out.contains("tool_use"));
+        assert!(out.contains("Bash"));
+    }
+}

--- a/src/codex/export/format/markdown.rs
+++ b/src/codex/export/format/markdown.rs
@@ -30,6 +30,20 @@ use crate::codex::export::read::LoadedArchive;
 
 static SYSTEM_REMINDER_RE: OnceLock<Regex> = OnceLock::new();
 
+/// Compiled pattern for stripping `<system-reminder>...</system-reminder>`
+/// blocks injected by the platform.
+///
+/// **Known limitation (v1, by design).** This is a textual heuristic: any
+/// occurrence of the byte sequence `<system-reminder>...</system-reminder>`
+/// in a string field is removed, regardless of who wrote it. A user
+/// message that legitimately quotes that sequence — e.g. an excerpt of a
+/// meta-conversation about reminders — will be incorrectly stripped along
+/// with the platform-injected blocks. Acceptable for v1: the failure mode
+/// is a redaction, not data leakage, and the false-positive rate on real
+/// transcripts is effectively zero. Future work could anchor stripping to
+/// the platform-injection envelope (a stable discriminator on the message
+/// shape rather than a substring match) once the platform exposes one.
+/// Tracked as TODO(#254-followup).
 fn system_reminder_re() -> &'static Regex {
     SYSTEM_REMINDER_RE.get_or_init(|| {
         Regex::new(r"(?s)<system-reminder>.*?</system-reminder>")
@@ -39,6 +53,12 @@ fn system_reminder_re() -> &'static Regex {
 
 /// Cross-emitter accessor: the JSON emitter scrubs `<system-reminder>`
 /// blocks from string fields too, so it borrows the same compiled regex.
+///
+/// Inherits the textual-heuristic limitation documented on
+/// [`system_reminder_re`]. The JSON walker recurses into every string
+/// value in the document, so the same false-positive applies anywhere a
+/// quoted `<system-reminder>...</system-reminder>` appears in legitimate
+/// content.
 pub(crate) fn system_reminder_re_for_export() -> &'static Regex {
     system_reminder_re()
 }
@@ -345,6 +365,45 @@ mod tests {
         inc.system_reminders = true;
         let out = render(&arc, &m, &inc).unwrap();
         assert!(out.contains("secret"));
+    }
+
+    /// W2 / TODO(#254-followup): the `<system-reminder>` regex is a
+    /// textual heuristic and will strip the byte sequence even from
+    /// legitimately-quoted user prose (e.g. a meta-conversation excerpt).
+    /// This test documents the v1 limitation by asserting the
+    /// known-incorrect behavior: a user message that quotes the pattern
+    /// IS stripped. When future work anchors stripping to the
+    /// platform-injection envelope, this assertion will need to flip
+    /// (the prose should survive) and that flip is the signal that the
+    /// limitation has been lifted.
+    #[test]
+    fn render_xfail_strips_legitimately_quoted_system_reminder() {
+        // The user is meta-quoting what a reminder block looks like;
+        // ideally this prose would be preserved.
+        let jsonl = concat!(
+            r#"{"type":"user","message":{"content":"For context, the platform sometimes injects <system-reminder>do X</system-reminder> blocks — please ignore them."}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"understood"}]}}"#,
+            "\n",
+        );
+        let m = fixture_manifest();
+        let arc = empty_archive_with_jsonl(jsonl);
+        let inc = ExportIncludeSet::default_clean(); // system_reminders=false
+        let out = render(&arc, &m, &inc).unwrap();
+        // XFAIL: the regex strips the quoted block from the user prose.
+        // When this changes (correctly preserving the user's quote), the
+        // assertions below should flip — that's the signal to revisit
+        // the doc comment on `system_reminder_re`.
+        assert!(
+            !out.contains("do X"),
+            "v1 textual heuristic strips the quoted reminder; if this assertion \
+             starts failing, the limitation has been lifted — update the doc \
+             comment on system_reminder_re()"
+        );
+        // Surrounding prose is preserved (the regex is non-greedy and
+        // only eats the matched span).
+        assert!(out.contains("the platform sometimes injects"));
+        assert!(out.contains("please ignore them"));
     }
 
     #[test]

--- a/src/codex/export/format/markdown.rs
+++ b/src/codex/export/format/markdown.rs
@@ -1,0 +1,406 @@
+//! Markdown emitter for `mx codex export`.
+//!
+//! Two rendering paths, in priority order:
+//!
+//! 1. If the archive has a `conversation.md` (i.e. it was archived in
+//!    clean mode), prefer that for the human/assistant prose. Apply the
+//!    include filters as best we can — `system_reminders` and `tools`
+//!    can't actually be re-introduced (clean mode already stripped
+//!    them), but we still honour the filters for the optional sidecars
+//!    appended below.
+//! 2. Otherwise render from the raw `session.jsonl`. Walk every event
+//!    line and:
+//!    - skip `<system-reminder>` blocks unless `include.system_reminders`
+//!    - skip `tool_use` blocks unless `include.tools`
+//!    - render human / assistant turns as Markdown
+//!    - inline subagent transcripts at the parent's Task-tool boundary
+//!      if `include.subagents`
+//!
+//! After the prose, optional sidecars are appended as separate sections
+//! gated on the matching include flag.
+
+use anyhow::Result;
+use regex::Regex;
+use serde_json::Value;
+use std::sync::OnceLock;
+
+use crate::codex::Manifest;
+use crate::codex::export::include::ExportIncludeSet;
+use crate::codex::export::read::LoadedArchive;
+
+static SYSTEM_REMINDER_RE: OnceLock<Regex> = OnceLock::new();
+
+fn system_reminder_re() -> &'static Regex {
+    SYSTEM_REMINDER_RE.get_or_init(|| {
+        Regex::new(r"(?s)<system-reminder>.*?</system-reminder>")
+            .expect("system-reminder regex must compile")
+    })
+}
+
+/// Cross-emitter accessor: the JSON emitter scrubs `<system-reminder>`
+/// blocks from string fields too, so it borrows the same compiled regex.
+pub(crate) fn system_reminder_re_for_export() -> &'static Regex {
+    system_reminder_re()
+}
+
+/// Render a loaded archive to a single Markdown document.
+pub fn render(
+    archive: &LoadedArchive,
+    manifest: &Manifest,
+    include: &ExportIncludeSet,
+) -> Result<String> {
+    let mut out = String::new();
+
+    // Header: enough metadata to be self-describing without dumping the
+    // full manifest.
+    out.push_str(&format!("# Session {}\n\n", manifest.session_id));
+    out.push_str(&format!(
+        "- **Started:** {}\n",
+        manifest.session_start.to_rfc3339()
+    ));
+    out.push_str(&format!(
+        "- **Ended:** {}\n",
+        manifest.session_end.to_rfc3339()
+    ));
+    if let Some(p) = &manifest.project_path {
+        out.push_str(&format!("- **Project:** `{}`\n", p));
+    }
+    out.push_str(&format!(
+        "- **Messages:** {} (across {} agent(s))\n",
+        manifest.message_count, manifest.agent_count
+    ));
+    out.push('\n');
+
+    // -- Conversation body --
+
+    if let Some(md) = &archive.conversation_md {
+        // Clean-mode archive: re-use the on-disk markdown. The include
+        // filters for `tools` / `system-reminders` are advisory here —
+        // the clean transcript stripped them at archive time, so there's
+        // nothing left to re-introduce. Document this in the rendered
+        // output so consumers know the filters are partially load-bearing.
+        out.push_str("## Conversation\n\n");
+        if include.system_reminders || include.tools {
+            out.push_str(
+                "_Note: this archive was captured in clean mode. \
+                 `tools` / `system-reminders` filters cannot reintroduce \
+                 content that was stripped at archive time; rerun with a \
+                 full-mode archive if you need them._\n\n",
+            );
+        }
+        out.push_str(md);
+        if !md.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
+    } else if let Some(jsonl) = &archive.session_jsonl {
+        out.push_str("## Conversation\n\n");
+        out.push_str(&render_jsonl_body(jsonl, include)?);
+
+        // Inline sub-agent transcripts after the parent prose if requested.
+        if include.subagents {
+            for (name, content) in &archive.agents {
+                let agent_md = render_jsonl_body(content, include)?;
+                if !agent_md.trim().is_empty() {
+                    out.push_str("\n---\n\n");
+                    out.push_str(&format!("## Agent: {}\n\n", name));
+                    out.push_str(&agent_md);
+                }
+            }
+        }
+    } else {
+        out.push_str("## Conversation\n\n_(no transcript available)_\n\n");
+    }
+
+    // -- Optional sidecar sections --
+
+    if include.mcp && !archive.mcp_logs.is_empty() {
+        out.push_str("\n## MCP Logs\n\n");
+        for path in &archive.mcp_logs {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("(unnamed)");
+            out.push_str(&format!("### {}\n\n", name));
+            match std::fs::read_to_string(path) {
+                Ok(content) => {
+                    out.push_str("```jsonl\n");
+                    out.push_str(content.trim_end_matches('\n'));
+                    out.push_str("\n```\n\n");
+                }
+                Err(e) => {
+                    out.push_str(&format!("_(failed to read: {})_\n\n", e));
+                }
+            }
+        }
+    }
+
+    if include.tool_output && !archive.tool_outputs.is_empty() {
+        out.push_str("\n## Tool Output\n\n");
+        for path in &archive.tool_outputs {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("(unnamed)");
+            out.push_str(&format!("### {}\n\n", name));
+            match std::fs::read_to_string(path) {
+                Ok(content) => {
+                    out.push_str("```\n");
+                    out.push_str(content.trim_end_matches('\n'));
+                    out.push_str("\n```\n\n");
+                }
+                Err(e) => {
+                    out.push_str(&format!("_(failed to read: {})_\n\n", e));
+                }
+            }
+        }
+    }
+
+    if include.history
+        && let Some(history) = &archive.history_jsonl
+        && !history.trim().is_empty()
+    {
+        out.push_str("\n## History Slice\n\n");
+        out.push_str("```jsonl\n");
+        out.push_str(history.trim_end_matches('\n'));
+        out.push_str("\n```\n");
+    }
+
+    Ok(out)
+}
+
+/// Render the body (no header, no sidecars) of a session.jsonl according
+/// to the include flags. Used for both the parent and (recursively) the
+/// inlined subagent transcripts.
+fn render_jsonl_body(content: &str, include: &ExportIncludeSet) -> Result<String> {
+    let mut out = String::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let msg: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let msg_type = match msg["type"].as_str() {
+            Some(t) => t,
+            None => continue,
+        };
+
+        match msg_type {
+            "user" => {
+                let content_node = &msg["message"]["content"];
+                if let Some(text) = content_node.as_str() {
+                    let processed = if include.system_reminders {
+                        text.to_string()
+                    } else {
+                        system_reminder_re().replace_all(text, "").to_string()
+                    };
+                    let trimmed = processed.trim();
+                    if !trimmed.is_empty() {
+                        out.push_str(&format!("**User:** {}\n\n", trimmed));
+                    }
+                }
+                // Array content (tool results) — skip in markdown render
+                // unless tools is on. The block-level rendering of tool
+                // results lives in the tools branch under "assistant".
+            }
+            "assistant" => {
+                if let Some(blocks) = msg["message"]["content"].as_array() {
+                    let mut text_parts = Vec::new();
+                    let mut tool_parts = Vec::new();
+                    for block in blocks {
+                        match block["type"].as_str() {
+                            Some("text") => {
+                                if let Some(text) = block["text"].as_str() {
+                                    let processed = if include.system_reminders {
+                                        text.to_string()
+                                    } else {
+                                        system_reminder_re().replace_all(text, "").to_string()
+                                    };
+                                    let trimmed = processed.trim();
+                                    if !trimmed.is_empty() {
+                                        text_parts.push(trimmed.to_string());
+                                    }
+                                }
+                            }
+                            Some("tool_use") if include.tools => {
+                                let name = block["name"].as_str().unwrap_or("(tool)");
+                                let id = block["id"].as_str().unwrap_or("");
+                                let input = serde_json::to_string_pretty(&block["input"])
+                                    .unwrap_or_else(|_| "{}".to_string());
+                                tool_parts.push(format!(
+                                    "**Tool use:** `{}` (id: `{}`)\n\n```json\n{}\n```",
+                                    name, id, input
+                                ));
+                            }
+                            _ => {}
+                        }
+                    }
+                    let prose = text_parts.join("\n\n");
+                    if !prose.is_empty() {
+                        out.push_str(&format!("**Assistant:** {}\n\n", prose));
+                    }
+                    for tool in tool_parts {
+                        out.push_str(&tool);
+                        out.push_str("\n\n");
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codex::MANIFEST_WRITE_VERSION;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    fn fixture_manifest() -> Manifest {
+        Manifest {
+            version: MANIFEST_WRITE_VERSION,
+            session_id: "test-session-id".to_string(),
+            archived_at: Utc::now(),
+            session_start: "2026-04-29T10:00:00Z".parse().unwrap(),
+            session_end: "2026-04-29T10:30:00Z".parse().unwrap(),
+            project_path: Some("/home/charlie/work/mx".to_string()),
+            message_count: 4,
+            agent_count: 1,
+            agents: vec![],
+            size_bytes: 0,
+            checksum: "sha256:zero".to_string(),
+            image_count: None,
+            images: None,
+            has_clean_transcript: None,
+            user_name: None,
+            assistant_name: None,
+            tool_output_count: None,
+            mcp_log_count: None,
+            history_lines: None,
+            source_breakdown: None,
+        }
+    }
+
+    fn fixture_jsonl() -> &'static str {
+        concat!(
+            r#"{"type":"user","message":{"content":"hello there"}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi back"}]}}"#,
+            "\n",
+            r#"{"type":"user","message":{"content":"<system-reminder>secret</system-reminder>visible"}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}},{"type":"text","text":"running"}]}}"#,
+            "\n",
+        )
+    }
+
+    fn empty_archive_with_jsonl(jsonl: &str) -> LoadedArchive {
+        LoadedArchive {
+            archive_dir: PathBuf::from("/nonexistent"),
+            session_jsonl: Some(jsonl.to_string()),
+            conversation_md: None,
+            agents: vec![],
+            mcp_logs: vec![],
+            tool_outputs: vec![],
+            history_jsonl: None,
+        }
+    }
+
+    #[test]
+    fn render_default_clean_strips_system_reminders_and_tools() {
+        let m = fixture_manifest();
+        let arc = empty_archive_with_jsonl(fixture_jsonl());
+        let out = render(&arc, &m, &ExportIncludeSet::default_clean()).unwrap();
+        assert!(out.contains("**User:** hello there"));
+        assert!(out.contains("**Assistant:** hi back"));
+        assert!(out.contains("visible"));
+        assert!(!out.contains("secret"), "system reminder leaked");
+        assert!(!out.contains("Tool use"), "tool_use leaked");
+    }
+
+    #[test]
+    fn render_with_tools_shows_tool_use_block() {
+        let m = fixture_manifest();
+        let arc = empty_archive_with_jsonl(fixture_jsonl());
+        let mut inc = ExportIncludeSet::default_clean();
+        inc.tools = true;
+        let out = render(&arc, &m, &inc).unwrap();
+        assert!(out.contains("Tool use"));
+        assert!(out.contains("Bash"));
+        assert!(out.contains("toolu_1"));
+    }
+
+    #[test]
+    fn render_with_system_reminders_keeps_them() {
+        let m = fixture_manifest();
+        let arc = empty_archive_with_jsonl(fixture_jsonl());
+        let mut inc = ExportIncludeSet::default_clean();
+        inc.system_reminders = true;
+        let out = render(&arc, &m, &inc).unwrap();
+        assert!(out.contains("secret"));
+    }
+
+    #[test]
+    fn render_inlines_subagents_when_enabled() {
+        let m = fixture_manifest();
+        let agent_jsonl = concat!(
+            r#"{"type":"user","message":{"content":"agent prompt"}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"agent answer"}]}}"#,
+            "\n",
+        );
+        let mut arc = empty_archive_with_jsonl(fixture_jsonl());
+        arc.agents = vec![("agent-aaaa.jsonl".to_string(), agent_jsonl.to_string())];
+        let inc = ExportIncludeSet::default_clean();
+        let out = render(&arc, &m, &inc).unwrap();
+        assert!(out.contains("## Agent: agent-aaaa.jsonl"));
+        assert!(out.contains("agent answer"));
+    }
+
+    #[test]
+    fn render_skips_subagents_when_disabled() {
+        let m = fixture_manifest();
+        let agent_jsonl =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"agent answer"}]}}"#;
+        let mut arc = empty_archive_with_jsonl(fixture_jsonl());
+        arc.agents = vec![("agent-aaaa.jsonl".to_string(), agent_jsonl.to_string())];
+        let inc = ExportIncludeSet::none();
+        let out = render(&arc, &m, &inc).unwrap();
+        assert!(!out.contains("## Agent"));
+        assert!(!out.contains("agent answer"));
+    }
+
+    #[test]
+    fn render_appends_history_section_when_enabled() {
+        let m = fixture_manifest();
+        let mut arc = empty_archive_with_jsonl(fixture_jsonl());
+        arc.history_jsonl = Some("{\"timestamp\": \"2026-04-29T10:15:00Z\"}\n".to_string());
+        let mut inc = ExportIncludeSet::default_clean();
+        inc.history = true;
+        let out = render(&arc, &m, &inc).unwrap();
+        assert!(out.contains("## History Slice"));
+    }
+
+    #[test]
+    fn render_uses_conversation_md_when_present() {
+        let m = fixture_manifest();
+        let arc = LoadedArchive {
+            archive_dir: PathBuf::from("/nonexistent"),
+            session_jsonl: None,
+            conversation_md: Some("**Charlie:** prebaked\n".to_string()),
+            agents: vec![],
+            mcp_logs: vec![],
+            tool_outputs: vec![],
+            history_jsonl: None,
+        };
+        let out = render(&arc, &m, &ExportIncludeSet::default_clean()).unwrap();
+        assert!(out.contains("prebaked"));
+    }
+}

--- a/src/codex/export/format/mod.rs
+++ b/src/codex/export/format/mod.rs
@@ -1,0 +1,49 @@
+//! Output format emitters for `mx codex export`.
+
+pub mod json;
+pub mod markdown;
+
+/// Which renderer(s) to drive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// Markdown — what humans read. Default.
+    Markdown,
+    /// Structured JSON for tool consumers.
+    Json,
+    /// Both — JSON to the output file (or stdout), markdown to stderr
+    /// commentary. The CLI handler is responsible for routing.
+    Both,
+}
+
+impl Format {
+    /// Parse the `--format` CLI value.
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "markdown" | "md" => Ok(Self::Markdown),
+            "json" => Ok(Self::Json),
+            "both" => Ok(Self::Both),
+            other => anyhow::bail!(
+                "unknown --format '{}' (expected markdown, json, or both)",
+                other
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_recognized() {
+        assert_eq!(Format::parse("markdown").unwrap(), Format::Markdown);
+        assert_eq!(Format::parse("MD").unwrap(), Format::Markdown);
+        assert_eq!(Format::parse("json").unwrap(), Format::Json);
+        assert_eq!(Format::parse("Both").unwrap(), Format::Both);
+    }
+
+    #[test]
+    fn parse_rejects_unknown() {
+        assert!(Format::parse("xml").is_err());
+    }
+}

--- a/src/codex/export/include.rs
+++ b/src/codex/export/include.rs
@@ -1,0 +1,224 @@
+//! Render-time include set for `mx codex export`.
+//!
+//! Distinct from `archive::IncludeSet`: archive's set gates which source
+//! files are *captured* into the codex archive, while this set gates
+//! which captured artifacts are *rendered* into the export output. The
+//! tokens overlap (`subagents`, `mcp`, `history`) but the semantics
+//! differ — `tools`, `system-reminders`, and `tool-output` are
+//! export-only knobs that govern what the markdown/JSON emitters
+//! include from the session.jsonl that's already on disk.
+//!
+//! Tokens are case-insensitive. Recognized:
+//!
+//! - `subagents` — render sub-agent transcripts (DEFAULT ON)
+//! - `tools` — render `tool_use` blocks (default OFF)
+//! - `system-reminders` — render `<system-reminder>` blocks (default OFF)
+//! - `mcp` — render captured MCP log sidecars (default OFF)
+//! - `tool-output` — render captured /tmp tool outputs (default OFF)
+//! - `history` — render captured history slice (default OFF)
+//! - `all` / `none` — exclusive overrides
+//!
+//! Validation matches `archive::IncludeSet`:
+//!
+//! - `all,none` together is a hard error
+//! - empty tokens between commas (`subagents,,mcp`) are rejected as typos
+//! - unknown tokens emit a stderr warning and are ignored
+
+use anyhow::Result;
+
+/// Which captured/in-session content to render in the export output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ExportIncludeSet {
+    /// Sub-agent transcripts inlined at the parent's Task tool boundary.
+    pub subagents: bool,
+    /// `tool_use` blocks (the assistant's tool invocations).
+    pub tools: bool,
+    /// `<system-reminder>` blocks.
+    pub system_reminders: bool,
+    /// MCP log sidecars captured at archive time.
+    pub mcp: bool,
+    /// /tmp tool-output sidecars captured at archive time.
+    pub tool_output: bool,
+    /// `history.jsonl` slice captured at archive time.
+    pub history: bool,
+}
+
+impl ExportIncludeSet {
+    /// "Clean human conversation": sub-agents in, every other extra off.
+    /// This is the export default — what someone running
+    /// `mx codex export` with no `--include` sees.
+    pub fn default_clean() -> Self {
+        Self {
+            subagents: true,
+            tools: false,
+            system_reminders: false,
+            mcp: false,
+            tool_output: false,
+            history: false,
+        }
+    }
+
+    /// Everything on. Useful for `--include all`.
+    pub fn all() -> Self {
+        Self {
+            subagents: true,
+            tools: true,
+            system_reminders: true,
+            mcp: true,
+            tool_output: true,
+            history: true,
+        }
+    }
+
+    /// Nothing on. Yields a transcript with only human/assistant prose.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Parse a comma-separated CLI value.
+    ///
+    /// Mirrors `archive::IncludeSet::parse` for consistency: tokens are
+    /// trimmed and lowercased, unknown tokens warn-and-skip, `all+none`
+    /// in the same input is rejected, and empty tokens between commas
+    /// are rejected.
+    pub fn parse(s: &str) -> Result<Self> {
+        let mut set = Self::default();
+        let mut saw_all = false;
+        let mut saw_none = false;
+
+        for (idx, raw) in s.split(',').enumerate() {
+            let token = raw.trim().to_ascii_lowercase();
+            if token.is_empty() {
+                if s.trim().is_empty() && idx == 0 {
+                    continue;
+                }
+                anyhow::bail!(
+                    "empty token in --include list (got '{}'); \
+                     remove the stray comma or use --include none",
+                    s
+                );
+            }
+            match token.as_str() {
+                "all" => {
+                    saw_all = true;
+                    set = Self::all();
+                }
+                "none" => {
+                    saw_none = true;
+                    set = Self::none();
+                }
+                "subagents" => set.subagents = true,
+                "tools" => set.tools = true,
+                "system-reminders" => set.system_reminders = true,
+                "mcp" => set.mcp = true,
+                "tool-output" => set.tool_output = true,
+                "history" => set.history = true,
+                other => {
+                    eprintln!(
+                        "warning: ignoring unknown --include token '{}' \
+                         (recognized: subagents, tools, system-reminders, mcp, \
+                         tool-output, history, all, none)",
+                        other
+                    );
+                }
+            }
+        }
+
+        if saw_all && saw_none {
+            anyhow::bail!(
+                "--include cannot contain both 'all' and 'none' (got '{}'); \
+                 pick one — they are mutually exclusive",
+                s
+            );
+        }
+        Ok(set)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_clean_matches_brief() {
+        let s = ExportIncludeSet::default_clean();
+        assert!(s.subagents);
+        assert!(!s.tools);
+        assert!(!s.system_reminders);
+        assert!(!s.mcp);
+        assert!(!s.tool_output);
+        assert!(!s.history);
+    }
+
+    #[test]
+    fn parse_subagents_only_is_default_clean() {
+        let s = ExportIncludeSet::parse("subagents").unwrap();
+        assert_eq!(s, ExportIncludeSet::default_clean());
+    }
+
+    #[test]
+    fn parse_all_token() {
+        let s = ExportIncludeSet::parse("all").unwrap();
+        assert_eq!(s, ExportIncludeSet::all());
+    }
+
+    #[test]
+    fn parse_none_token() {
+        let s = ExportIncludeSet::parse("none").unwrap();
+        assert_eq!(s, ExportIncludeSet::none());
+    }
+
+    #[test]
+    fn parse_export_only_tokens() {
+        // tools and system-reminders only exist on the export side.
+        let s = ExportIncludeSet::parse("tools,system-reminders").unwrap();
+        assert!(s.tools);
+        assert!(s.system_reminders);
+        assert!(!s.subagents);
+    }
+
+    #[test]
+    fn parse_case_insensitive() {
+        let s = ExportIncludeSet::parse("SubAgents,TOOLS,System-Reminders,MCP").unwrap();
+        assert!(s.subagents);
+        assert!(s.tools);
+        assert!(s.system_reminders);
+        assert!(s.mcp);
+    }
+
+    #[test]
+    fn parse_all_and_none_together_is_rejected() {
+        let err = ExportIncludeSet::parse("all,none").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.to_lowercase().contains("all"));
+        assert!(msg.to_lowercase().contains("none"));
+    }
+
+    #[test]
+    fn parse_empty_token_between_commas_is_rejected() {
+        let err = ExportIncludeSet::parse("subagents,,mcp").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("empty token"), "got: {msg}");
+    }
+
+    #[test]
+    fn parse_empty_string_yields_none() {
+        let s = ExportIncludeSet::parse("").unwrap();
+        assert_eq!(s, ExportIncludeSet::none());
+    }
+
+    #[test]
+    fn parse_trims_whitespace() {
+        let s = ExportIncludeSet::parse(" subagents , history ").unwrap();
+        assert!(s.subagents);
+        assert!(s.history);
+    }
+
+    #[test]
+    fn parse_unknown_token_warns_and_skips() {
+        let s = ExportIncludeSet::parse("subagents,bogus,history").unwrap();
+        assert!(s.subagents);
+        assert!(s.history);
+        assert!(!s.tools);
+    }
+}

--- a/src/codex/export/mod.rs
+++ b/src/codex/export/mod.rs
@@ -16,7 +16,7 @@
 
 use anyhow::{Context, Result};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub mod detect;
 pub mod filter;
@@ -37,9 +37,13 @@ pub struct ExportRequest {
     /// If set, run `mx codex archive --all` before exporting and skip
     /// the unarchived-data warning.
     pub archive_first: bool,
-    /// Output file path. `None` means stdout for markdown / JSON; for
-    /// `Format::Both` an output path is required (we route JSON to the
-    /// file and markdown to stderr).
+    /// Output file path. `None` means stdout for markdown / JSON.
+    ///
+    /// `Format::Both` requires this to be `Some`: JSON is written to the
+    /// supplied path and markdown is written to a sibling sidecar file
+    /// (see [`both_sidecar_paths`] for the naming rule). Calling `run`
+    /// with `Format::Both` and `output: None` returns an error rather
+    /// than silently mixing JSON on stdout with markdown on stderr.
     pub output: Option<PathBuf>,
 }
 
@@ -54,8 +58,48 @@ pub struct ExportResult {
     pub output_path: Option<PathBuf>,
 }
 
+/// Compute the sidecar file pair for `Format::Both`.
+///
+/// Rule:
+/// - If `path` ends in `.json`: JSON goes to `path`, markdown goes to
+///   `path.with_extension("md")`.
+/// - If `path` ends in `.md`: markdown goes to `path`, JSON goes to
+///   `path.with_extension("json")`.
+/// - Otherwise: JSON goes to `<path>.json`, markdown goes to `<path>.md`
+///   (the original `path` is preserved as a stem).
+///
+/// Returns `(json_path, markdown_path)`.
+pub fn both_sidecar_paths(path: &Path) -> (PathBuf, PathBuf) {
+    let ext = path.extension().and_then(|s| s.to_str());
+    match ext {
+        Some("json") => (path.to_path_buf(), path.with_extension("md")),
+        Some("md") => (path.with_extension("json"), path.to_path_buf()),
+        _ => {
+            // Append the typed extension to whatever stem the operator
+            // gave us (e.g. `out` → `out.json` + `out.md`, or
+            // `out.txt` → `out.txt.json` + `out.txt.md`). We deliberately
+            // do NOT strip arbitrary extensions here — that would be
+            // surprising for paths like `archive.tar` where the operator
+            // expects the name preserved verbatim.
+            let mut json_path = path.as_os_str().to_owned();
+            json_path.push(".json");
+            let mut md_path = path.as_os_str().to_owned();
+            md_path.push(".md");
+            (PathBuf::from(json_path), PathBuf::from(md_path))
+        }
+    }
+}
+
 /// Canonical export entry point.
 pub fn run(request: ExportRequest) -> Result<ExportResult> {
+    // -------- Step 0: validate --------
+    if matches!(request.format, Format::Both) && request.output.is_none() {
+        anyhow::bail!(
+            "--format both requires --output (writes <out>.json and <out>.md sidecar files; \
+             pure stdout would mix JSON on stdout with markdown on stderr)"
+        );
+    }
+
     // -------- Step 1: optional pre-archive --------
     if request.archive_first {
         let archive_request = crate::codex::archive::ArchiveRequest::All;
@@ -139,14 +183,23 @@ pub fn run(request: ExportRequest) -> Result<ExportResult> {
             emit(&request.output, &body)?
         }
         Format::Both => {
-            // For `both`, JSON goes to the output (file or stdout) and
-            // markdown is sent to stderr commentary. The brief calls
-            // out that pure stdout for json+markdown is confusing.
+            // Step 0 has guaranteed `output.is_some()`. Split into two
+            // sidecar files so neither stream stomps on the other.
+            let path = request
+                .output
+                .as_ref()
+                .expect("Format::Both with no output should have been rejected at step 0");
+            let (json_path, md_path) = both_sidecar_paths(path);
             let json_body = join_json(&json_chunks);
             let md_body = join_markdown(&markdown_chunks);
-            let p = emit(&request.output, &json_body)?;
-            eprintln!("{}", md_body);
-            p
+            std::fs::write(&json_path, &json_body)
+                .with_context(|| format!("write export JSON to {}", json_path.display()))?;
+            std::fs::write(&md_path, &md_body)
+                .with_context(|| format!("write export markdown to {}", md_path.display()))?;
+            // Report the JSON path as the "primary" output_path for
+            // backwards-compatibility with callers that already inspect
+            // it; the markdown sidecar is implied by the rule.
+            Some(json_path)
         }
     };
 
@@ -404,5 +457,128 @@ mod tests {
         // Post-archive-first detection: there's no live ~/.claude/projects/
         // session here, so unarchived count must be zero.
         assert_eq!(result.detection.unarchived_session_count, 0);
+    }
+
+    // ---- W1: Format::Both sidecar split ----
+
+    #[test]
+    #[serial]
+    fn export_format_both_without_output_errors() {
+        // `Format::Both` without `--output` must be rejected loudly. The
+        // previous behavior routed JSON to stdout and markdown to stderr,
+        // which mangled `mx codex export --format both > out.json`.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path().join("codex");
+        let projects = tmp.path().join("projects");
+        std::fs::create_dir_all(&codex).unwrap();
+        std::fs::create_dir_all(&projects).unwrap();
+        write_archive(&codex, "2026-04-29-100000-aaaaaaaa", "aaaaaaaa-1111");
+
+        let prev_codex = std::env::var("MX_CODEX_PATH").ok();
+        let prev_proj = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex);
+            std::env::set_var("MX_CLAUDE_PROJECTS_DIR", &projects);
+        }
+        let req = ExportRequest {
+            selector: Selector::Latest,
+            format: Format::Both,
+            include: ExportIncludeSet::default_clean(),
+            archive_first: false,
+            output: None,
+        };
+        let result = run(req);
+        unsafe {
+            match prev_codex {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+            match prev_proj {
+                Some(v) => std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_PROJECTS_DIR"),
+            }
+        }
+        let err = result.expect_err("Format::Both without --output should error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("--format both requires --output"),
+            "error message should call out the requirement; got: {msg}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn export_format_both_writes_sidecar_files() {
+        // With `-o foo.json` we expect `foo.json` (JSON) and `foo.md`
+        // (markdown) written side by side.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path().join("codex");
+        let projects = tmp.path().join("projects");
+        let out_json = tmp.path().join("foo.json");
+        let out_md = tmp.path().join("foo.md");
+        std::fs::create_dir_all(&codex).unwrap();
+        std::fs::create_dir_all(&projects).unwrap();
+        write_archive(&codex, "2026-04-29-100000-aaaaaaaa", "aaaaaaaa-1111");
+
+        let prev_codex = std::env::var("MX_CODEX_PATH").ok();
+        let prev_proj = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex);
+            std::env::set_var("MX_CLAUDE_PROJECTS_DIR", &projects);
+        }
+        let req = ExportRequest {
+            selector: Selector::Latest,
+            format: Format::Both,
+            include: ExportIncludeSet::default_clean(),
+            archive_first: false,
+            output: Some(out_json.clone()),
+        };
+        let result = run(req);
+        unsafe {
+            match prev_codex {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+            match prev_proj {
+                Some(v) => std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_PROJECTS_DIR"),
+            }
+        }
+        let result = result.expect("Format::Both export should succeed with --output");
+        assert_eq!(result.output_path.as_deref(), Some(out_json.as_path()));
+        assert!(out_json.exists(), "JSON sidecar at .json path must exist");
+        assert!(out_md.exists(), "markdown sidecar at .md path must exist");
+        let json_body = std::fs::read_to_string(&out_json).unwrap();
+        // Must parse as JSON (not be markdown by accident).
+        let _: serde_json::Value =
+            serde_json::from_str(&json_body).expect("json sidecar must be parseable JSON");
+        let md_body = std::fs::read_to_string(&out_md).unwrap();
+        assert!(
+            md_body.contains("Session aaaaaaaa-1111"),
+            "markdown sidecar must contain the rendered conversation"
+        );
+    }
+
+    #[test]
+    fn both_sidecar_paths_extension_rules() {
+        let (j, m) = both_sidecar_paths(Path::new("/tmp/foo.json"));
+        assert_eq!(j, PathBuf::from("/tmp/foo.json"));
+        assert_eq!(m, PathBuf::from("/tmp/foo.md"));
+
+        let (j, m) = both_sidecar_paths(Path::new("/tmp/foo.md"));
+        assert_eq!(j, PathBuf::from("/tmp/foo.json"));
+        assert_eq!(m, PathBuf::from("/tmp/foo.md"));
+
+        // No extension: append both.
+        let (j, m) = both_sidecar_paths(Path::new("/tmp/foo"));
+        assert_eq!(j, PathBuf::from("/tmp/foo.json"));
+        assert_eq!(m, PathBuf::from("/tmp/foo.md"));
+
+        // Unrelated extension: preserve verbatim and append.
+        let (j, m) = both_sidecar_paths(Path::new("/tmp/archive.tar"));
+        assert_eq!(j, PathBuf::from("/tmp/archive.tar.json"));
+        assert_eq!(m, PathBuf::from("/tmp/archive.tar.md"));
     }
 }

--- a/src/codex/export/mod.rs
+++ b/src/codex/export/mod.rs
@@ -411,6 +411,93 @@ mod tests {
         assert!(result.detection.unarchived_session_count >= 1);
     }
 
+    /// S1: same architectural invariant as the markdown test, but for
+    /// the JSON emitter. The JSON walker recurses into every string
+    /// field — if it ever read live `~/.claude/projects/` content, the
+    /// sentinel would surface in some string somewhere in the document.
+    /// We parse the output and walk every string value, asserting the
+    /// sentinel never appears.
+    #[test]
+    #[serial]
+    fn export_does_not_read_claude_projects_for_content_json() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path().join("codex");
+        let sentinel = tmp.path().join("claude-projects-sentinel");
+        std::fs::create_dir_all(&codex).unwrap();
+        let proj_subdir = sentinel.join("-home-charlie-mx");
+        std::fs::create_dir_all(&proj_subdir).unwrap();
+        // Same fixture path / sentinel value as the markdown test, so a
+        // regression in either emitter looks the same in the failure.
+        std::fs::write(
+            proj_subdir.join("ffffffff-9999.jsonl"),
+            r#"{"type":"user","message":{"content":"LIVE_DATA_SHOULD_NOT_LEAK"}}
+"#,
+        )
+        .unwrap();
+        write_archive(&codex, "2026-04-29-100000-aaaaaaaa", "aaaaaaaa-1111");
+
+        let prev_codex = std::env::var("MX_CODEX_PATH").ok();
+        let prev_proj = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex);
+            std::env::set_var("MX_CLAUDE_PROJECTS_DIR", &sentinel);
+        }
+        let out_path = tmp.path().join("out.json");
+        let req = ExportRequest {
+            selector: Selector::Latest,
+            format: Format::Json,
+            include: ExportIncludeSet::default_clean(),
+            archive_first: false,
+            output: Some(out_path.clone()),
+        };
+        let result = run(req);
+        unsafe {
+            match prev_codex {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+            match prev_proj {
+                Some(v) => std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_PROJECTS_DIR"),
+            }
+        }
+        let result = result.expect("export::run failed");
+        let body = std::fs::read_to_string(result.output_path.as_ref().unwrap()).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).expect("JSON output must parse");
+
+        // Walk every string in the JSON tree and assert the sentinel
+        // never appears. This catches the case where a future field
+        // surfaces live content in some unanticipated path (e.g. an
+        // image caption or a subagent excerpt).
+        fn assert_no_sentinel(v: &serde_json::Value, path: &str) {
+            match v {
+                serde_json::Value::String(s) => {
+                    assert!(
+                        !s.contains("LIVE_DATA_SHOULD_NOT_LEAK"),
+                        "sentinel leaked into JSON at {path}: {s}"
+                    );
+                }
+                serde_json::Value::Array(arr) => {
+                    for (i, item) in arr.iter().enumerate() {
+                        assert_no_sentinel(item, &format!("{path}[{i}]"));
+                    }
+                }
+                serde_json::Value::Object(map) => {
+                    for (k, val) in map {
+                        assert_no_sentinel(val, &format!("{path}.{k}"));
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert_no_sentinel(&parsed, "$");
+        // Detection still flagged the live session as unarchived (same
+        // side-effect signal as the markdown invariant test).
+        assert!(result.detection.unarchived_session_count >= 1);
+    }
+
     #[test]
     #[serial]
     fn export_archive_first_skips_warning() {

--- a/src/codex/export/mod.rs
+++ b/src/codex/export/mod.rs
@@ -1,0 +1,408 @@
+//! `mx codex export` — read sessions out of the codex and emit them.
+//!
+//! Mirrors the shape of `archive::run`: build an `ExportRequest`, call
+//! `export::run`, get an `ExportResult`. The CLI handler does the
+//! parameter parsing.
+//!
+//! Architectural invariants (enforced here):
+//!
+//! - Content is read from `<codex_dir>/<archive_dir>/` ONLY. The
+//!   detection layer scans `~/.claude/` for the warning, but no
+//!   rendering ever ingests live Claude data — that's PR 2's domain
+//!   (archive).
+//! - `--archive-first` short-circuits the warning by running
+//!   `archive::run(ArchiveRequest::All, _)` first, then re-detecting,
+//!   then exporting.
+
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::PathBuf;
+
+pub mod detect;
+pub mod filter;
+pub mod format;
+pub mod include;
+pub mod read;
+
+pub use filter::{DateRange, Selector, SessionRef};
+pub use format::Format;
+pub use include::ExportIncludeSet;
+
+/// What the caller wants exported.
+#[derive(Debug, Clone)]
+pub struct ExportRequest {
+    pub selector: Selector,
+    pub format: Format,
+    pub include: ExportIncludeSet,
+    /// If set, run `mx codex archive --all` before exporting and skip
+    /// the unarchived-data warning.
+    pub archive_first: bool,
+    /// Output file path. `None` means stdout for markdown / JSON; for
+    /// `Format::Both` an output path is required (we route JSON to the
+    /// file and markdown to stderr).
+    pub output: Option<PathBuf>,
+}
+
+/// Outcome of a successful `export::run`.
+#[derive(Debug, Clone, Default)]
+pub struct ExportResult {
+    /// How many archive directories were rendered.
+    pub session_count: usize,
+    /// The detection report (post-archive-first re-run if applicable).
+    pub detection: detect::DetectionReport,
+    /// Where output was written (file path) or `None` for stdout.
+    pub output_path: Option<PathBuf>,
+}
+
+/// Canonical export entry point.
+pub fn run(request: ExportRequest) -> Result<ExportResult> {
+    // -------- Step 1: optional pre-archive --------
+    if request.archive_first {
+        let archive_request = crate::codex::archive::ArchiveRequest::All;
+        let archive_options = crate::codex::archive::ArchiveOptions::default();
+        crate::codex::archive::run(archive_request, archive_options)
+            .context("--archive-first: archive::run(All) failed")?;
+    }
+
+    // -------- Step 2: detect unarchived data --------
+    let detection = detect::detect_unarchived().unwrap_or_default();
+    if !request.archive_first
+        && let Some(warn) = detection.warning_text()
+    {
+        eprintln!("{}", warn);
+    }
+
+    // -------- Step 3: resolve selector --------
+    let codex_dir = crate::paths::codex_dir();
+    let all_archives = filter::collect_codex_archives(&codex_dir)?;
+
+    let archives = match &request.selector {
+        Selector::Latest => vec![filter::resolve_latest(all_archives)?],
+        Selector::Session(sref) => vec![filter::resolve_session(all_archives, sref)?],
+        Selector::Project(query) => filter::resolve_project(all_archives, query)?,
+        Selector::Date(range) => {
+            let matched = filter::resolve_date(all_archives, range);
+            if matched.is_empty() {
+                anyhow::bail!(
+                    "no archived sessions fall in date range [{} .. {})",
+                    range.start.to_rfc3339(),
+                    range.end.to_rfc3339()
+                );
+            }
+            matched
+        }
+    };
+
+    // -------- Step 4: render each archive --------
+    let mut markdown_chunks: Vec<String> = Vec::new();
+    let mut json_chunks: Vec<String> = Vec::new();
+    for resolved in &archives {
+        let loaded = read::read_archive(&resolved.archive_dir)?;
+        match request.format {
+            Format::Markdown => {
+                markdown_chunks.push(format::markdown::render(
+                    &loaded,
+                    &resolved.manifest,
+                    &request.include,
+                )?);
+            }
+            Format::Json => {
+                json_chunks.push(format::json::render(
+                    &loaded,
+                    &resolved.manifest,
+                    &request.include,
+                )?);
+            }
+            Format::Both => {
+                markdown_chunks.push(format::markdown::render(
+                    &loaded,
+                    &resolved.manifest,
+                    &request.include,
+                )?);
+                json_chunks.push(format::json::render(
+                    &loaded,
+                    &resolved.manifest,
+                    &request.include,
+                )?);
+            }
+        }
+    }
+
+    // -------- Step 5: emit --------
+    let output_path = match request.format {
+        Format::Markdown => {
+            let body = join_markdown(&markdown_chunks);
+            emit(&request.output, &body)?
+        }
+        Format::Json => {
+            let body = join_json(&json_chunks);
+            emit(&request.output, &body)?
+        }
+        Format::Both => {
+            // For `both`, JSON goes to the output (file or stdout) and
+            // markdown is sent to stderr commentary. The brief calls
+            // out that pure stdout for json+markdown is confusing.
+            let json_body = join_json(&json_chunks);
+            let md_body = join_markdown(&markdown_chunks);
+            let p = emit(&request.output, &json_body)?;
+            eprintln!("{}", md_body);
+            p
+        }
+    };
+
+    Ok(ExportResult {
+        session_count: archives.len(),
+        detection,
+        output_path,
+    })
+}
+
+fn join_markdown(chunks: &[String]) -> String {
+    if chunks.len() == 1 {
+        return chunks[0].clone();
+    }
+    chunks.join("\n\n---\n\n")
+}
+
+fn join_json(chunks: &[String]) -> String {
+    // Multiple sessions → wrap in an array. Re-parse so the result is
+    // always valid JSON (concatenating pretty-printed objects with `,`
+    // would not be).
+    if chunks.len() == 1 {
+        return chunks[0].clone();
+    }
+    let parsed: Vec<serde_json::Value> = chunks
+        .iter()
+        .filter_map(|c| serde_json::from_str(c).ok())
+        .collect();
+    serde_json::to_string_pretty(&parsed).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn emit(output: &Option<PathBuf>, body: &str) -> Result<Option<PathBuf>> {
+    match output {
+        Some(path) => {
+            std::fs::write(path, body)
+                .with_context(|| format!("write export output to {}", path.display()))?;
+            Ok(Some(path.clone()))
+        }
+        None => {
+            std::io::stdout().write_all(body.as_bytes())?;
+            // Trailing newline so terminal prompts don't run together
+            // with the last line of output.
+            if !body.ends_with('\n') {
+                std::io::stdout().write_all(b"\n")?;
+            }
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codex::MANIFEST_WRITE_VERSION;
+    use chrono::Utc;
+    use serial_test::serial;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn write_archive(codex_dir: &std::path::Path, dir_name: &str, session_id: &str) {
+        let archive_dir = codex_dir.join(dir_name);
+        std::fs::create_dir_all(&archive_dir).unwrap();
+        let manifest = crate::codex::Manifest {
+            version: MANIFEST_WRITE_VERSION,
+            session_id: session_id.to_string(),
+            archived_at: Utc::now(),
+            session_start: Utc::now(),
+            session_end: Utc::now(),
+            project_path: Some("/home/charlie/work/mx".to_string()),
+            message_count: 1,
+            agent_count: 0,
+            agents: vec![],
+            size_bytes: 0,
+            checksum: "sha256:zero".to_string(),
+            image_count: None,
+            images: None,
+            has_clean_transcript: None,
+            user_name: None,
+            assistant_name: None,
+            tool_output_count: None,
+            mcp_log_count: None,
+            history_lines: None,
+            source_breakdown: None,
+        };
+        std::fs::write(
+            archive_dir.join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            archive_dir.join("session.jsonl"),
+            r#"{"type":"user","message":{"content":"hi"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}
+"#,
+        )
+        .unwrap();
+    }
+
+    /// Run an export with `MX_CODEX_PATH` and `MX_CLAUDE_PROJECTS_DIR`
+    /// pointed at temp dirs.
+    #[test]
+    #[serial]
+    fn export_latest_writes_markdown_to_file() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path().join("codex");
+        let projects = tmp.path().join("claude-projects-sentinel");
+        let out_path = tmp.path().join("out.md");
+        std::fs::create_dir_all(&codex).unwrap();
+        std::fs::create_dir_all(&projects).unwrap();
+        write_archive(&codex, "2026-04-29-100000-aaaaaaaa", "aaaaaaaa-1111");
+
+        let prev_codex = std::env::var("MX_CODEX_PATH").ok();
+        let prev_proj = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        // SAFETY: env mutation guarded by ENV_LOCK + #[serial].
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex);
+            std::env::set_var("MX_CLAUDE_PROJECTS_DIR", &projects);
+        }
+
+        let req = ExportRequest {
+            selector: Selector::Latest,
+            format: Format::Markdown,
+            include: ExportIncludeSet::default_clean(),
+            archive_first: false,
+            output: Some(out_path.clone()),
+        };
+        let result = run(req);
+
+        unsafe {
+            match prev_codex {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+            match prev_proj {
+                Some(v) => std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_PROJECTS_DIR"),
+            }
+        }
+        let result = result.expect("export::run failed");
+        assert_eq!(result.session_count, 1);
+        assert_eq!(result.output_path.as_deref(), Some(out_path.as_path()));
+        let body = std::fs::read_to_string(&out_path).unwrap();
+        assert!(body.contains("Session aaaaaaaa-1111"));
+        assert!(body.contains("hello"));
+    }
+
+    #[test]
+    #[serial]
+    fn export_does_not_read_claude_projects_for_content() {
+        // Architectural invariant: export reads content from the codex
+        // exclusively. We point MX_CLAUDE_PROJECTS_DIR at a sentinel
+        // path containing a session JSONL that, if read, would obviously
+        // collide with the codex archive (different UUID, different
+        // body). The export must not surface anything from the sentinel.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path().join("codex");
+        let sentinel = tmp.path().join("claude-projects-sentinel");
+        std::fs::create_dir_all(&codex).unwrap();
+        let proj_subdir = sentinel.join("-home-charlie-mx");
+        std::fs::create_dir_all(&proj_subdir).unwrap();
+        // Plant a "live but not archived" session in the sentinel.
+        std::fs::write(
+            proj_subdir.join("ffffffff-9999.jsonl"),
+            r#"{"type":"user","message":{"content":"LIVE_DATA_SHOULD_NOT_LEAK"}}
+"#,
+        )
+        .unwrap();
+        // And one archived session in the codex.
+        write_archive(&codex, "2026-04-29-100000-aaaaaaaa", "aaaaaaaa-1111");
+
+        let prev_codex = std::env::var("MX_CODEX_PATH").ok();
+        let prev_proj = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex);
+            std::env::set_var("MX_CLAUDE_PROJECTS_DIR", &sentinel);
+        }
+        let req = ExportRequest {
+            selector: Selector::Latest,
+            format: Format::Markdown,
+            include: ExportIncludeSet::default_clean(),
+            archive_first: false,
+            output: Some(tmp.path().join("out.md")),
+        };
+        let result = run(req);
+        unsafe {
+            match prev_codex {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+            match prev_proj {
+                Some(v) => std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_PROJECTS_DIR"),
+            }
+        }
+        let result = result.expect("export::run failed");
+        let body = std::fs::read_to_string(result.output_path.as_ref().unwrap()).unwrap();
+        // The codex archive's content should be present.
+        assert!(body.contains("Session aaaaaaaa-1111"));
+        // The sentinel's content must NEVER be in the output.
+        assert!(
+            !body.contains("LIVE_DATA_SHOULD_NOT_LEAK"),
+            "export read live ~/.claude/projects/ content — invariant violated"
+        );
+        // The detection report should have flagged the live session as
+        // unarchived (a side-effect signal that the detection scan ran).
+        assert!(result.detection.unarchived_session_count >= 1);
+    }
+
+    #[test]
+    #[serial]
+    fn export_archive_first_skips_warning() {
+        // With `--archive-first`, the warning is NOT printed (because
+        // detection is re-run after archiving and should be zero). We
+        // can't easily intercept stderr, but we can verify the
+        // detection report on the result is the post-archive state.
+        // Here we don't actually have any live ~/.claude data, so this
+        // is mostly a smoke test for the archive-first path not
+        // crashing.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path().join("codex");
+        let projects = tmp.path().join("projects");
+        std::fs::create_dir_all(&codex).unwrap();
+        std::fs::create_dir_all(&projects).unwrap();
+        write_archive(&codex, "2026-04-29-100000-aaaaaaaa", "aaaaaaaa-1111");
+
+        let prev_codex = std::env::var("MX_CODEX_PATH").ok();
+        let prev_proj = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex);
+            std::env::set_var("MX_CLAUDE_PROJECTS_DIR", &projects);
+        }
+        let req = ExportRequest {
+            selector: Selector::Latest,
+            format: Format::Markdown,
+            include: ExportIncludeSet::default_clean(),
+            archive_first: true,
+            output: Some(tmp.path().join("out.md")),
+        };
+        let result = run(req);
+        unsafe {
+            match prev_codex {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+            match prev_proj {
+                Some(v) => std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_PROJECTS_DIR"),
+            }
+        }
+        let result = result.expect("--archive-first export failed");
+        // Post-archive-first detection: there's no live ~/.claude/projects/
+        // session here, so unarchived count must be zero.
+        assert_eq!(result.detection.unarchived_session_count, 0);
+    }
+}

--- a/src/codex/export/read.rs
+++ b/src/codex/export/read.rs
@@ -1,0 +1,173 @@
+//! Codex-store reader for `mx codex export`.
+//!
+//! Reads a single archive directory and returns the on-disk artifacts
+//! the format emitters render: the session source (jsonl OR
+//! conversation.md), every agent JSONL, and the optional sidecars
+//! (mcp/, tool-output/, history/).
+//!
+//! Reads are scoped to `<codex_dir>/<archive_dir>/` exclusively. We do
+//! NOT read `~/.claude/projects/` here — that's the architectural
+//! invariant. The detection layer (detect.rs) is the only path that
+//! touches live Claude data, and it never reads content for rendering.
+
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// What `read_archive` returns: every on-disk artifact the emitters
+/// might want to render, with `None` for missing-but-optional pieces.
+#[derive(Debug)]
+pub struct LoadedArchive {
+    pub archive_dir: PathBuf,
+    /// Raw `session.jsonl` content, if present.
+    pub session_jsonl: Option<String>,
+    /// Pre-rendered `conversation.md` if archive was clean-mode.
+    pub conversation_md: Option<String>,
+    /// Sub-agent JSONLs: `(name, content)` tuples sorted by name.
+    pub agents: Vec<(String, String)>,
+    /// MCP log file paths under `mcp/` (raw — emitters decide how to
+    /// render).
+    pub mcp_logs: Vec<PathBuf>,
+    /// Tool-output file paths under `tool-output/`.
+    pub tool_outputs: Vec<PathBuf>,
+    /// Captured history slice content if `history/history.jsonl` exists.
+    pub history_jsonl: Option<String>,
+}
+
+impl LoadedArchive {
+    /// True iff at least one human/assistant content source was loaded.
+    pub fn has_transcript(&self) -> bool {
+        self.session_jsonl.is_some() || self.conversation_md.is_some()
+    }
+}
+
+/// Load every artifact under `archive_dir`. Returns `Ok` even if some
+/// pieces are missing — the emitter decides what's mandatory.
+pub fn read_archive(archive_dir: &Path) -> Result<LoadedArchive> {
+    let session_jsonl = read_optional(&archive_dir.join("session.jsonl"))?;
+    let conversation_md = read_optional(&archive_dir.join("conversation.md"))?;
+    let agents = read_agents(&archive_dir.join("agents"))?;
+    let mcp_logs = list_dir_files(&archive_dir.join("mcp"))?;
+    let tool_outputs = list_dir_files(&archive_dir.join("tool-output"))?;
+    let history_jsonl = read_optional(&archive_dir.join("history").join("history.jsonl"))?;
+
+    Ok(LoadedArchive {
+        archive_dir: archive_dir.to_path_buf(),
+        session_jsonl,
+        conversation_md,
+        agents,
+        mcp_logs,
+        tool_outputs,
+        history_jsonl,
+    })
+}
+
+fn read_optional(path: &Path) -> Result<Option<String>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(fs::read_to_string(path)?))
+}
+
+fn read_agents(agents_dir: &Path) -> Result<Vec<(String, String)>> {
+    if !agents_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in fs::read_dir(agents_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if !name.ends_with(".jsonl") {
+            continue;
+        }
+        let content = fs::read_to_string(&path)?;
+        out.push((name, content));
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+fn list_dir_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let p = entry.path();
+        if p.is_file() {
+            out.push(p);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_empty_archive_has_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loaded = read_archive(tmp.path()).unwrap();
+        assert!(!loaded.has_transcript());
+        assert!(loaded.agents.is_empty());
+        assert!(loaded.mcp_logs.is_empty());
+        assert!(loaded.tool_outputs.is_empty());
+        assert!(loaded.history_jsonl.is_none());
+    }
+
+    #[test]
+    fn read_archive_finds_session_and_agents() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("session.jsonl"), "{}\n").unwrap();
+        fs::create_dir_all(tmp.path().join("agents")).unwrap();
+        fs::write(tmp.path().join("agents/agent-aaaa.jsonl"), "agent-a\n").unwrap();
+        fs::write(tmp.path().join("agents/agent-bbbb.jsonl"), "agent-b\n").unwrap();
+        // Plus stray non-jsonl file that should be ignored.
+        fs::write(tmp.path().join("agents/notes.txt"), "ignored").unwrap();
+
+        let loaded = read_archive(tmp.path()).unwrap();
+        assert!(loaded.session_jsonl.is_some());
+        assert_eq!(loaded.agents.len(), 2);
+        assert_eq!(loaded.agents[0].0, "agent-aaaa.jsonl");
+        assert_eq!(loaded.agents[1].0, "agent-bbbb.jsonl");
+    }
+
+    #[test]
+    fn read_archive_finds_optional_sidecars() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("mcp")).unwrap();
+        fs::write(tmp.path().join("mcp/server-1.jsonl"), "log\n").unwrap();
+        fs::create_dir_all(tmp.path().join("tool-output")).unwrap();
+        fs::write(tmp.path().join("tool-output/abc.output"), "out\n").unwrap();
+        fs::create_dir_all(tmp.path().join("history")).unwrap();
+        fs::write(
+            tmp.path().join("history/history.jsonl"),
+            "{\"timestamp\": \"2026-04-29T12:00:00Z\"}\n",
+        )
+        .unwrap();
+
+        let loaded = read_archive(tmp.path()).unwrap();
+        assert_eq!(loaded.mcp_logs.len(), 1);
+        assert_eq!(loaded.tool_outputs.len(), 1);
+        assert!(loaded.history_jsonl.is_some());
+    }
+
+    #[test]
+    fn read_archive_prefers_both_when_both_present() {
+        // Clean-mode archives may have BOTH conversation.md and session.jsonl
+        // — the emitter chooses precedence; the reader exposes both.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("session.jsonl"), "{}\n").unwrap();
+        fs::write(tmp.path().join("conversation.md"), "# hi\n").unwrap();
+        let loaded = read_archive(tmp.path()).unwrap();
+        assert!(loaded.session_jsonl.is_some());
+        assert!(loaded.conversation_md.is_some());
+    }
+}

--- a/src/codex/index/mod.rs
+++ b/src/codex/index/mod.rs
@@ -99,13 +99,133 @@ impl ProjectIndex {
 
     /// Like `open`, but rooted under an explicit codex dir. Used by tests
     /// to avoid touching `$MX_HOME/codex/`.
+    ///
+    /// Populates the in-memory `entries` cache from the on-disk
+    /// `by-project/` tree if and only if the index is fresh (per
+    /// [`Self::is_stale`]). When the index is stale or absent, the cache
+    /// is left empty and lookup falls back to a manifest walk; the
+    /// caller can rebuild via [`Self::rebuild_from_manifests`] to refresh
+    /// the on-disk tree.
     pub fn open_under(codex_dir: &Path) -> Result<Self> {
         let root = codex_dir.join(INDEX_SUBDIR);
         fs::create_dir_all(&root)?;
-        Ok(Self {
+        let mut idx = Self {
             root,
             entries: Vec::new(),
-        })
+        };
+        // S2: populate the cache so abs-path lookups consult the index
+        // instead of falling straight through to a manifest walk. We
+        // skip population when the index is stale — a stale cache would
+        // miss recent archives, and the manifest-walk fallback is
+        // already correct for every input form. The caller is expected
+        // to rebuild before relying on freshness.
+        match idx.is_stale() {
+            Ok(false) => {
+                if let Err(e) = idx.populate_from_disk() {
+                    eprintln!(
+                        "warning: by-project index cache population failed; falling back \
+                         to manifest walk: {e}"
+                    );
+                }
+            }
+            Ok(true) => {
+                // Index missing or stale — leave cache empty so callers
+                // see the same manifest-walk behavior they had before
+                // populate_from_disk existed.
+            }
+            Err(e) => {
+                eprintln!("warning: by-project staleness check failed: {e}");
+            }
+        }
+        Ok(idx)
+    }
+
+    /// Walk `<codex_dir>/by-project/<basename-slug>/<archive-name>`
+    /// symlinks, read each pointed-at manifest, and build the in-memory
+    /// `entries` cache. Called by [`Self::open_under`] when the index is
+    /// fresh.
+    ///
+    /// Manifests with bad JSON are surfaced via a stderr warning, mirroring
+    /// the behavior of [`Self::rebuild_from_manifests`]. Symlinks that
+    /// don't resolve to a manifest are silently skipped — they may be a
+    /// transient state during a concurrent rebuild.
+    fn populate_from_disk(&mut self) -> Result<()> {
+        if !self.root.exists() {
+            return Ok(());
+        }
+        let codex_dir = self.root.parent().ok_or_else(|| {
+            anyhow::anyhow!("by-project root has no parent: {}", self.root.display())
+        })?;
+
+        // Group by basename-slug. For each slug we collect:
+        //   (absolute_paths, session_archive_paths)
+        let mut by_slug: HashMap<String, (Vec<PathBuf>, Vec<PathBuf>)> = HashMap::new();
+        for slug_entry in fs::read_dir(&self.root)? {
+            let slug_entry = slug_entry?;
+            let bucket = slug_entry.path();
+            if !bucket.is_dir() {
+                continue;
+            }
+            let slug = match bucket.file_name().and_then(|n| n.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let cell = by_slug.entry(slug).or_default();
+
+            let entries = match fs::read_dir(&bucket) {
+                Ok(rd) => rd,
+                Err(_) => continue,
+            };
+            for archive_entry in entries.flatten() {
+                let archive_name = match archive_entry.file_name().to_str().map(String::from) {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let resolved = codex_dir.join(&archive_name);
+                let manifest_path = resolved.join("manifest.json");
+                if !manifest_path.exists() {
+                    continue;
+                }
+                let raw = match fs::read_to_string(&manifest_path) {
+                    Ok(r) => r,
+                    Err(_) => continue,
+                };
+                let manifest: Manifest = match serde_json::from_str(&raw) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        eprintln!(
+                            "warning: skipping unparseable manifest {}: {e}",
+                            manifest_path.display()
+                        );
+                        continue;
+                    }
+                };
+                if let Some(p) = manifest.project_path.as_ref() {
+                    cell.0.push(PathBuf::from(p));
+                }
+                cell.1.push(resolved);
+            }
+        }
+
+        let mut entries: Vec<ProjectEntry> = by_slug
+            .into_iter()
+            .map(|(slug, (mut abs, mut paths))| {
+                abs.sort();
+                abs.dedup();
+                paths.sort();
+                ProjectEntry {
+                    basename_slug: slug,
+                    absolute_paths: abs,
+                    session_archive_paths: paths,
+                }
+            })
+            // Drop slugs that yielded zero project_paths — they're not
+            // useful for any lookup form and would only confuse callers.
+            .filter(|e| !e.absolute_paths.is_empty())
+            .collect();
+        entries.sort_by(|a, b| a.basename_slug.cmp(&b.basename_slug));
+        self.entries = entries;
+        Ok(())
     }
 
     /// Regenerate the index from all manifests under `<codex_dir>/`.
@@ -1118,6 +1238,78 @@ mod tests {
         let err = idx.lookup("does-not-exist").unwrap_err();
         let downcast = err.downcast_ref::<IndexError>().expect("IndexError");
         assert!(matches!(downcast, IndexError::NotFound { .. }));
+    }
+
+    #[test]
+    fn open_populates_cache_from_existing_index() {
+        // S2: after a rebuild leaves a fresh by-project/ tree on disk,
+        // a *new* ProjectIndex opened against the same codex must see
+        // the entries in its in-memory cache without re-rebuilding.
+        // This is what makes abs-path lookups consult the index instead
+        // of falling straight to a manifest walk.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/charlie/work/mx",
+            "aaa",
+        );
+        write_manifest(
+            &codex.join("2026-04-29-110000-bbbbbbbb"),
+            "/home/charlie/work/wonka",
+            "bbb",
+        );
+        // Build the index in one handle, drop it.
+        {
+            let mut idx = ProjectIndex::open_under(codex).unwrap();
+            idx.rebuild_from_manifests().unwrap();
+        }
+        // Open a fresh handle — the cache should be populated from
+        // the on-disk by-project/ tree.
+        let idx = ProjectIndex::open_under(codex).unwrap();
+        assert_eq!(idx.entry_count(), 2, "cache should be populated on open");
+        // And abs-path lookup should now resolve from the cache.
+        let entry = idx
+            .lookup("/home/charlie/work/mx")
+            .expect("abs-path lookup should hit the populated cache");
+        assert_eq!(entry.basename_slug, "mx");
+    }
+
+    #[test]
+    fn open_leaves_cache_empty_when_index_is_stale() {
+        // If a manifest is newer than the by-project/ tree, the index
+        // is stale and the cache must be left empty so callers don't
+        // surface a result that misses the new archive.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/charlie/work/mx",
+            "aaa",
+        );
+        {
+            let mut idx = ProjectIndex::open_under(codex).unwrap();
+            idx.rebuild_from_manifests().unwrap();
+        }
+        // Sleep so the next manifest's mtime is strictly newer.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        write_manifest(
+            &codex.join("2026-04-29-110000-bbbbbbbb"),
+            "/home/charlie/work/wonka",
+            "bbb",
+        );
+        let idx = ProjectIndex::open_under(codex).unwrap();
+        // Stale → cache empty → lookup must fall through to manifest
+        // walk, which DOES see the new archive.
+        assert_eq!(
+            idx.entry_count(),
+            0,
+            "stale index should not seed an outdated cache"
+        );
+        let entry = idx
+            .lookup("/home/charlie/work/wonka")
+            .expect("manifest-walk fallback must find the new archive");
+        assert_eq!(entry.basename_slug, "wonka");
     }
 
     #[test]

--- a/src/codex/index/mod.rs
+++ b/src/codex/index/mod.rs
@@ -31,13 +31,11 @@
 //!
 //! Readers (PR 3) MUST call `is_stale` before trusting the index.
 
+use crate::codex::Manifest;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use thiserror::Error;
-
-use crate::codex::Manifest;
 
 /// On-disk subdirectory name where the by-project index lives, under
 /// the codex root.
@@ -791,18 +789,55 @@ fn make_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
 }
 
 /// Errors raised by the by-project index.
-#[derive(Debug, Error)]
+///
+/// `AmbiguousProject` has a hand-written `Display` so the path list
+/// pretty-prints (one per line, indented) instead of the default `{:?}`
+/// debug form. The result is what an operator sees on stderr when the
+/// basename collides:
+///
+/// ```text
+/// project 'mx' is ambiguous — matches multiple absolute paths:
+///   /home/alice/mx
+///   /home/bob/recipes/mx
+/// Disambiguate by passing the absolute path.
+/// ```
+#[derive(Debug)]
 pub enum IndexError {
-    #[error("ambiguous project query '{query}' matches multiple paths: {matches:?}")]
     AmbiguousProject {
         query: String,
         matches: Vec<PathBuf>,
     },
-    #[error("project query '{query}' did not match any archived session")]
-    NotFound { query: String },
-    #[error("ProjectIndex::{method} is not yet implemented (wired up in a later PR)")]
-    NotImplemented { method: &'static str },
+    NotFound {
+        query: String,
+    },
 }
+
+impl std::fmt::Display for IndexError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexError::AmbiguousProject { query, matches } => {
+                writeln!(
+                    f,
+                    "project '{}' is ambiguous — matches multiple absolute paths:",
+                    query
+                )?;
+                for p in matches {
+                    writeln!(f, "  {}", p.display())?;
+                }
+                write!(f, "Disambiguate by passing the absolute path.")
+            }
+            IndexError::NotFound { query } => {
+                write!(
+                    f,
+                    "project query '{}' did not match any archived session",
+                    query
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for IndexError {}
 
 #[cfg(test)]
 mod tests {
@@ -913,6 +948,20 @@ mod tests {
         assert!(msg.contains("'mx'"));
         assert!(msg.contains("/home/a/mx"));
         assert!(msg.contains("/home/b/mx"));
+        // S4: the new pretty-printed shape uses indented lines, no
+        // debug-syntax brackets/quotes around the path list.
+        assert!(
+            !msg.contains("\"/home/a/mx\""),
+            "must not use debug-quoted paths"
+        );
+        assert!(
+            !msg.contains("PathBuf"),
+            "must not leak debug type names: {msg}"
+        );
+        // Each match should appear on its own indented line.
+        assert!(msg.contains("\n  /home/a/mx"));
+        assert!(msg.contains("\n  /home/b/mx"));
+        assert!(msg.contains("Disambiguate by passing the absolute path."));
     }
 
     #[test]

--- a/src/codex/index/mod.rs
+++ b/src/codex/index/mod.rs
@@ -315,19 +315,312 @@ impl ProjectIndex {
     /// the matched entry, or an [`IndexError::AmbiguousProject`] error if a
     /// basename matches multiple absolute paths.
     ///
-    /// PR 3 will integrate this when export reads the index. Until then,
-    /// this returns [`IndexError::NotImplemented`].
-    pub fn lookup(&self, _query: &str) -> Result<ProjectEntry> {
-        Err(IndexError::NotImplemented { method: "lookup" }.into())
+    /// Three input forms are accepted:
+    ///
+    /// - **Absolute path** (starts with `/`): exact match against
+    ///   `ProjectEntry.absolute_paths`. Returns the first entry that
+    ///   contains the path verbatim.
+    /// - **Raw slug** (starts with `-`, the cwd-encoded form Claude uses
+    ///   on disk, e.g. `-home-charlie-recipes-coryzibell-mx`): treat the
+    ///   query as the basename-slug directory directly. The basename of
+    ///   that slug is the basename-slug used in the by-project tree.
+    /// - **Basename** (anything else, e.g. `mx`): match against
+    ///   `ProjectEntry.basename_slug`. If exactly one entry matches, return
+    ///   it. If the matched entry has more than one absolute_path, surface
+    ///   [`IndexError::AmbiguousProject`] listing all colliding paths.
+    ///
+    /// If the in-memory `entries` cache is empty (the typical state right
+    /// after `open()`), the disk by-project/ tree is consulted directly
+    /// via `read_dir`. Stale-index detection is the caller's
+    /// responsibility — callers should consult [`Self::is_stale`] first
+    /// and rebuild if the index lags.
+    pub fn lookup(&self, query: &str) -> Result<ProjectEntry> {
+        if query.is_empty() {
+            return Err(IndexError::NotFound {
+                query: query.to_string(),
+            }
+            .into());
+        }
+
+        // Absolute path: look for an entry whose absolute_paths contain it.
+        if query.starts_with('/') {
+            let needle = PathBuf::from(query);
+            // Prefer cached entries.
+            if !self.entries.is_empty() {
+                for entry in &self.entries {
+                    if entry.absolute_paths.iter().any(|p| p == &needle) {
+                        return Ok(entry.clone());
+                    }
+                }
+                return Err(IndexError::NotFound {
+                    query: query.to_string(),
+                }
+                .into());
+            }
+            // Fall back to manifest walk so abs-path lookups still work
+            // before the in-memory cache has been hydrated.
+            return self.lookup_via_manifests(|m_abs| m_abs == needle, query);
+        }
+
+        // Raw slug: a Claude cwd-encoded slug (e.g. `-home-charlie-recipes-...`).
+        // The on-disk by-project bucket name is the *basename* of that slug —
+        // last `-`-delimited segment — to match the basename_slug convention.
+        if query.starts_with('-') {
+            let basename = query.rsplit('-').next().unwrap_or(query);
+            return self.lookup_by_basename(basename);
+        }
+
+        // Basename match.
+        self.lookup_by_basename(query)
+    }
+
+    /// Resolve a basename query against either the cached entries or the
+    /// on-disk by-project tree (whichever is populated).
+    fn lookup_by_basename(&self, basename: &str) -> Result<ProjectEntry> {
+        if !self.entries.is_empty() {
+            let matches: Vec<&ProjectEntry> = self
+                .entries
+                .iter()
+                .filter(|e| e.basename_slug == basename)
+                .collect();
+            return match matches.len() {
+                0 => Err(IndexError::NotFound {
+                    query: basename.to_string(),
+                }
+                .into()),
+                1 => {
+                    let entry = matches[0].clone();
+                    if entry.absolute_paths.len() > 1 {
+                        Err(IndexError::AmbiguousProject {
+                            query: basename.to_string(),
+                            matches: entry.absolute_paths.clone(),
+                        }
+                        .into())
+                    } else {
+                        Ok(entry)
+                    }
+                }
+                // Multiple cached entries with the same basename_slug shouldn't
+                // happen — `rebuild_from_manifests` partitions by basename —
+                // but defend against it by returning ambiguous with the union.
+                _ => {
+                    let merged: Vec<PathBuf> = matches
+                        .iter()
+                        .flat_map(|e| e.absolute_paths.iter().cloned())
+                        .collect();
+                    Err(IndexError::AmbiguousProject {
+                        query: basename.to_string(),
+                        matches: merged,
+                    }
+                    .into())
+                }
+            };
+        }
+
+        // No in-memory cache. Read the on-disk bucket directly.
+        let bucket = self.root.join(basename);
+        if !bucket.exists() {
+            // Index might be empty / not rebuilt — fall through to a
+            // manifest walk so callers don't need to remember to rebuild.
+            return self.lookup_via_manifests(
+                |m_abs| {
+                    m_abs
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s == basename)
+                        .unwrap_or(false)
+                },
+                basename,
+            );
+        }
+
+        // Walk the bucket's symlinks to recover archive paths and the
+        // distinct project_paths they point to.
+        let codex_dir = self.root.parent().ok_or_else(|| {
+            anyhow::anyhow!("by-project root has no parent: {}", self.root.display())
+        })?;
+        let mut session_archive_paths: Vec<PathBuf> = Vec::new();
+        let mut absolute_paths: Vec<PathBuf> = Vec::new();
+        for entry in fs::read_dir(&bucket)? {
+            let entry = entry?;
+            let archive_name = entry.file_name();
+            let resolved = codex_dir.join(&archive_name);
+            session_archive_paths.push(resolved.clone());
+            // Read the manifest's project_path so we can detect ambiguity.
+            let manifest_path = resolved.join("manifest.json");
+            if let Ok(raw) = fs::read_to_string(&manifest_path)
+                && let Ok(m) = serde_json::from_str::<Manifest>(&raw)
+                && let Some(p) = m.project_path
+            {
+                absolute_paths.push(PathBuf::from(p));
+            }
+        }
+        absolute_paths.sort();
+        absolute_paths.dedup();
+        session_archive_paths.sort();
+
+        if absolute_paths.is_empty() {
+            return Err(IndexError::NotFound {
+                query: basename.to_string(),
+            }
+            .into());
+        }
+        if absolute_paths.len() > 1 {
+            return Err(IndexError::AmbiguousProject {
+                query: basename.to_string(),
+                matches: absolute_paths,
+            }
+            .into());
+        }
+        Ok(ProjectEntry {
+            basename_slug: basename.to_string(),
+            absolute_paths,
+            session_archive_paths,
+        })
+    }
+
+    /// Last-resort lookup helper: walk every manifest under the codex root
+    /// and group by the supplied predicate. Used when the on-disk index
+    /// hasn't been rebuilt yet but a caller still needs an answer (PR 3
+    /// `mx codex export` may run before any archive ever fired).
+    fn lookup_via_manifests(
+        &self,
+        matches: impl Fn(&Path) -> bool,
+        query: &str,
+    ) -> Result<ProjectEntry> {
+        let codex_dir = self.root.parent().ok_or_else(|| {
+            anyhow::anyhow!("by-project root has no parent: {}", self.root.display())
+        })?;
+        if !codex_dir.exists() {
+            return Err(IndexError::NotFound {
+                query: query.to_string(),
+            }
+            .into());
+        }
+
+        let mut absolute_paths: Vec<PathBuf> = Vec::new();
+        let mut session_archive_paths: Vec<PathBuf> = Vec::new();
+        let mut basename: Option<String> = None;
+
+        for entry in fs::read_dir(codex_dir)? {
+            let entry = entry?;
+            let archive_dir = entry.path();
+            if !archive_dir.is_dir() {
+                continue;
+            }
+            let name = match archive_dir.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            if name == INDEX_SUBDIR || name == STAGING_SUBDIR || name == OLD_SUBDIR {
+                continue;
+            }
+            let manifest_path = archive_dir.join("manifest.json");
+            if !manifest_path.exists() {
+                continue;
+            }
+            let raw = match fs::read_to_string(&manifest_path) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            let manifest: Manifest = match serde_json::from_str(&raw) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let abs = match manifest.project_path.as_ref() {
+                Some(p) => PathBuf::from(p),
+                None => continue,
+            };
+            if !matches(&abs) {
+                continue;
+            }
+            if basename.is_none() {
+                basename = Some(basename_slug_for(&abs));
+            }
+            session_archive_paths.push(archive_dir);
+            absolute_paths.push(abs);
+        }
+
+        absolute_paths.sort();
+        absolute_paths.dedup();
+        session_archive_paths.sort();
+
+        if absolute_paths.is_empty() {
+            return Err(IndexError::NotFound {
+                query: query.to_string(),
+            }
+            .into());
+        }
+        if absolute_paths.len() > 1 {
+            return Err(IndexError::AmbiguousProject {
+                query: query.to_string(),
+                matches: absolute_paths,
+            }
+            .into());
+        }
+        Ok(ProjectEntry {
+            basename_slug: basename.unwrap_or_else(|| query.to_string()),
+            absolute_paths,
+            session_archive_paths,
+        })
     }
 
     /// Returns true if the on-disk index is stale relative to the manifest
     /// timestamps. Readers MUST call this before trusting the index.
     ///
-    /// PR 3 will integrate this when export reads the index. Until then,
-    /// this returns [`IndexError::NotImplemented`].
+    /// Comparison rule:
+    ///
+    /// - If `<codex_dir>/by-project/` does not exist: stale (true).
+    /// - If no `manifest.json` files exist under `<codex_dir>/`: not stale
+    ///   (false) — vacuous match.
+    /// - Otherwise: compare the newest `manifest.json` mtime to the
+    ///   `by-project/` directory mtime; stale iff a manifest is strictly
+    ///   newer than the index.
     pub fn is_stale(&self) -> Result<bool> {
-        Err(IndexError::NotImplemented { method: "is_stale" }.into())
+        if !self.root.exists() {
+            return Ok(true);
+        }
+        let codex_dir = self.root.parent().ok_or_else(|| {
+            anyhow::anyhow!("by-project root has no parent: {}", self.root.display())
+        })?;
+        if !codex_dir.exists() {
+            return Ok(false);
+        }
+
+        let index_mtime = fs::metadata(&self.root)?.modified()?;
+
+        let mut newest_manifest: Option<std::time::SystemTime> = None;
+        for entry in fs::read_dir(codex_dir)? {
+            let entry = entry?;
+            let archive_dir = entry.path();
+            if !archive_dir.is_dir() {
+                continue;
+            }
+            let name = match archive_dir.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            if name == INDEX_SUBDIR || name == STAGING_SUBDIR || name == OLD_SUBDIR {
+                continue;
+            }
+            let manifest_path = archive_dir.join("manifest.json");
+            if !manifest_path.exists() {
+                continue;
+            }
+            let mtime = match fs::metadata(&manifest_path).and_then(|m| m.modified()) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            newest_manifest = Some(match newest_manifest {
+                Some(prev) if prev >= mtime => prev,
+                _ => mtime,
+            });
+        }
+
+        match newest_manifest {
+            None => Ok(false),
+            Some(t) => Ok(t > index_mtime),
+        }
     }
 
     /// Number of entries currently held in memory.
@@ -385,6 +678,8 @@ pub enum IndexError {
         query: String,
         matches: Vec<PathBuf>,
     },
+    #[error("project query '{query}' did not match any archived session")]
+    NotFound { query: String },
     #[error("ProjectIndex::{method} is not yet implemented (wired up in a later PR)")]
     NotImplemented { method: &'static str },
 }
@@ -735,19 +1030,186 @@ mod tests {
         assert_eq!(basename_slug_for(Path::new("/")), "home");
     }
 
-    #[test]
-    fn lookup_still_unimplemented_in_pr2() {
-        let idx = ProjectIndex::default();
-        let err = idx.lookup("mx").unwrap_err();
-        let msg = format!("{}", err);
-        assert!(msg.contains("not yet implemented"), "got: {msg}");
+    // -----------------------------------------------------------------
+    // PR 3: lookup
+    // -----------------------------------------------------------------
+
+    /// Build a populated index with one project (`/home/charlie/work/mx`)
+    /// holding a single archive. Returns `(idx, codex_dir)` so tests can
+    /// poke at the on-disk tree.
+    fn populated_index() -> (ProjectIndex, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path().to_path_buf();
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/charlie/work/mx",
+            "aaa",
+        );
+        let mut idx = ProjectIndex::open_under(&codex).unwrap();
+        idx.rebuild_from_manifests().unwrap();
+        (idx, tmp)
     }
 
     #[test]
-    fn is_stale_still_unimplemented_in_pr2() {
-        let idx = ProjectIndex::default();
-        let err = idx.is_stale().unwrap_err();
-        let msg = format!("{}", err);
-        assert!(msg.contains("not yet implemented"), "got: {msg}");
+    fn lookup_by_basename_returns_entry() {
+        let (idx, _tmp) = populated_index();
+        let entry = idx.lookup("mx").expect("basename lookup should succeed");
+        assert_eq!(entry.basename_slug, "mx");
+        assert_eq!(entry.absolute_paths.len(), 1);
+        assert_eq!(
+            entry.absolute_paths[0],
+            PathBuf::from("/home/charlie/work/mx")
+        );
+    }
+
+    #[test]
+    fn lookup_by_absolute_path_returns_entry() {
+        let (idx, _tmp) = populated_index();
+        let entry = idx
+            .lookup("/home/charlie/work/mx")
+            .expect("abs path lookup should succeed");
+        assert_eq!(entry.basename_slug, "mx");
+    }
+
+    #[test]
+    fn lookup_by_raw_slug_returns_entry() {
+        // Raw slug is the cwd-encoded form Claude uses on disk. Its
+        // basename (last `-` segment) should match the bucket name.
+        let (idx, _tmp) = populated_index();
+        let entry = idx
+            .lookup("-home-charlie-work-mx")
+            .expect("raw slug lookup should succeed");
+        assert_eq!(entry.basename_slug, "mx");
+    }
+
+    #[test]
+    fn lookup_ambiguous_basename_returns_ambiguous_error() {
+        // Two projects share basename `mx` → ambiguous.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/alice/recipes/mx",
+            "aaa",
+        );
+        write_manifest(
+            &codex.join("2026-04-29-110000-bbbbbbbb"),
+            "/home/bob/work/mx",
+            "bbb",
+        );
+        let mut idx = ProjectIndex::open_under(codex).unwrap();
+        idx.rebuild_from_manifests().unwrap();
+
+        let err = idx.lookup("mx").unwrap_err();
+        // Underlying type should be IndexError::AmbiguousProject.
+        let downcast = err.downcast_ref::<IndexError>().expect("IndexError");
+        match downcast {
+            IndexError::AmbiguousProject { query, matches } => {
+                assert_eq!(query, "mx");
+                assert_eq!(matches.len(), 2);
+            }
+            other => panic!("expected AmbiguousProject, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lookup_not_found_returns_notfound_error() {
+        let (idx, _tmp) = populated_index();
+        let err = idx.lookup("does-not-exist").unwrap_err();
+        let downcast = err.downcast_ref::<IndexError>().expect("IndexError");
+        assert!(matches!(downcast, IndexError::NotFound { .. }));
+    }
+
+    #[test]
+    fn lookup_falls_back_to_manifest_walk_when_cache_empty() {
+        // Hot path used by callers that `open()` without rebuilding —
+        // the abs-path query should still resolve via manifest walk.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/charlie/work/mx",
+            "aaa",
+        );
+        let idx = ProjectIndex::open_under(codex).unwrap();
+        // Did NOT call rebuild_from_manifests — cache is empty, but the
+        // on-disk codex has a manifest.
+        let entry = idx
+            .lookup("/home/charlie/work/mx")
+            .expect("manifest-walk fallback should resolve abs path");
+        assert_eq!(entry.basename_slug, "mx");
+    }
+
+    // -----------------------------------------------------------------
+    // PR 3: is_stale
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn is_stale_fresh_codex_no_archives_is_not_stale() {
+        // Vacuous case: no manifests means there's nothing the index
+        // could be lagging behind.
+        let tmp = tempfile::tempdir().unwrap();
+        let idx = ProjectIndex::open_under(tmp.path()).unwrap();
+        assert!(!idx.is_stale().unwrap());
+    }
+
+    #[test]
+    fn is_stale_after_archive_added_is_stale() {
+        // Build a clean index, then drop in a new manifest — the index's
+        // mtime predates the new manifest, so the index reports stale.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+        let mut idx = ProjectIndex::open_under(codex).unwrap();
+        idx.rebuild_from_manifests().unwrap();
+
+        // Force a clear ordering: the manifest must be strictly newer
+        // than the by-project/ dir's mtime, even on filesystems with
+        // coarse timestamp resolution.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/charlie/work/mx",
+            "aaa",
+        );
+
+        assert!(
+            idx.is_stale().unwrap(),
+            "manifest written after rebuild should mark index stale"
+        );
+    }
+
+    #[test]
+    fn is_stale_after_rebuild_is_not_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/charlie/work/mx",
+            "aaa",
+        );
+        let mut idx = ProjectIndex::open_under(codex).unwrap();
+        // Touch by-project AFTER the manifest exists so the rebuild's
+        // staging-rename produces an index newer than the manifest.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        idx.rebuild_from_manifests().unwrap();
+        assert!(
+            !idx.is_stale().unwrap(),
+            "fresh rebuild should not be stale"
+        );
+    }
+
+    #[test]
+    fn is_stale_when_index_dir_missing_is_stale() {
+        // If by-project/ never existed, callers must rebuild before
+        // trusting the index — return stale.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+        // Manually skip open() and just construct an idx pointed at a
+        // path that does not exist on disk.
+        let idx = ProjectIndex {
+            root: codex.join(INDEX_SUBDIR),
+            entries: Vec::new(),
+        };
+        assert!(idx.is_stale().unwrap());
     }
 }

--- a/src/codex/index/mod.rs
+++ b/src/codex/index/mod.rs
@@ -184,9 +184,19 @@ impl ProjectIndex {
                 if !manifest_path.exists() {
                     continue;
                 }
+                // S5: same stderr warning shape as `rebuild_from_manifests`
+                // and `lookup_via_manifests` so the operator sees one
+                // consistent message regardless of which code path
+                // tripped over a bad manifest.
                 let raw = match fs::read_to_string(&manifest_path) {
                     Ok(r) => r,
-                    Err(_) => continue,
+                    Err(e) => {
+                        eprintln!(
+                            "warning: skipping unreadable manifest {}: {e}",
+                            manifest_path.display()
+                        );
+                        continue;
+                    }
                 };
                 let manifest: Manifest = match serde_json::from_str(&raw) {
                     Ok(m) => m,
@@ -565,12 +575,33 @@ impl ProjectIndex {
             let resolved = codex_dir.join(&archive_name);
             session_archive_paths.push(resolved.clone());
             // Read the manifest's project_path so we can detect ambiguity.
+            // S5: surface unreadable / unparseable manifests via the
+            // same stderr warning the rebuild path uses, instead of
+            // silently dropping them.
             let manifest_path = resolved.join("manifest.json");
-            if let Ok(raw) = fs::read_to_string(&manifest_path)
-                && let Ok(m) = serde_json::from_str::<Manifest>(&raw)
-                && let Some(p) = m.project_path
-            {
-                absolute_paths.push(PathBuf::from(p));
+            match fs::read_to_string(&manifest_path) {
+                Ok(raw) => match serde_json::from_str::<Manifest>(&raw) {
+                    Ok(m) => {
+                        if let Some(p) = m.project_path {
+                            absolute_paths.push(PathBuf::from(p));
+                        }
+                    }
+                    Err(e) => eprintln!(
+                        "warning: skipping unparseable manifest {}: {e}",
+                        manifest_path.display()
+                    ),
+                },
+                Err(e) => {
+                    // ENOENT through a dangling symlink isn't actionable;
+                    // only warn when the symlink resolves to something
+                    // else broken.
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        eprintln!(
+                            "warning: skipping unreadable manifest {}: {e}",
+                            manifest_path.display()
+                        );
+                    }
+                }
             }
         }
         absolute_paths.sort();
@@ -637,13 +668,30 @@ impl ProjectIndex {
             if !manifest_path.exists() {
                 continue;
             }
+            // S5: surface the same stderr warning as
+            // `rebuild_from_manifests` when a manifest is unreadable or
+            // unparseable. The fallback used to swallow these silently,
+            // which made bad manifests invisible until the next archive
+            // run forced a rebuild.
             let raw = match fs::read_to_string(&manifest_path) {
                 Ok(r) => r,
-                Err(_) => continue,
+                Err(e) => {
+                    eprintln!(
+                        "warning: skipping unreadable manifest {}: {e}",
+                        manifest_path.display()
+                    );
+                    continue;
+                }
             };
             let manifest: Manifest = match serde_json::from_str(&raw) {
                 Ok(m) => m,
-                Err(_) => continue,
+                Err(e) => {
+                    eprintln!(
+                        "warning: skipping unparseable manifest {}: {e}",
+                        manifest_path.display()
+                    );
+                    continue;
+                }
             };
             let abs = match manifest.project_path.as_ref() {
                 Some(p) => PathBuf::from(p),
@@ -1359,6 +1407,37 @@ mod tests {
             .lookup("/home/charlie/work/wonka")
             .expect("manifest-walk fallback must find the new archive");
         assert_eq!(entry.basename_slug, "wonka");
+    }
+
+    #[test]
+    fn lookup_via_manifests_skips_bad_manifests_without_panic() {
+        // S5: the manifest-walk fallback must not panic on a manifest
+        // that's unparseable garbage. It should warn (to stderr — we
+        // can't capture that here without an extra dep) and then keep
+        // walking. The good manifest at the same level should still
+        // resolve.
+        let tmp = tempfile::tempdir().unwrap();
+        let codex = tmp.path();
+
+        // Good manifest.
+        write_manifest(
+            &codex.join("2026-04-29-100000-aaaaaaaa"),
+            "/home/charlie/work/mx",
+            "aaa",
+        );
+        // Bad manifest: invalid JSON.
+        let bad_archive = codex.join("2026-04-29-110000-bbbbbbbb");
+        fs::create_dir_all(&bad_archive).unwrap();
+        fs::write(bad_archive.join("manifest.json"), "{not json").unwrap();
+
+        // Open without rebuilding so the lookup goes through the
+        // manifest-walk fallback (cache is empty + on-disk index is
+        // empty).
+        let idx = ProjectIndex::open_under(codex).unwrap();
+        let entry = idx
+            .lookup("/home/charlie/work/mx")
+            .expect("good manifest should still resolve");
+        assert_eq!(entry.basename_slug, "mx");
     }
 
     #[test]

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -1,4 +1,5 @@
-mod archive;
+pub(crate) mod archive;
+pub(crate) mod export;
 mod images;
 pub mod index;
 mod migrate;
@@ -10,6 +11,8 @@ use serde::{Deserialize, Serialize};
 
 // Re-export public API
 pub(crate) use archive::{IncludeSet, save_session};
+pub(crate) use export::run as run_export;
+pub(crate) use export::{ExportIncludeSet, ExportRequest, Format, Selector};
 pub(crate) use migrate::migrate_archives;
 pub(crate) use read::{list_sessions, read_session, search_archives};
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -106,6 +106,23 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
             codex::save_session(path, all, clean, include_agents, include_set)?;
             Ok(())
         }
+        CodexCommands::Export {
+            session,
+            project,
+            date,
+            format,
+            include,
+            archive_first,
+            output,
+        } => handle_codex_export(
+            session,
+            project,
+            date,
+            format,
+            include,
+            archive_first,
+            output,
+        ),
         CodexCommands::List { all, json } => {
             codex::list_sessions(all, json)?;
             Ok(())
@@ -136,6 +153,46 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
             Ok(())
         }
     }
+}
+
+/// Build an `ExportRequest` from the flat CLI args and dispatch to
+/// `codex::export::run`. The selectors are mutually exclusive at the
+/// CLI level (clap `group = "selector"`) so at most one of
+/// `--session / --project / --date` will be `Some`.
+#[allow(clippy::too_many_arguments)]
+fn handle_codex_export(
+    session: Option<String>,
+    project: Option<String>,
+    date: Option<String>,
+    format: String,
+    include: String,
+    archive_first: bool,
+    output: Option<String>,
+) -> Result<()> {
+    use std::path::PathBuf;
+
+    let selector = match (session, project, date) {
+        (Some(s), None, None) => codex::Selector::Session(codex::export::SessionRef(s)),
+        (None, Some(p), None) => codex::Selector::Project(p),
+        (None, None, Some(d)) => codex::Selector::Date(codex::export::DateRange::parse(&d)?),
+        (None, None, None) => codex::Selector::Latest,
+        // The clap group should prevent this, but defend anyway so the
+        // error is friendly if a downstream caller hand-builds the args.
+        _ => anyhow::bail!(
+            "--session, --project, and --date are mutually exclusive; pass at most one"
+        ),
+    };
+    let format = codex::Format::parse(&format)?;
+    let include = codex::ExportIncludeSet::parse(&include)?;
+    let request = codex::ExportRequest {
+        selector,
+        format,
+        include,
+        archive_first,
+        output: output.map(PathBuf::from),
+    };
+    codex::run_export(request)?;
+    Ok(())
 }
 
 pub(crate) fn handle_convert(cmd: ConvertCommands) -> Result<()> {


### PR DESCRIPTION
**Part of:** #254 (PR 5 closes the umbrella)

**Architecture context:** https://github.com/coryzibell/mx/issues/254#issuecomment-4349828527

**Prior PRs:** #267 (foundation), #268 (archive skeleton)

## Summary

Lands `mx codex export`, the read side of the codex story. The new subcommand reads exclusively from the codex (never `~/.claude/`), filters by session/project/date, and emits markdown or structured JSON. It implements `ProjectIndex::lookup` and `is_stale` -- the two methods stubbed since PR 1. A detection warning fires when unarchived sessions/tool-outputs are found in live sources, and `--archive-first` is offered as a one-shot capture-and-emit convenience. Default `--include` is `subagents` only -- clean human conversation by default.

## Files affected

- **New module:** `src/codex/export/{mod,filter,detect,read,include}.rs` + `src/codex/export/format/{mod,markdown,json}.rs`
- **Index implementation:** `src/codex/index/mod.rs` (`lookup` and `is_stale` no longer return `NotImplemented`; new `IndexError::NotFound` variant)
- **CLI wiring:** `src/cli.rs` (`CodexCommands::Export`), `src/handlers/mod.rs` (`handle_codex_export`)
- 8 new files, 12 files modified total; +2804 net LOC

## CLI surface

```
mx codex export
  [--session <uuid-or-short>]
  [--project <abs-path|slug|basename>]
  [--date <YYYY-MM-DD|range|YYYY-MM>]
  [--format markdown|json|both]
  [--include <comma-list>]   (default: "subagents")
  [--archive-first]
  [-o, --output <path>]
```

`--session`, `--project`, and `--date` are mutually exclusive; if none are given, "latest" by `session_start`.

## Detection warning

Runs at the start of every `export` invocation. Scans `~/.claude/projects/` (overridable via `MX_CLAUDE_PROJECTS_DIR` for testing) and `/tmp/claude-<uid>/.../tasks/`. Prints a stderr note with count and sample UUIDs (capped at 5). `--archive-first` short-circuits the warning by running `archive::run(All)`, re-detecting, and proceeding to export.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` 630 / 0 / 3 (+65 from the 565 baseline post-PR-#268)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] The known `surreal_db::tests::test_open_with_path` flake did not fire this run (6th confirmed shift overall; ticket overdue -- separate scope)
- [x] **Architectural-invariant test:** `export::mod::export_does_not_read_claude_projects_for_content` plants a sentinel in the `MX_CLAUDE_PROJECTS_DIR` fixture and asserts the sentinel never appears in export output -- proves the codex-only-reads contract.

## Notable design decisions / deviations from brief

- **Code-share for markdown renderer not extracted.** `transcript::generate_clean_transcript` is golden-tested via PR 2's manifest-golden fixtures and adding filter knobs would risk that. Local emitter in `export/format/markdown.rs` with a TODO referencing #254 for a future shared module if a third caller emerges. Local code-share between `markdown.rs` and `json.rs` is via a `pub(crate)` system-reminder regex accessor.
- **`ProjectIndex::lookup` signature kept as `anyhow::Result<ProjectEntry>`.** PR 1's stub used anyhow and existing tests downcast through it. Switching to `Result<ProjectEntry, IndexError>` was riskier than surfacing typed variants via `.into()`. New `IndexError::NotFound` variant added.
- **`Format::Both` routes JSON to the chosen output and markdown to stderr.** Reviewer should sanity-check this is the right precedence -- alternative is markdown to stdout / JSON to a sidecar file. (Verdictia, take a look.)
- **`MX_CLAUDE_PROJECTS_DIR` env override** introduced for testability of detection. Production users probably don't need it but it's harmless and documented inline.

## What this PR does NOT do

- Does NOT modify `mx session export` or `src/session.rs` (PR 4)
- Does NOT add `--backfill` or vault-detected warning (PR 5)
- Does NOT change archive behavior in any way (manifest schema still v5; archive `IncludeSet` default unchanged)
- Does NOT touch `~/.wonka/bin/activate` (separate factory commit, post-series)