### PR TITLE
fix(ci): cfg(unix) gate symlink + tmp-path tests on Windows (CI hotfix 2)

### DIFF
--- a/src/codex/export/detect.rs
+++ b/src/codex/export/detect.rs
@@ -487,6 +487,11 @@ mod tests {
 
     #[test]
     #[serial]
+    #[cfg(unix)]
+    // Windows: count_in_tmp_root is cfg(unix)-gated (returns 0); the
+    // override path is exercised only on unix. Tool-output capture is
+    // a unix-only feature in v1 because /tmp/claude-<uid> has no
+    // stable Windows analogue.
     fn detect_counts_unarchived_tool_outputs_via_override() {
         // Exercise the env-var override path: a fixture /tmp tree with
         // two sessions, one of which IS in the codex. Expect a count of

--- a/src/codex/index/mod.rs
+++ b/src/codex/index/mod.rs
@@ -1038,6 +1038,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    // Windows: by-project index uses relative symlinks; production
+    // make_symlink is cfg(unix)-gated, so this scenario is unix-only.
     fn rebuild_populated_codex_creates_symlinks() {
         let tmp = tempfile::tempdir().unwrap();
         let codex = tmp.path();
@@ -1135,6 +1138,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    // Windows: rollback exercises the symlinked by-project tree, which
+    // is unix-only (see make_symlink).
     fn rebuild_rolls_back_on_swap_failure() {
         // If the staging->by-project rename fails, the previous index
         // must be restored. We force the failure by pre-creating a
@@ -1338,6 +1344,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    // Windows: cache-from-existing-index requires the symlinked
+    // by-project tree, which is unix-only.
     fn open_populates_cache_from_existing_index() {
         // S2: after a rebuild leaves a fresh by-project/ tree on disk,
         // a *new* ProjectIndex opened against the same codex must see


### PR DESCRIPTION
**HOTFIX 2.** PR #275 cleared the Windows compile errors and the macOS/Ubuntu test failure. Re-running CI on the hotfix merge surfaced four Windows runtime test failures that the first hotfix didn't catch. This PR gates them.

**Failing CI run:** https://github.com/coryzibell/mx/actions/runs/25186770073

## Tests gated (all with `#[cfg(unix)]`)

- `codex::index::tests::rebuild_populated_codex_creates_symlinks` — calls `fs::read_link`; symlinks unavailable on Windows
- `codex::index::tests::rebuild_rolls_back_on_swap_failure` — exercises rollback of symlinked by-project tree
- `codex::index::tests::open_populates_cache_from_existing_index` — cache populates by reading symlinks
- `codex::export::detect::tests::detect_counts_unarchived_tool_outputs_via_override` — `count_in_tmp_root` is itself `#[cfg(unix)]`-gated and returns 0 on Windows, so the override path is unreachable; gating the test matches the production gate

## Why option (a) for all four

The by-project index is symlink-based and intentionally `cfg(unix)`-only in production. The /tmp tool-output capture has the same gate. Tests that exercise these unix-only features should match.

## Sweep audit

`rg "fs::symlink|read_link|symlink_metadata|os::unix::fs::symlink|getuid|/tmp/claude"` across `src/` showed all unix-only test symlink usage is in the four tests gated here. `paths::tests::tmp_claude_tasks_dir_layout` builds a `/tmp/...` PathBuf on both sides of the assertion — platform-portable.

## Files affected

- `src/codex/export/detect.rs` (+5)
- `src/codex/index/mod.rs` (+9)
- 14 lines added; zero deletions

## Test plan

- `cargo build` clean
- `cargo test` 667 pass / 1 known flake (surreal_db::tests::test_open_with_path, 10th shift, issue #274) / 3 ignored
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- The four gated tests still run AND pass on Linux; they skip on Windows per the gate

## Out of scope

Same as PR #275 — does not alter PRs #267-272 architecture.