### PR TITLE
feat(codex): vault backfill + presence warning, closes #254 (PR 5/5)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1185,10 +1185,11 @@ pub enum CodexCommands {
     /// Archive current session to permanent storage
     Save {
         /// Path to session JSONL file (defaults to most recent non-agent session)
+        #[arg(conflicts_with_all = ["all", "backfill"])]
         path: Option<String>,
 
         /// Archive all unarchived sessions
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["backfill"])]
         all: bool,
 
         /// Save only conversation.md + manifest.json + images (no JSONL, no agent files)
@@ -1216,6 +1217,26 @@ pub enum CodexCommands {
         /// `conversation.md` rendering when `--clean` is set.
         #[arg(long, default_value = "subagents")]
         include: String,
+
+        /// Ingest the legacy wonka vault snapshots into the codex.
+        ///
+        /// Walks every `session-*` snapshot under the supplied path
+        /// (defaults to `~/.wonka/vault/archives/`) and feeds each
+        /// session JSONL through the regular archive pipeline.
+        /// Idempotent: re-running on the same vault produces the same
+        /// codex state.
+        ///
+        /// Mutually exclusive with `--all` and the positional `[PATH]`.
+        /// `--include` and `--clean` still apply (they govern what the
+        /// per-session pipeline captures).
+        #[arg(
+            long,
+            value_name = "VAULT_PATH",
+            num_args = 0..=1,
+            default_missing_value = "",
+            conflicts_with_all = ["all", "path"],
+        )]
+        backfill: Option<String>,
     },
 
     /// Export an archived session as Markdown or structured JSON.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1277,7 +1277,7 @@ pub enum CodexCommands {
         #[arg(long, default_value = "subagents")]
         include: String,
 
-        /// Run `mx codex archive --all` before exporting and skip the
+        /// Run `mx codex save --all` before exporting and skip the
         /// unarchived-data warning. Useful when you know live
         /// `~/.claude/projects/` data hasn't been ingested yet.
         #[arg(long)]

--- a/src/codex/archive/backfill.rs
+++ b/src/codex/archive/backfill.rs
@@ -339,7 +339,14 @@ mod tests {
     }
 
     /// Drive a backfill against an isolated codex dir + fake vault.
-    fn drive_backfill(n_snaps: usize, sess_per_snap: usize) -> (BackfillReport, PathBuf) {
+    /// Returns the `TempDir` so the caller's scope keeps it alive
+    /// (dropping it cleans up the codex + vault on test exit). The
+    /// previous version called `tmp.keep()` which leaked the directory
+    /// onto disk on every test run — fixed per S2 in PR 272 review.
+    fn drive_backfill(
+        n_snaps: usize,
+        sess_per_snap: usize,
+    ) -> (BackfillReport, PathBuf, tempfile::TempDir) {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let codex_dir = tmp.path().join("codex");
@@ -362,11 +369,7 @@ mod tests {
             }
         }
 
-        // Hold tmp dir for the caller to inspect. Caller's responsibility
-        // to keep it alive long enough; here we leak it via PathBuf and
-        // accept the temp-dir orphan for the duration of the test.
-        let leaked = tmp.keep();
-        (report, leaked.join("codex"))
+        (report, codex_dir, tmp)
     }
 
     /// Add a "corrupt" session JSONL to an existing vault snapshot. The
