### PR TITLE
fix(test): clear MX_CLAUDE_PROJECTS_DIR in dir_missing test

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -549,10 +549,12 @@ mod tests {
 
         let prev_home = std::env::var("HOME").ok();
         let prev_mx_home = std::env::var("MX_HOME").ok();
+        let prev_proj = std::env::var("MX_CLAUDE_PROJECTS_DIR").ok();
         // SAFETY: serial + lock.
         unsafe {
             std::env::set_var("HOME", &nonexistent);
             std::env::remove_var("MX_HOME");
+            std::env::remove_var("MX_CLAUDE_PROJECTS_DIR");
         }
         let result = find_most_recent_session();
         unsafe {
@@ -562,6 +564,10 @@ mod tests {
             }
             if let Some(v) = prev_mx_home {
                 std::env::set_var("MX_HOME", v);
+            }
+            match prev_proj {
+                Some(v) => std::env::set_var("MX_CLAUDE_PROJECTS_DIR", v),
+                None => std::env::remove_var("MX_CLAUDE_PROJECTS_DIR"),
             }
         }
         assert!(result.is_err(), "missing projects dir must error");


### PR DESCRIPTION
Closes #276

## Summary

Clears `MX_CLAUDE_PROJECTS_DIR` at test start and restores it at end, mirroring the existing capture/clear/restore pattern for `HOME` and `MX_HOME`. Defense-in-depth against env leakage after PR #275 wired the override into `paths::claude_projects_dir()`.

## Files affected

- `src/session.rs`