### PR TITLE
feat(commit): add --dry-run flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,12 @@ pub enum Commands {
         /// Default output is just the footer line and `Committed.`
         #[arg(long, conflicts_with = "encode_only", conflicts_with_all = ["title", "body"])]
         show_encoded: bool,
+
+        /// Preview what would be committed without mutating git state.
+        /// Runs all encoding/validation logic but skips git commit and push.
+        /// Output is prefixed with `[dry-run]`.
+        #[arg(long, conflicts_with = "encode_only", conflicts_with_all = ["title", "body"])]
+        dry_run: bool,
     },
 
     /// Pull request operations

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -479,6 +479,19 @@ pub fn format_encoded_commit(encoded: &EncodedCommit, show_encoded: bool) -> Str
     out
 }
 
+/// Prefix every line of `output` with `[dry-run] `.
+///
+/// Useful for marking preview output so it is never mistaken for a real
+/// commit log. Extracted as a standalone helper so it can be unit-tested
+/// without git state.
+pub fn prefix_dry_run(output: &str) -> String {
+    output
+        .lines()
+        .map(|line| format!("[dry-run] {}", line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Perform the full upload commit.
 ///
 /// `show_encoded` controls stdout verbosity:
@@ -499,14 +512,17 @@ pub fn upload_commit(
     show_encoded: bool,
     dry_run: bool,
 ) -> Result<()> {
-    // Stage if requested (real staging even in dry-run so we can validate
-    // the diff — `git add -A` is idempotent and non-destructive)
-    if stage_all_flag {
+    // Stage if requested — but never under dry-run: mutating the index
+    // violates the dry-run contract.
+    if stage_all_flag && !dry_run {
         stage_all()?;
     }
 
     // Check for staged changes
     if !has_staged_changes()? {
+        if dry_run {
+            bail!("[dry-run] No staged changes to commit");
+        }
         bail!("No staged changes to commit");
     }
 
@@ -517,15 +533,13 @@ pub fn upload_commit(
     let encoded = encode_commit(&diff, message)?;
 
     if dry_run {
-        // Prefix every output line with [dry-run]
         let formatted = format_encoded_commit(&encoded, show_encoded);
-        for line in formatted.lines() {
-            println!("[dry-run] {}", line);
-        }
-        println!("[dry-run] Would commit.");
+        let mut preview = formatted;
+        preview.push_str("\nWould commit.");
         if push {
-            println!("[dry-run] Would push.");
+            preview.push_str("\nWould push.");
         }
+        println!("{}", prefix_dry_run(&preview));
         return Ok(());
     }
 
@@ -891,5 +905,93 @@ mod tests {
         assert!(!is_known_compress_algo("notreal"));
         assert!(!is_known_compress_algo(""));
         assert!(!is_known_compress_algo("anything"));
+    }
+
+    // --- prefix_dry_run ---
+
+    #[test]
+    fn test_prefix_dry_run_single_line() {
+        let out = prefix_dry_run("Footer: [sha384:base62|lzma:uuencode]");
+        assert_eq!(out, "[dry-run] Footer: [sha384:base62|lzma:uuencode]");
+    }
+
+    #[test]
+    fn test_prefix_dry_run_multi_line() {
+        let input = "Title:  TTTT\nBody:   BBBB\nFooter: [x:y|z:w]";
+        let out = prefix_dry_run(input);
+        for line in out.lines() {
+            assert!(
+                line.starts_with("[dry-run] "),
+                "every line must start with [dry-run] prefix -- got {:?}",
+                line,
+            );
+        }
+        assert_eq!(out.lines().count(), 3);
+    }
+
+    #[test]
+    fn test_prefix_dry_run_empty_input() {
+        // An empty string has zero lines, so the prefixed result is also empty.
+        let out = prefix_dry_run("");
+        assert_eq!(out, "");
+    }
+
+    // --- dry-run formatted output ---
+
+    #[test]
+    fn test_dry_run_output_format_default() {
+        // Simulate what upload_commit builds for dry-run (default mode):
+        // format_encoded_commit + status lines, then prefix_dry_run.
+        let encoded = sample_encoded_no_dejavu();
+        let formatted = format_encoded_commit(&encoded, false);
+        let mut preview = formatted;
+        preview.push_str("\nWould commit.");
+        let prefixed = prefix_dry_run(&preview);
+
+        let lines: Vec<&str> = prefixed.lines().collect();
+        // Should have: footer line + "Would commit."
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with("[dry-run] Footer:"));
+        assert_eq!(lines[1], "[dry-run] Would commit.");
+    }
+
+    #[test]
+    fn test_dry_run_output_format_with_push() {
+        let encoded = sample_encoded_no_dejavu();
+        let formatted = format_encoded_commit(&encoded, false);
+        let mut preview = formatted;
+        preview.push_str("\nWould commit.");
+        preview.push_str("\nWould push.");
+        let prefixed = prefix_dry_run(&preview);
+
+        let lines: Vec<&str> = prefixed.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("[dry-run] Footer:"));
+        assert_eq!(lines[1], "[dry-run] Would commit.");
+        assert_eq!(lines[2], "[dry-run] Would push.");
+    }
+
+    #[test]
+    fn test_dry_run_output_format_verbose() {
+        // With show_encoded == true, more lines appear before the status.
+        let encoded = sample_encoded_with_dejavu();
+        let formatted = format_encoded_commit(&encoded, true);
+        let mut preview = formatted;
+        preview.push_str("\nWould commit.");
+        let prefixed = prefix_dry_run(&preview);
+
+        for line in prefixed.lines() {
+            assert!(
+                line.starts_with("[dry-run] "),
+                "every line must have [dry-run] prefix -- got {:?}",
+                line,
+            );
+        }
+        // Title, Body, Dejavu, Footer (with dejavu marker on same footer value),
+        // Would commit.
+        assert!(prefixed.contains("[dry-run] Title:  TTTT-title-glyphs"));
+        assert!(prefixed.contains("[dry-run] Body:   BBBB-body-glyphs"));
+        assert!(prefixed.contains("[dry-run] Dejavu: true (both used base62)"));
+        assert!(prefixed.contains("[dry-run] Would commit."));
     }
 }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -486,13 +486,21 @@ pub fn format_encoded_commit(encoded: &EncodedCommit, show_encoded: bool) -> Str
 ///   (plus `Pushed.` if `push` is set).
 /// - `true`: prints the full `Title:` / `Body:` / `Dejavu:` / `Footer:`
 ///   block — historical behavior, opt-in via `mx commit --show-encoded`.
+///
+/// `dry_run` runs all encoding/validation logic but skips the actual git
+/// operations (commit, push). Output is prefixed with `[dry-run]` so it
+/// is never mistaken for a real commit log. Exits 0 on success, nonzero
+/// if the real commit would have failed (no staged changes, encoding
+/// error, etc.).
 pub fn upload_commit(
     message: &str,
     stage_all_flag: bool,
     push: bool,
     show_encoded: bool,
+    dry_run: bool,
 ) -> Result<()> {
-    // Stage if requested
+    // Stage if requested (real staging even in dry-run so we can validate
+    // the diff — `git add -A` is idempotent and non-destructive)
     if stage_all_flag {
         stage_all()?;
     }
@@ -507,6 +515,19 @@ pub fn upload_commit(
 
     // Encode with retry: title from diff hash, body from compressed message
     let encoded = encode_commit(&diff, message)?;
+
+    if dry_run {
+        // Prefix every output line with [dry-run]
+        let formatted = format_encoded_commit(&encoded, show_encoded);
+        for line in formatted.lines() {
+            println!("[dry-run] {}", line);
+        }
+        println!("[dry-run] Would commit.");
+        if push {
+            println!("[dry-run] Would push.");
+        }
+        return Ok(());
+    }
 
     println!("{}", format_encoded_commit(&encoded, show_encoded));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ fn main() -> Result<()> {
             title,
             body,
             show_encoded,
+            dry_run,
         } => {
             if encode_only {
                 // PR-style encoding: encode title and body, print to stdout.
@@ -62,7 +63,7 @@ fn main() -> Result<()> {
                 // Normal commit workflow
                 let msg =
                     message.ok_or_else(|| anyhow::anyhow!("message is required for commit"))?;
-                commit::upload_commit(&msg, all, push, show_encoded)?;
+                commit::upload_commit(&msg, all, push, show_encoded, dry_run)?;
             }
             Ok(())
         }


### PR DESCRIPTION
Closes #201

## Summary

Adds a `--dry-run` flag to `mx commit` that runs all encoding and validation logic but skips the actual `git commit` and `git push`. Output is prefixed with `[dry-run]`. Exits 0 on success, nonzero if the commit would have failed. Conflicts with `--encode-only`. Compatible with `--show-encoded`, `-a`, and `-p`.

## Motivation

Prevents accidental commits when testing CLI behavior — a near-miss during the PR #200 review highlighted the need for a safe way to exercise the full commit pipeline without mutating git state.

## Files changed

- `src/cli.rs` — adds `--dry-run` flag definition and conflict with `--encode-only`
- `src/commit.rs` — dry-run gate around git commit/push, `[dry-run]` output prefix
- `src/main.rs` — threads the dry-run flag through to the commit handler