@@ -461,7 +464,7 @@ mod tests {
     #[test]
     #[serial]
     fn backfill_walks_snapshots_and_archives_sessions() {
-        let (report, codex) = drive_backfill(3, 2);
+        let (report, codex, _tmp) = drive_backfill(3, 2);
         assert_eq!(report.vault_snapshots_walked, 3);
         assert_eq!(report.sessions_found, 6);
         assert_eq!(report.sessions_archived, 6);

--- a/src/codex/archive/backfill.rs
+++ b/src/codex/archive/backfill.rs
@@ -91,9 +91,25 @@ pub fn run_backfill(vault_path: &Path, options: ArchiveOptions) -> Result<Backfi
     // `Single` codepath gets dedup too. Failures to read the codex dir
     // are non-fatal — we'd rather over-archive (and let the suffix
     // collision logic in `determine_archive_dir` handle it) than abort
-    // the whole run.
-    let archived_ids = collect_archived_ids().unwrap_or_default();
-    let mut seen: HashSet<String> = archived_ids;
+    // the whole run. But we MUST surface the failure: silently swallowing
+    // it (W1 from the PR 272 review) means a permission-denied or
+    // corrupted manifest produces zero dedup, which leads to
+    // double-archiving on re-run with no warning to the operator.
+    let mut seen: HashSet<String> = match collect_archived_ids() {
+        Ok(ids) => ids,
+        Err(e) => {
+            eprintln!(
+                "warning: failed to scan codex for dedup set: {e}; \
+                 backfill may produce duplicates"
+            );
+            let codex_dir = get_codex_dir().unwrap_or_else(|_| PathBuf::from("<codex>"));
+            report.errors.push((
+                codex_dir,
+                e.context("scanning codex for already-archived session_ids (dedup set)"),
+            ));
+            HashSet::new()
+        }
+    };
 
     let total_snapshots = snapshots.len();
     for (idx, snapshot) in snapshots.iter().enumerate() {
@@ -413,6 +429,63 @@ mod tests {
         assert!(
             msg.contains("does not exist"),
             "expected helpful error, got: {msg}"
+        );
+    }
+
+    /// W1 from the PR 272 review: if `collect_archived_ids` fails (e.g.,
+    /// the codex path points at a regular file rather than a directory,
+    /// simulating a permission-denied or corrupted-tree state), the old
+    /// code silently swallowed the error via `unwrap_or_default()` and
+    /// proceeded with zero dedup — risking double-archives on re-run.
+    /// The new behavior surfaces the failure on the report and continues
+    /// with an empty seen set so the bulk operation still completes.
+    #[test]
+    #[serial]
+    fn backfill_surfaces_codex_scan_failure_on_report() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Codex path is a *file*, not a directory. `read_dir` will return
+        // NotADirectory, which now propagates to `BackfillReport.errors`.
+        let codex_path = tmp.path().join("codex-not-a-dir");
+        fs::write(&codex_path, "i am a file, not a directory").unwrap();
+
+        let vault = build_fake_vault(tmp.path(), 1, 1);
+
+        let prev = std::env::var("MX_CODEX_PATH").ok();
+        // SAFETY: process-wide env mutation, serialized via ENV_LOCK +
+        // #[serial] so concurrent codex tests stay correct.
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex_path);
+        }
+
+        let report = run_backfill(&vault, ArchiveOptions::default())
+            .expect("backfill must continue past a codex scan failure (non-fatal error model)");
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+        }
+
+        // The codex-scan failure must show up on the report so the
+        // operator sees it. There may be additional per-session errors
+        // (the per-session archive path may also choke on the
+        // not-a-directory codex), but we require the scan failure to be
+        // present.
+        let scan_err_present = report.errors.iter().any(|(_, e)| {
+            let msg = format!("{e:#}");
+            msg.contains("scanning codex") || msg.contains("dedup set")
+        });
+        assert!(
+            scan_err_present,
+            "expected a codex-scan failure in report.errors, got: {:?}",
+            report
+                .errors
+                .iter()
+                .map(|(p, e)| format!("{}: {e}", p.display()))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/src/codex/archive/backfill.rs
+++ b/src/codex/archive/backfill.rs
@@ -283,6 +283,16 @@ fn collect_archived_ids() -> Result<HashSet<String>> {
     Ok(ids)
 }
 
+/// Derive the dedup key for a vault session JSONL from its filename
+/// stem (`<uuid>.jsonl` → `<uuid>`).
+///
+/// This mirrors what `archive::run(ArchiveRequest::Single, ...)` ends
+/// up using as the canonical `session_id` (the manifest's `session_id`
+/// is currently set from the same file stem). If that ever changes —
+/// e.g., the canonical id starts coming from a `sessionId` field
+/// inside the JSONL — this function and the corresponding NOTE in
+/// `archive::run` (`mod.rs`, the `Single` arm) must be updated
+/// together. See W2 in PR 272 review for context.
 fn session_id_from_path(path: &Path) -> Option<String> {
     path.file_stem()
         .and_then(|s| s.to_str())

--- a/src/codex/archive/backfill.rs
+++ b/src/codex/archive/backfill.rs
@@ -369,6 +369,95 @@ mod tests {
         (report, leaked.join("codex"))
     }
 
+    /// Add a "corrupt" session JSONL to an existing vault snapshot. The
+    /// file is unreadable (mode 000) so the archive pipeline's
+    /// `read_to_string` returns permission-denied — a realistic shape
+    /// for the failure mode S3 cares about.
+    fn drop_unreadable_session(vault_path: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        // Pick the first snapshot's slug dir.
+        let snap = fs::read_dir(vault_path)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with("session-"))
+            })
+            .expect("at least one snapshot");
+        let slug = snap.path().join("projects").join("-home-charlie");
+        let path = slug.join("deadbeef-corrupt-uuid-0000-000000000000.jsonl");
+        fs::write(&path, "this content cannot be read because chmod 000").unwrap();
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o000);
+        fs::set_permissions(&path, perms).unwrap();
+        path
+    }
+
+    /// S3 from PR 272 review: a corrupt session JSONL in the vault must
+    /// not abort the whole backfill. The error is recorded on
+    /// `report.errors`, the other (valid) sessions still archive, and
+    /// `run_backfill` returns Ok overall — the non-fatal error model
+    /// must hold.
+    #[test]
+    #[serial]
+    fn backfill_per_session_failure_is_non_fatal() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join("codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+
+        // 3 valid sessions across 3 snapshots (one each), then drop one
+        // corrupt session into the first snapshot for a total of 4
+        // sessions found (3 valid + 1 corrupt).
+        let vault = build_fake_vault(tmp.path(), 3, 1);
+        let corrupt = drop_unreadable_session(&vault);
+
+        let prev = std::env::var("MX_CODEX_PATH").ok();
+        // SAFETY: process-wide env mutation, serialized via ENV_LOCK +
+        // #[serial] so concurrent codex tests stay correct.
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex_dir);
+        }
+
+        let report = run_backfill(&vault, ArchiveOptions::default())
+            .expect("backfill must return Ok even when a session fails");
+
+        // Restore permissions so TempDir cleanup doesn't choke.
+        use std::os::unix::fs::PermissionsExt;
+        if corrupt.exists() {
+            let mut perms = fs::metadata(&corrupt).unwrap().permissions();
+            perms.set_mode(0o644);
+            let _ = fs::set_permissions(&corrupt, perms);
+        }
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+        }
+
+        // 4 sessions found (3 valid + 1 corrupt), 3 archived.
+        assert_eq!(report.sessions_found, 4);
+        assert_eq!(report.sessions_archived, 3);
+        assert_eq!(report.sessions_skipped_already_archived, 0);
+
+        // Exactly one per-session error, and it points at the corrupt
+        // file.
+        assert_eq!(
+            report.errors.len(),
+            1,
+            "expected exactly one error (the corrupt session), got: {:?}",
+            report
+                .errors
+                .iter()
+                .map(|(p, e)| format!("{}: {e}", p.display()))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(report.errors[0].0, corrupt);
+    }
+
     #[test]
     #[serial]
     fn backfill_walks_snapshots_and_archives_sessions() {

--- a/src/codex/archive/backfill.rs
+++ b/src/codex/archive/backfill.rs
@@ -1,0 +1,446 @@
+//! Vault-backfill walker.
+//!
+//! Walks `~/.wonka/vault/archives/` (or a caller-supplied path) and feeds
+//! every session JSONL it finds back through `archive::run` so the codex
+//! ingests historical clean-shift snapshots.
+//!
+//! Layout we walk (verified empirically against the live vault — every
+//! observed snapshot has the same shape):
+//!
+//! ```text
+//! <vault_path>/
+//!   session-YYYYMMDD-HHMMSS-NNNNNN/
+//!     projects/
+//!       <project-slug>/
+//!         <session-uuid>.jsonl
+//!         <session-uuid>/
+//!           subagents/
+//!             agent-*.jsonl
+//!     plans/         (optional, often empty)
+//!     history.jsonl  (slash-command history slice)
+//! ```
+//!
+//! For each session JSONL we delegate to
+//! `archive::run(ArchiveRequest::Single, options)` — the existing
+//! pipeline already dedups against `manifest.session_id` via the
+//! `archived_ids` mechanism in `write::save_all_sessions`, but `Single`
+//! has no such guard, so we maintain our own seen-set here. (PR 4 left
+//! `Single` archive intentionally unconditional; backfill is the first
+//! caller that actually needs idempotence over the same source set.)
+//!
+//! Per-session failures are non-fatal: the bulk operation must survive a
+//! single corrupt JSONL. Errors are accumulated on the report.
+
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::super::Manifest;
+use super::{ArchiveOptions, ArchiveRequest, get_codex_dir, run};
+
+/// Aggregated outcome of a `--backfill` run.
+#[derive(Debug, Default)]
+pub struct BackfillReport {
+    /// The vault root we walked.
+    pub vault_path: PathBuf,
+    /// How many `session-*` snapshot directories we visited.
+    pub vault_snapshots_walked: usize,
+    /// How many session JSONLs we found across all snapshots.
+    pub sessions_found: usize,
+    /// How many were freshly archived into the codex.
+    pub sessions_archived: usize,
+    /// How many were skipped because their `session_id` was already in
+    /// the codex (dedup hit).
+    pub sessions_skipped_already_archived: usize,
+    /// Per-session failures (non-fatal). Reported at the end of the run.
+    pub errors: Vec<(PathBuf, anyhow::Error)>,
+}
+
+/// Walk `vault_path` and feed every session JSONL back through the
+/// archive pipeline. See module docs for layout.
+pub fn run_backfill(vault_path: &Path, options: ArchiveOptions) -> Result<BackfillReport> {
+    let mut report = BackfillReport {
+        vault_path: vault_path.to_path_buf(),
+        ..Default::default()
+    };
+
+    if !vault_path.exists() {
+        anyhow::bail!(
+            "vault path does not exist: {}. The vault may have already been removed.",
+            vault_path.display()
+        );
+    }
+
+    // Collect the vault snapshot directories first so we can emit
+    // accurate progress ("12/26") and so `read_dir` ordering doesn't
+    // matter to the final report.
+    let snapshots = collect_snapshot_dirs(vault_path)
+        .with_context(|| format!("walking vault root {}", vault_path.display()))?;
+
+    if snapshots.is_empty() {
+        eprintln!(
+            "warning: vault path {} has no session-* snapshots; nothing to backfill",
+            vault_path.display()
+        );
+        return Ok(report);
+    }
+
+    // Pre-compute the set of already-archived session_ids. This is the
+    // same trick `save_all_sessions` uses; we replicate it here so the
+    // `Single` codepath gets dedup too. Failures to read the codex dir
+    // are non-fatal — we'd rather over-archive (and let the suffix
+    // collision logic in `determine_archive_dir` handle it) than abort
+    // the whole run.
+    let archived_ids = collect_archived_ids().unwrap_or_default();
+    let mut seen: HashSet<String> = archived_ids;
+
+    let total_snapshots = snapshots.len();
+    for (idx, snapshot) in snapshots.iter().enumerate() {
+        report.vault_snapshots_walked += 1;
+
+        let sessions = match collect_session_jsonls(snapshot) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "warning: failed to walk vault snapshot {}: {}",
+                    snapshot.display(),
+                    e
+                );
+                report.errors.push((snapshot.clone(), e));
+                continue;
+            }
+        };
+
+        for session_path in sessions {
+            report.sessions_found += 1;
+
+            // Dedup: derive session_id from the filename
+            // (`<uuid>.jsonl` → `<uuid>`) and skip if we've already
+            // archived it. The session uuid IS the canonical id used by
+            // the archive pipeline, so this matches what `archive::run`
+            // would compute internally.
+            let session_id = match session_id_from_path(&session_path) {
+                Some(id) => id,
+                None => {
+                    let err = anyhow::anyhow!(
+                        "could not derive session_id from {}",
+                        session_path.display()
+                    );
+                    report.errors.push((session_path, err));
+                    continue;
+                }
+            };
+
+            if seen.contains(&session_id) {
+                report.sessions_skipped_already_archived += 1;
+                continue;
+            }
+
+            match run(
+                ArchiveRequest::Single(session_path.clone()),
+                options.clone(),
+            ) {
+                Ok(_result) => {
+                    report.sessions_archived += 1;
+                    seen.insert(session_id);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "warning: failed to archive {}: {}",
+                        session_path.display(),
+                        e
+                    );
+                    report.errors.push((session_path, e));
+                }
+            }
+        }
+
+        eprintln!(
+            "Backfilling vault: {}/{} snapshots, {}/{} sessions archived...",
+            idx + 1,
+            total_snapshots,
+            report.sessions_archived,
+            report.sessions_found
+        );
+    }
+
+    eprintln!(
+        "Backfill complete: {} vault snapshots, {} sessions found, {} archived, \
+         {} already in codex, {} errors.",
+        report.vault_snapshots_walked,
+        report.sessions_found,
+        report.sessions_archived,
+        report.sessions_skipped_already_archived,
+        report.errors.len()
+    );
+
+    Ok(report)
+}
+
+/// Enumerate `session-*` subdirectories under `vault_path`. Non-matching
+/// entries (e.g. stray files) are silently skipped — the vault is a
+/// best-effort historical store, not a sealed contract.
+fn collect_snapshot_dirs(vault_path: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(vault_path)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) if name.starts_with("session-") => out.push(path),
+            _ => continue,
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Walk `<snapshot>/projects/<slug>/*.jsonl` and return every session
+/// JSONL we find. Subagent files (which live one directory deeper in
+/// `<uuid>/subagents/`) are deliberately NOT returned — `archive::run`
+/// finds them automatically via `find_agent_sessions` so we'd just
+/// re-archive them as if they were primary sessions.
+fn collect_session_jsonls(snapshot_dir: &Path) -> Result<Vec<PathBuf>> {
+    let projects = snapshot_dir.join("projects");
+    if !projects.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for slug_entry in fs::read_dir(&projects)? {
+        let slug_entry = slug_entry?;
+        let slug_path = slug_entry.path();
+        if !slug_path.is_dir() {
+            continue;
+        }
+        for entry in fs::read_dir(&slug_path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+            // Skip stray agent-*.jsonl that may have been deposited at
+            // the slug root (shouldn't happen per the vault layout but
+            // defend anyway — the agent walker handles them).
+            if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && name.starts_with("agent-")
+            {
+                continue;
+            }
+            out.push(path);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Build the set of session_ids already present in the codex. Mirrors
+/// the inline logic in `write::save_all_sessions` — could be hoisted to
+/// a shared helper later, but two call sites isn't enough churn yet.
+fn collect_archived_ids() -> Result<HashSet<String>> {
+    let codex_dir = get_codex_dir()?;
+    let mut ids = HashSet::new();
+    if !codex_dir.exists() {
+        return Ok(ids);
+    }
+    for entry in fs::read_dir(&codex_dir)? {
+        let entry = entry?;
+        let manifest_path = entry.path().join("manifest.json");
+        if !manifest_path.exists() {
+            continue;
+        }
+        let content = match fs::read_to_string(&manifest_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let manifest: Manifest = match serde_json::from_str(&content) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        ids.insert(manifest.session_id);
+    }
+    Ok(ids)
+}
+
+fn session_id_from_path(path: &Path) -> Option<String> {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Build a minimal vault layout under `root` containing `n_snapshots`
+    /// snapshots, each with one project slug and `sessions_per_snapshot`
+    /// session JSONLs. Returns the vault path.
+    fn build_fake_vault(root: &Path, n_snapshots: usize, sessions_per_snapshot: usize) -> PathBuf {
+        let vault = root.join("vault-archives");
+        fs::create_dir_all(&vault).unwrap();
+        for s in 0..n_snapshots {
+            let snap = vault.join(format!("session-2026{:04}-100000-{:06}", s, s));
+            let slug = snap.join("projects").join("-home-charlie");
+            fs::create_dir_all(&slug).unwrap();
+            for k in 0..sessions_per_snapshot {
+                // Session UUIDs have to look uuid-ish enough for the
+                // 8-char short-id slice; pad with zeros.
+                let uuid = format!(
+                    "{:08x}-snap{:02}-sess{:02}-0000-000000000000",
+                    s * 1000 + k,
+                    s,
+                    k
+                );
+                let session = slug.join(format!("{uuid}.jsonl"));
+                let line = format!(
+                    "{{\"role\":\"user\",\"content\":\"hello\",\
+                     \"timestamp\":\"2026-04-29T10:00:0{}Z\"}}\n",
+                    k % 10
+                );
+                fs::write(&session, line).unwrap();
+            }
+        }
+        vault
+    }
+
+    /// Drive a backfill against an isolated codex dir + fake vault.
+    fn drive_backfill(n_snaps: usize, sess_per_snap: usize) -> (BackfillReport, PathBuf) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join("codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let vault = build_fake_vault(tmp.path(), n_snaps, sess_per_snap);
+
+        let prev = std::env::var("MX_CODEX_PATH").ok();
+        // SAFETY: process-wide env mutation, serialized via ENV_LOCK +
+        // #[serial] so concurrent codex tests stay correct.
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex_dir);
+        }
+        let options = ArchiveOptions::default();
+        let report = run_backfill(&vault, options).expect("backfill failed");
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+        }
+
+        // Hold tmp dir for the caller to inspect. Caller's responsibility
+        // to keep it alive long enough; here we leak it via PathBuf and
+        // accept the temp-dir orphan for the duration of the test.
+        let leaked = tmp.keep();
+        (report, leaked.join("codex"))
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_walks_snapshots_and_archives_sessions() {
+        let (report, codex) = drive_backfill(3, 2);
+        assert_eq!(report.vault_snapshots_walked, 3);
+        assert_eq!(report.sessions_found, 6);
+        assert_eq!(report.sessions_archived, 6);
+        assert_eq!(report.sessions_skipped_already_archived, 0);
+        assert!(report.errors.is_empty());
+
+        // Codex dir should now contain 6 archive directories (one per
+        // session) — count the manifest.json files.
+        let manifests = fs::read_dir(&codex)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().join("manifest.json").exists())
+            .count();
+        assert_eq!(manifests, 6);
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_is_idempotent_on_second_run() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join("codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let vault = build_fake_vault(tmp.path(), 2, 2);
+
+        let prev = std::env::var("MX_CODEX_PATH").ok();
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex_dir);
+        }
+
+        let r1 = run_backfill(&vault, ArchiveOptions::default()).unwrap();
+        assert_eq!(r1.sessions_archived, 4);
+        assert_eq!(r1.sessions_skipped_already_archived, 0);
+
+        let r2 = run_backfill(&vault, ArchiveOptions::default()).unwrap();
+        // Second run: nothing new should be archived; everything is a
+        // dedup hit.
+        assert_eq!(r2.sessions_archived, 0);
+        assert_eq!(r2.sessions_skipped_already_archived, 4);
+
+        // The codex directory should still hold exactly the archives
+        // from the first pass — no duplicates.
+        let manifests = fs::read_dir(&codex_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().join("manifest.json").exists())
+            .count();
+        assert_eq!(manifests, 4);
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+        }
+    }
+
+    #[test]
+    fn backfill_missing_vault_path_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bogus = tmp.path().join("does-not-exist");
+        let err = run_backfill(&bogus, ArchiveOptions::default()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("does not exist"),
+            "expected helpful error, got: {msg}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn backfill_empty_vault_warns_and_reports_zeros() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().join("empty-vault");
+        fs::create_dir_all(&vault).unwrap();
+        // No session-* children — should warn and return zeros.
+        let codex_dir = tmp.path().join("codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let prev = std::env::var("MX_CODEX_PATH").ok();
+        unsafe {
+            std::env::set_var("MX_CODEX_PATH", &codex_dir);
+        }
+
+        let report = run_backfill(&vault, ArchiveOptions::default()).unwrap();
+        assert_eq!(report.vault_snapshots_walked, 0);
+        assert_eq!(report.sessions_found, 0);
+        assert_eq!(report.sessions_archived, 0);
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_CODEX_PATH", v),
+                None => std::env::remove_var("MX_CODEX_PATH"),
+            }
+        }
+    }
+}

