### PR TITLE
fix(ci): cfg(unix) gates + graceful missing claude projects dir (CI hotfix)

### DIFF
--- a/src/codex/archive/backfill.rs
+++ b/src/codex/archive/backfill.rs
@@ -376,6 +376,12 @@ mod tests {
     /// file is unreadable (mode 000) so the archive pipeline's
     /// `read_to_string` returns permission-denied — a realistic shape
     /// for the failure mode S3 cares about.
+    ///
+    /// Unix-only: the chmod-000 trick relies on POSIX permission bits.
+    /// Windows uses a different ACL model where there is no clean
+    /// equivalent of "owner cannot read its own file", so we skip the
+    /// failure-mode coverage there.
+    #[cfg(unix)]
     fn drop_unreadable_session(vault_path: &Path) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
         // Pick the first snapshot's slug dir.
@@ -402,6 +408,11 @@ mod tests {
     /// `report.errors`, the other (valid) sessions still archive, and
     /// `run_backfill` returns Ok overall — the non-fatal error model
     /// must hold.
+    ///
+    /// Unix-only: depends on `drop_unreadable_session` which uses
+    /// `chmod 000` to simulate the unreadable case. See helper for the
+    /// rationale on Windows.
+    #[cfg(unix)]
     #[test]
     #[serial]
     fn backfill_per_session_failure_is_non_fatal() {

--- a/src/codex/archive/write.rs
+++ b/src/codex/archive/write.rs
@@ -545,8 +545,19 @@ pub(crate) fn save_all_sessions(
 ) -> Result<ArchiveResult> {
     let projects_dir = crate::paths::claude_projects_dir();
 
+    // A missing `~/.claude/projects/` is a normal state -- a fresh user
+    // who has never run Claude, or a CI environment that has no live
+    // Claude install, will land here. Treating it as a hard error makes
+    // `mx codex archive --all` (and the `--archive-first` export hop
+    // that wraps it) blow up on first run. Instead, we treat "no
+    // projects dir" as "no sessions to archive", warn on stderr so the
+    // operator knows nothing was scanned, and return an empty summary.
     if !projects_dir.exists() {
-        anyhow::bail!("Claude projects directory not found");
+        eprintln!(
+            "note: no Claude projects found at {}; nothing to archive",
+            projects_dir.display()
+        );
+        return Ok(ArchiveResult::default());
     }
 
     let codex_dir = get_codex_dir()?;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -278,7 +278,17 @@ pub fn claude_dir() -> PathBuf {
 }
 
 /// `~/.claude/projects/` -- read-only by convention.
+///
+/// Honors the `MX_CLAUDE_PROJECTS_DIR` environment variable as an
+/// override. Tests set this to a controlled tempdir so they don't
+/// depend on the developer's (or CI machine's) live `~/.claude/`
+/// state. Production paths reach this through the same surface, so
+/// the override is opt-in via env var only — no behavior change for
+/// real users.
 pub fn claude_projects_dir() -> PathBuf {
+    if let Ok(override_dir) = std::env::var("MX_CLAUDE_PROJECTS_DIR") {
+        return PathBuf::from(override_dir);
+    }
     claude_dir().join("projects")
 }
 
@@ -374,9 +384,14 @@ pub fn wonka_vault_archives_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     // Tests call the `_with` variants directly with explicit parameters,
     // avoiding any env-var mutation and running safely in parallel.
+    // The handful of tests that DO observe `claude_projects_dir()`'s env
+    // override (`MX_CLAUDE_PROJECTS_DIR`) are marked `#[serial]` so they
+    // can clear the env without racing concurrent codex tests that set
+    // the override to a tempdir.
 
     #[test]
     fn mx_home_default_when_unset() {
@@ -571,10 +586,25 @@ mod tests {
     // ---------------------------------------------------------------------
 
     #[test]
+    #[serial]
     fn claude_paths_under_home() {
+        // `claude_projects_dir()` reads `MX_CLAUDE_PROJECTS_DIR` for
+        // hermetic test overrides; clear it here so we observe the
+        // real default.
+        let prev = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        // SAFETY: process-wide env mutation, serialized via #[serial]
+        // so concurrent codex tests don't race on the override.
+        unsafe {
+            std::env::remove_var("MX_CLAUDE_PROJECTS_DIR");
+        }
         let home = dirs::home_dir().unwrap();
         assert_eq!(claude_projects_dir(), home.join(".claude").join("projects"));
         assert_eq!(claude_config_path(), home.join(".claude.json"));
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v);
+            }
+        }
     }
 
     #[test]
@@ -584,7 +614,16 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn claude_subagents_dir_layout() {
+        // Calls `claude_projects_dir()` transitively, which reads
+        // `MX_CLAUDE_PROJECTS_DIR`; clear it for the default-case
+        // assertion here.
+        let prev = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
+        // SAFETY: process-wide env mutation, serialized via #[serial].
+        unsafe {
+            std::env::remove_var("MX_CLAUDE_PROJECTS_DIR");
+        }
         let home = dirs::home_dir().unwrap();
         let p = claude_subagents_dir("-home-charlie-recipes-coryzibell-mx", "abc-123");
         let expected = home
@@ -594,6 +633,11 @@ mod tests {
             .join("abc-123")
             .join("subagents");
         assert_eq!(p, expected);
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## HOTFIX

CI on `main` has been failing since PR #267 merged. This PR stops the bleeding.

Each individual PR (#267-272) passed PR-level CI, but post-merge CI on main exposed:

1. **Windows compile failures** — un-gated `Permissions::set_mode()` in PR 5's S3 fix test
2. **macOS+Ubuntu test failure** — `export_archive_first_skips_warning` panicked because `archive::run(All)` errored on missing `~/.claude/projects/` (CI machines never ran Claude)

**Failing CI run for reference:** https://github.com/coryzibell/mx/actions/runs/25184704339 (commit `1343d84`)

## Two fixes

### Commit `a6a97ca` — `cfg(unix)` gates

`#[cfg(unix)]` gate on the `chmod 000` test + helper in `backfill.rs`. The third unix call site (`make_symlink` in `index/mod.rs:825`) was already correctly gated.

Verified: `rg "set_mode|PermissionsExt|std::os::unix" src/` returns only sites inside `cfg(unix)` blocks.

### Commit `4fa85e1` — graceful missing claude projects dir

Twofold fix:

- `save_all_sessions` (`archive/write.rs:548`) replaced its hard `anyhow::bail!` on missing projects dir with stderr warning + `ArchiveResult::default()`. Fresh users (and CI) now get a graceful no-op instead of a crash.
- `paths::claude_projects_dir()` was IGNORING the `MX_CLAUDE_PROJECTS_DIR` env override — meaning every test that "set" the override was actually walking the developer's real `~/.claude/projects/`. The override is now respected. PR 3's `MX_CLAUDE_PROJECTS_DIR` design always intended this; the wiring was incomplete. **This is the hidden bug behind the CI failure.**
- Two `paths.rs` tests (`claude_paths_under_home`, `claude_subagents_dir_layout`) marked `#[serial]` with env clear/restore to avoid racing with codex tests that set the override.

## Files affected

- `src/codex/archive/backfill.rs` — `cfg(unix)` gates
- `src/codex/archive/write.rs` — graceful no-op on missing projects dir
- `src/paths.rs` — env override wired in; serial-test guards on existing tests

3 files, +67/-1 net.

## Test plan

- [x] `cargo build` clean (Linux verified; Windows compile previously failed at the unix gate, expected to pass now)
- [x] `cargo test`: 668 passed / 0 failed / 3 ignored (+4 from PR 5's 667 baseline; net of new test functions across the unification series)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `rg "set_mode|PermissionsExt|std::os::unix" src/` confirms all references are inside `cfg(unix)` blocks

## Notable

The `MX_CLAUDE_PROJECTS_DIR` env override was a dormant bug — the unification series' tests passed locally because the developer's `~/.claude/projects/` happened to exist, not because the override worked. This is exactly the kind of "test passes for the wrong reason" trap captured in `kn-2e2c5c85` from PR #268.

## Out of scope

- Does NOT alter PRs #267-272's architecture or design
- Does NOT touch the `surreal_db::tests::test_open_with_path` flake (10+ shifts; tracked separately at issue #274)