--- a/src/codex/archive/include.rs
+++ b/src/codex/archive/include.rs
@@ -1,4 +1,4 @@
-//! Opt-in source selection for `mx codex archive`.
+//! Opt-in source selection for `mx codex save`.
 //!
 //! `IncludeSet` controls which optional sidecars the writer captures.
 //! Today only `subagents` is on by default — the same artifact the
@@ -28,7 +28,7 @@ pub struct IncludeSet {
 }
 
 impl IncludeSet {
-    /// The set that reproduces today's `mx codex archive` defaults
+    /// The set that reproduces today's `mx codex save` defaults
     /// byte-for-byte: subagents on, everything else off.
     pub fn status_quo() -> Self {
         Self {

--- a/src/codex/archive/mod.rs
+++ b/src/codex/archive/mod.rs
@@ -18,7 +18,7 @@
 //! `archive::run` is the one canonical entry point. The historical
 //! `save_session` is a thin wrapper that builds an `ArchiveRequest` from
 //! CLI args and calls `run`. Status-quo invocations
-//! (`mx codex archive` with no `--include`) produce byte-identical
+//! (`mx codex save` with no `--include`) produce byte-identical
 //! output to the pre-PR-2 implementation.
 
 use anyhow::Result;
@@ -92,7 +92,7 @@ pub struct ArchiveResult {
 /// to `request` and `options`, returns a summary.
 ///
 /// Behavior with `IncludeSet::status_quo()` and `clean = false` is
-/// byte-identical to the pre-PR-2 `mx codex archive` flow.
+/// byte-identical to the pre-PR-2 `mx codex save` flow.
 ///
 /// After a successful write, the by-project index
 /// (`<codex_dir>/by-project/`) is rebuilt so subsequent reads can find

--- a/src/codex/archive/mod.rs
+++ b/src/codex/archive/mod.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 
 use super::{ArchiveEntry, Manifest};
 
+mod backfill;
 mod include;
 mod paths;
 mod sources;
@@ -34,6 +35,7 @@ mod write;
 
 // Re-exports kept at the historical paths so `super::archive::*` callers
 // (notably `migrate.rs` and `read.rs`) need no changes.
+pub(crate) use backfill::run_backfill;
 pub(crate) use include::IncludeSet;
 pub(crate) use paths::{get_base_archive_name, parse_archive_name};
 

--- a/src/codex/archive/mod.rs
+++ b/src/codex/archive/mod.rs
@@ -104,6 +104,13 @@ pub fn run(request: ArchiveRequest, options: ArchiveOptions) -> Result<ArchiveRe
 
     match request {
         ArchiveRequest::Single(path) => {
+            // NOTE: backfill.rs::session_id_from_path derives the dedup
+            // key from the JSONL filename stem. If we ever change how
+            // the canonical session_id is derived for a Single archive
+            // (e.g., from the JSONL's `sessionId` field instead of the
+            // filename), update backfill's dedup logic to match,
+            // otherwise idempotence will break silently. See W2 in PR
+            // 272 review for context.
             let archive_dir = write::archive_session(
                 &path,
                 options.clean,

--- a/src/codex/export/detect.rs
+++ b/src/codex/export/detect.rs
@@ -78,7 +78,7 @@ impl DetectionReport {
         };
         let mut msg = head;
         msg.push_str(
-            "\n       Run `mx codex archive --all` to ingest, or rerun with --archive-first.",
+            "\n       Run `mx codex save --all` to ingest, or rerun with --archive-first.",
         );
         if !self.sample_unarchived_uuids.is_empty() {
             msg.push_str("\n       Sample: ");
@@ -460,7 +460,7 @@ mod tests {
         );
         assert!(warn.contains("/tmp/"), "should mention /tmp source: {warn}");
         assert!(
-            warn.contains("mx codex archive --all"),
+            warn.contains("mx codex save --all"),
             "should keep the remediation hint: {warn}"
         );
         assert!(

--- a/src/codex/export/filter.rs
+++ b/src/codex/export/filter.rs
@@ -301,7 +301,7 @@ pub fn resolve_latest(archives: Vec<ResolvedArchive>) -> Result<ResolvedArchive>
     archives
         .into_iter()
         .max_by_key(|a| a.manifest.session_start)
-        .context("no archived sessions in codex (run `mx codex archive --all`)")
+        .context("no archived sessions in codex (run `mx codex save --all`)")
 }
 
 #[cfg(test)]

--- a/src/codex/export/mod.rs
+++ b/src/codex/export/mod.rs
@@ -34,7 +34,7 @@ pub struct ExportRequest {
     pub selector: Selector,
     pub format: Format,
     pub include: ExportIncludeSet,
-    /// If set, run `mx codex archive --all` before exporting and skip
+    /// If set, run `mx codex save --all` before exporting and skip
     /// the unarchived-data warning.
     pub archive_first: bool,
     /// Output file path. `None` means stdout for markdown / JSON.

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod export;
 mod images;
 pub mod index;
 mod migrate;
+pub(crate) mod notices;
 mod read;
 mod transcript;
 

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 // Re-export public API
-pub(crate) use archive::{IncludeSet, save_session};
+pub(crate) use archive::{IncludeSet, run_backfill, save_session};
 pub(crate) use export::run as run_export;
 pub(crate) use export::{ExportIncludeSet, ExportRequest, Format, Selector};
 pub(crate) use migrate::migrate_archives;

--- a/src/codex/notices.rs
+++ b/src/codex/notices.rs
@@ -11,7 +11,7 @@ use std::sync::OnceLock;
 
 /// Emit the vault-present warning at most once per process. Idempotent
 /// across repeated calls — the `OnceLock` guarantees a single fire even
-/// if `mx codex archive` and `mx codex export` both run in the same
+/// if `mx codex save` and `mx codex export` both run in the same
 /// process.
 ///
 /// Skipped when:
@@ -35,7 +35,7 @@ pub(crate) fn warn_if_vault_present(suppress: bool) {
     }
     eprintln!(
         "note: {} contains historical session data not in the codex.\n      \
-         Run `mx codex archive --backfill` to ingest, then remove the vault directory.",
+         Run `mx codex save --backfill` to ingest, then remove the vault directory.",
         vault.display()
     );
     let _ = FIRED.set(());
@@ -99,5 +99,55 @@ mod tests {
         let vault = tmp.path().join("real-vault");
         fs::create_dir_all(vault.join("session-20260311-202812-631046")).unwrap();
         assert!(vault_has_snapshots(&vault));
+    }
+
+    /// Regression guard: the warning must reference the actual CLI verb
+    /// (`mx codex save --backfill`), not the architecturally-aspirational
+    /// `mx codex archive --backfill`. C1 from PR 272 review — the
+    /// non-existent subcommand string had been shipping to every operator
+    /// with a vault. We capture stderr by firing the warning against a
+    /// fake vault and assert the literal `mx codex save --backfill`
+    /// appears in the message body. If the verb ever gets renamed,
+    /// update both the message and this test.
+    #[test]
+    fn warning_text_uses_real_save_subcommand() {
+        // Build a vault with one snapshot so the warning fires.
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().join("real-vault");
+        fs::create_dir_all(vault.join("session-20260311-202812-631046")).unwrap();
+        assert!(vault_has_snapshots(&vault));
+
+        // Format the message exactly as `warn_if_vault_present` would.
+        // We don't go through `warn_if_vault_present` itself because its
+        // `OnceLock` makes the test order-sensitive across the suite —
+        // this is an equivalent literal-string assertion.
+        let msg = format!(
+            "note: {} contains historical session data not in the codex.\n      \
+             Run `mx codex save --backfill` to ingest, then remove the vault directory.",
+            vault.display()
+        );
+        assert!(
+            msg.contains("mx codex save --backfill"),
+            "vault-warning string must reference `mx codex save --backfill`: {msg}"
+        );
+
+        // Also assert the bug-fix invariant directly against the source
+        // line that produces the warning: `eprintln!` body should never
+        // contain the broken `mx codex archive --backfill` string. We
+        // grep just the `warn_if_vault_present` function body, not the
+        // test module (where the string legitimately appears in
+        // assertion messages).
+        let src = include_str!("notices.rs");
+        let func_start = src.find("pub(crate) fn warn_if_vault_present").unwrap();
+        let func_end = src[func_start..].find("\n}\n").unwrap() + func_start;
+        let func_body = &src[func_start..func_end];
+        assert!(
+            !func_body.contains("mx codex archive"),
+            "warn_if_vault_present must not emit `mx codex archive` (C1 regression)"
+        );
+        assert!(
+            func_body.contains("mx codex save --backfill"),
+            "warn_if_vault_present must emit `mx codex save --backfill` (C1)"
+        );
     }
 }

--- a/src/codex/notices.rs
+++ b/src/codex/notices.rs
@@ -1,0 +1,103 @@
+//! Operator-facing notices emitted at the start of every `mx codex *`
+//! invocation.
+//!
+//! Today there's exactly one notice — the vault-present nag — but this
+//! module is the right home for any future "before you do anything else,
+//! the codex would like to point out..." messages so the dispatch sites
+//! stay tidy.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+/// Emit the vault-present warning at most once per process. Idempotent
+/// across repeated calls — the `OnceLock` guarantees a single fire even
+/// if `mx codex archive` and `mx codex export` both run in the same
+/// process.
+///
+/// Skipped when:
+/// - the vault directory does not exist (clean machines stay silent), or
+/// - the vault directory exists but contains no `session-*` snapshots.
+///
+/// Callers that are already in the act of backfilling pass
+/// `suppress = true` so the operator doesn't get nagged about the very
+/// thing they're fixing.
+pub(crate) fn warn_if_vault_present(suppress: bool) {
+    if suppress {
+        return;
+    }
+    static FIRED: OnceLock<()> = OnceLock::new();
+    if FIRED.get().is_some() {
+        return;
+    }
+    let vault = crate::paths::wonka_vault_archives_dir();
+    if !vault_has_snapshots(&vault) {
+        return;
+    }
+    eprintln!(
+        "note: {} contains historical session data not in the codex.\n      \
+         Run `mx codex archive --backfill` to ingest, then remove the vault directory.",
+        vault.display()
+    );
+    let _ = FIRED.set(());
+}
+
+/// True iff `vault_path` exists and has at least one `session-*`
+/// subdirectory. Anything else (missing dir, empty dir, dir with only
+/// non-snapshot junk) returns false — those states represent "no work to
+/// surface" and shouldn't generate noise.
+fn vault_has_snapshots(vault_path: &Path) -> bool {
+    let entries = match std::fs::read_dir(vault_path) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    for entry in entries.flatten() {
+        if !entry.path().is_dir() {
+            continue;
+        }
+        match entry.file_name().to_str() {
+            Some(name) if name.starts_with("session-") => return true,
+            _ => continue,
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn vault_missing_is_silent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bogus = tmp.path().join("does-not-exist");
+        assert!(!vault_has_snapshots(&bogus));
+    }
+
+    #[test]
+    fn vault_present_but_empty_is_silent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().join("empty-vault");
+        fs::create_dir_all(&vault).unwrap();
+        assert!(!vault_has_snapshots(&vault));
+    }
+
+    #[test]
+    fn vault_with_only_junk_files_is_silent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().join("junk-vault");
+        fs::create_dir_all(&vault).unwrap();
+        fs::write(vault.join("README.txt"), "hi").unwrap();
+        // A directory that doesn't match the session-* prefix.
+        fs::create_dir_all(vault.join("other-dir")).unwrap();
+        assert!(!vault_has_snapshots(&vault));
+    }
+
+    #[test]
+    fn vault_with_one_snapshot_fires() {
+        let tmp = tempfile::tempdir().unwrap();
+        let vault = tmp.path().join("real-vault");
+        fs::create_dir_all(vault.join("session-20260311-202812-631046")).unwrap();
+        assert!(vault_has_snapshots(&vault));
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -85,7 +85,7 @@ pub(crate) fn handle_session(cmd: SessionCommands) -> Result<()> {
 
 pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
     // Suppress the vault nag for the one invocation that's already
-    // mid-fix: `mx codex archive --backfill`. Every other handler emits
+    // mid-fix: `mx codex save --backfill`. Every other handler emits
     // the warning at most once per process via the OnceLock guard
     // inside `warn_if_vault_present`.
     let suppress_vault_warning = matches!(

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -84,6 +84,19 @@ pub(crate) fn handle_session(cmd: SessionCommands) -> Result<()> {
 }
 
 pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
+    // Suppress the vault nag for the one invocation that's already
+    // mid-fix: `mx codex archive --backfill`. Every other handler emits
+    // the warning at most once per process via the OnceLock guard
+    // inside `warn_if_vault_present`.
+    let suppress_vault_warning = matches!(
+        cmd,
+        CodexCommands::Save {
+            backfill: Some(_),
+            ..
+        }
+    );
+    codex::notices::warn_if_vault_present(suppress_vault_warning);
+
     match cmd {
         CodexCommands::Save {
             path,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -91,6 +91,7 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
             clean,
             include_agents,
             include,
+            backfill,
         } => {
             let include_set = codex::IncludeSet::parse(&include)?;
             // W3: --include-agents only does anything when subagents are
@@ -103,6 +104,37 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
                     include
                 );
             }
+
+            if let Some(vault_arg) = backfill {
+                // `--backfill` with no value parses as `Some("")` thanks
+                // to `default_missing_value`. Resolve to the canonical
+                // `~/.wonka/vault/archives/` in that case.
+                let vault_path = if vault_arg.is_empty() {
+                    crate::paths::wonka_vault_archives_dir()
+                } else {
+                    std::path::PathBuf::from(vault_arg)
+                };
+                let options = codex::archive::ArchiveOptions {
+                    clean,
+                    include: include_set,
+                    include_agents_in_clean_md: include_agents,
+                };
+                let report = codex::run_backfill(&vault_path, options)?;
+                // Echo a final terse summary on stdout (the running
+                // progress lines went to stderr); stdout is the
+                // machine-readable channel for chaining in scripts.
+                println!(
+                    "vault={} snapshots={} found={} archived={} skipped={} errors={}",
+                    report.vault_path.display(),
+                    report.vault_snapshots_walked,
+                    report.sessions_found,
+                    report.sessions_archived,
+                    report.sessions_skipped_already_archived,
+                    report.errors.len()
+                );
+                return Ok(());
+            }
+
             codex::save_session(path, all, clean, include_agents, include_set)?;
             Ok(())
         }
@@ -987,6 +1019,7 @@ mod codex_save_validation_tests {
             clean: true,
             include_agents,
             include: include.to_string(),
+            backfill: None,
         }
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -355,7 +355,7 @@ pub fn tmp_claude_tasks_dir(uid: u32, user_slug: &str, session_uuid: &str) -> Pa
 
 /// `~/.wonka/vault/archives/` -- the legacy vault snapshot directory.
 ///
-/// Walked by `mx codex archive --backfill` (PR 5) to ingest the existing
+/// Walked by `mx codex save --backfill` (PR 5) to ingest the existing
 /// vault snapshots into the codex. Note the literal `~/.wonka/` prefix:
 /// the wonka vault is a *separate* root from `MX_HOME` and intentionally
 /// does not derive from it. If the user has a wonka home override in the

--- a/src/session.rs
+++ b/src/session.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 /// stderr from a child process.
 pub const DEPRECATION_NOTICE: &str = "\
 note: `mx session export` is deprecated; use `mx codex export` instead.
-      The new command reads from the codex (run `mx codex archive` first
+      The new command reads from the codex (run `mx codex save` first
       if needed; this alias does that for you), supports filtering by
       --session, --project, --date, multiple output formats, and inlines
       sub-agent transcripts by default. Run `mx codex export --help` for
@@ -48,7 +48,7 @@ note: the new command selects \"most recent\" by session start time, not
 /// - `output` flows through verbatim.
 /// - `archive_first: true` is forced. The legacy command read live
 ///   data; the new command reads codex. Without `--archive-first`, an
-///   operator who has never run `mx codex archive` would get a "no
+///   operator who has never run `mx codex save` would get a "no
 ///   codex data" error here. Forcing archive-first preserves the
 ///   user-visible "I just ran the command and it worked" semantics.
 /// - `format: Markdown` — the only output the legacy command emitted.
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn alias_forces_archive_first() {
         // Load-bearing: without this, a user who has never run
-        // `mx codex archive` would get "no codex data" instead of the
+        // `mx codex save` would get "no codex data" instead of the
         // legacy "exported your latest session" behavior.
         let req = build_alias_request(None, None).unwrap();
         assert!(req.archive_first, "alias must force archive_first=true");


### PR DESCRIPTION
**Closes #254.** This is the final PR of the 5-PR codex unification series. The umbrella issue tracks the full architecture: https://github.com/coryzibell/mx/issues/254#issuecomment-4349828527

**Prior PRs:** #267 (foundation: paths/index/manifest v5), #268 (archive skeleton + walkers + index writes), #270 (codex export + detection + index reads), #271 (session export deprecation alias)

## Summary

Adds `mx codex save --backfill [<vault-path>]` to ingest the historical session data still living in `~/.wonka/vault/archives/` (26 vault snapshots, ~28M of session data on this machine). Default vault path is `paths::wonka_vault_archives_dir()` if no argument given. Adds a vault-presence warning that fires once per process at the top of every `mx codex *` handler when `~/.wonka/vault/archives/` contains session snapshots — suppressed during `--backfill` invocations to avoid double-nagging users in the act of backfilling. Per-session failures during backfill are non-fatal; aggregated into the `BackfillReport` and surfaced at completion.

## Files affected

- **New module:** `src/codex/archive/backfill.rs` — vault walker, `BackfillReport` struct, 4 tests (idempotency, missing-vault error, empty-vault zero-report, normal walk)
- **New module:** `src/codex/notices.rs` — `warn_if_vault_present(suppress)` with `OnceLock` once-per-process guard, 4 tests (missing/empty/junk-only/has-snapshot)
- **CLI wiring:** `src/cli.rs` (new `--backfill` flag with `conflicts_with_all` against `--all` and the positional `[PATH]`; optional value via `num_args = 0..=1`)
- **Handler:** `src/handlers/mod.rs` (`handle_codex` calls `warn_if_vault_present` at top, computes suppress via `matches!` on the backfill flag)
- 6 files modified total; +621/-2 net LOC

## CLI surface addition

```
mx codex save --backfill [<vault-path>]
```

Optional positional argument; defaults to `~/.wonka/vault/archives/`. Mutually exclusive with `--all` and the positional `[PATH]`. The other capture flags (`--include`, `--clean`) still apply.

## Naming note

The user-facing CLI subcommand is `mx codex save` (existing); the architecture proposal called it `mx codex archive` throughout for clarity. The internal entry point is `archive::run`, but the CLI verb is `save`. A future PR could rename `save` → `archive` for full consistency with the architecture; out of scope for this series.

## Idempotence

`--backfill` is idempotent — running twice on the same vault produces the same final codex state. `archived_ids` dedup logic was rebuilt locally inside `run_backfill` (it only existed in the `save_all_sessions` `--all` path before; `Single` does not dedup natively). Verified by `backfill_is_idempotent` test.

## Vault warning behavior

- Vault present + has session-* snapshots → fires once per process
- Vault absent → silent
- Vault present but empty (no `session-*` children) → silent
- `--backfill` invocation → suppressed

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` 664 passed / 0 failed / 3 ignored (+8 from 656 baseline post-PR-#271)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] The known `surreal_db::tests::test_open_with_path` flake fired (9th confirmed shift; pre-existing; not in scope here)

## Out of scope (reviewer expectations)

- Does NOT delete the vault directory or any of its contents (user's call after verifying backfill)
- Does NOT touch `~/.wonka/bin/activate` (separate post-series factory commit will replace the vault-write block with `mx codex save` integration)
- Does NOT delete `src/session.rs` (future post-series PR after one release of deprecation warning)
- Does NOT capture tool-output or MCP sidecars from vault snapshots — those were never archived to the vault (ephemeral by the time backfill runs)

**Series complete after merge.** Five PRs, no broken intermediate states, status-quo behavior preserved at every step until users explicitly opt in via `--include` or `mx codex export`. The factory's `~/.wonka/bin/activate` change becomes a follow-on once this lands.