### PR TITLE
Rename mx codex save → mx codex archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ GitHub.sublime-settings
 # Logs
 *.log
 
+# Claude Code
+.claude/worktrees/
+
 # Environment
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ Archives Claude session JSONL files to permanent storage with transcripts, extra
 
 ```bash
 # Archive the current session
-mx codex save
+mx codex archive
 
 # Archive with clean markdown transcript only (no raw JSONL)
-mx codex save --clean
+mx codex archive --clean
 
 # Archive all unarchived sessions
-mx codex save --all
+mx codex archive --all
 
 # List archived sessions
 mx codex list

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -118,7 +118,7 @@ The knowledge graph backend and its inputs.
 
 ### `codex/`
 
-Session archives written by `mx codex save` -- transcripts, extracted images,
+Session archives written by `mx codex archive` -- transcripts, extracted images,
 and per-archive manifests. Override with [`MX_CODEX_PATH`](#env-paths). This is
 typically the largest directory in `~/.mx/`; point it at a roomier disk if you
 archive a lot of sessions.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1190,97 +1190,79 @@ pub enum SessionCommands {
     },
 }
 
+/// Shared fields for `mx codex archive` and its deprecated `save` alias.
+/// Extracted so both CLI variants use the same definition and neither can
+/// drift out of sync with the other.
+#[derive(Debug, Clone, clap::Args)]
+pub struct ArchiveArgs {
+    /// Path to session JSONL file (defaults to most recent non-agent session)
+    #[arg(conflicts_with_all = ["all", "backfill"])]
+    pub path: Option<String>,
+
+    /// Archive all unarchived sessions
+    #[arg(long, conflicts_with_all = ["backfill"])]
+    pub all: bool,
+
+    /// Save only conversation.md + manifest.json + images (no JSONL, no agent files)
+    #[arg(long)]
+    pub clean: bool,
+
+    /// Include agent sub-session conversations in clean transcript.
+    ///
+    /// Requires `subagents` in `--include` (the default; if you pass
+    /// `--include none` or any value without `subagents`, this flag
+    /// will error at parse time rather than silently no-op).
+    #[arg(long, requires = "clean")]
+    pub include_agents: bool,
+
+    /// Comma-separated list of optional source artifacts to capture.
+    ///
+    /// Recognized: `subagents`, `mcp`, `tool-output`, `history`, `all`,
+    /// `none`. Today's default behavior corresponds to `--include
+    /// subagents`. The other tokens enable forthcoming source walkers
+    /// (MCP server logs, /tmp tool outputs, history.jsonl slice).
+    ///
+    /// Note: this flag governs which source files are *captured* into
+    /// the archive sidecars. The separate `--include-agents` flag
+    /// controls whether subagent transcripts are folded into the
+    /// `conversation.md` rendering when `--clean` is set.
+    #[arg(long, default_value = "subagents")]
+    pub include: String,
+
+    /// Ingest the legacy wonka vault snapshots into the codex.
+    ///
+    /// Walks every `session-*` snapshot under the supplied path
+    /// (defaults to `~/.wonka/vault/archives/`) and feeds each
+    /// session JSONL through the regular archive pipeline.
+    /// Idempotent: re-running on the same vault produces the same
+    /// codex state.
+    ///
+    /// Mutually exclusive with `--all` and the positional `[PATH]`.
+    /// `--include` and `--clean` still apply (they govern what the
+    /// per-session pipeline captures).
+    #[arg(
+        long,
+        value_name = "VAULT_PATH",
+        num_args = 0..=1,
+        default_missing_value = "",
+        conflicts_with_all = ["all", "path"],
+    )]
+    pub backfill: Option<String>,
+}
+
 #[derive(Subcommand)]
 pub enum CodexCommands {
     /// Archive current session to permanent storage
     Archive {
-        /// Path to session JSONL file (defaults to most recent non-agent session)
-        #[arg(conflicts_with_all = ["all", "backfill"])]
-        path: Option<String>,
-
-        /// Archive all unarchived sessions
-        #[arg(long, conflicts_with_all = ["backfill"])]
-        all: bool,
-
-        /// Save only conversation.md + manifest.json + images (no JSONL, no agent files)
-        #[arg(long)]
-        clean: bool,
-
-        /// Include agent sub-session conversations in clean transcript.
-        ///
-        /// Requires `subagents` in `--include` (the default; if you pass
-        /// `--include none` or any value without `subagents`, this flag
-        /// will error at parse time rather than silently no-op).
-        #[arg(long, requires = "clean")]
-        include_agents: bool,
-
-        /// Comma-separated list of optional source artifacts to capture.
-        ///
-        /// Recognized: `subagents`, `mcp`, `tool-output`, `history`, `all`,
-        /// `none`. Today's default behavior corresponds to `--include
-        /// subagents`. The other tokens enable forthcoming source walkers
-        /// (MCP server logs, /tmp tool outputs, history.jsonl slice).
-        ///
-        /// Note: this flag governs which source files are *captured* into
-        /// the archive sidecars. The separate `--include-agents` flag
-        /// controls whether subagent transcripts are folded into the
-        /// `conversation.md` rendering when `--clean` is set.
-        #[arg(long, default_value = "subagents")]
-        include: String,
-
-        /// Ingest the legacy wonka vault snapshots into the codex.
-        ///
-        /// Walks every `session-*` snapshot under the supplied path
-        /// (defaults to `~/.wonka/vault/archives/`) and feeds each
-        /// session JSONL through the regular archive pipeline.
-        /// Idempotent: re-running on the same vault produces the same
-        /// codex state.
-        ///
-        /// Mutually exclusive with `--all` and the positional `[PATH]`.
-        /// `--include` and `--clean` still apply (they govern what the
-        /// per-session pipeline captures).
-        #[arg(
-            long,
-            value_name = "VAULT_PATH",
-            num_args = 0..=1,
-            default_missing_value = "",
-            conflicts_with_all = ["all", "path"],
-        )]
-        backfill: Option<String>,
+        #[command(flatten)]
+        args: ArchiveArgs,
     },
 
     /// Deprecated alias for `mx codex archive`. Use `archive` instead.
     #[command(hide = true)]
     Save {
-        /// Path to session JSONL file (defaults to most recent non-agent session)
-        #[arg(conflicts_with_all = ["all", "backfill"])]
-        path: Option<String>,
-
-        /// Archive all unarchived sessions
-        #[arg(long, conflicts_with_all = ["backfill"])]
-        all: bool,
-
-        /// Save only conversation.md + manifest.json + images (no JSONL, no agent files)
-        #[arg(long)]
-        clean: bool,
-
-        /// Include agent sub-session conversations in clean transcript.
-        #[arg(long, requires = "clean")]
-        include_agents: bool,
-
-        /// Comma-separated list of optional source artifacts to capture.
-        #[arg(long, default_value = "subagents")]
-        include: String,
-
-        /// Ingest the legacy wonka vault snapshots into the codex.
-        #[arg(
-            long,
-            value_name = "VAULT_PATH",
-            num_args = 0..=1,
-            default_missing_value = "",
-            conflicts_with_all = ["all", "path"],
-        )]
-        backfill: Option<String>,
+        #[command(flatten)]
+        args: ArchiveArgs,
     },
 
     /// Export an archived session as Markdown or structured JSON.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1193,7 +1193,7 @@ pub enum SessionCommands {
 #[derive(Subcommand)]
 pub enum CodexCommands {
     /// Archive current session to permanent storage
-    Save {
+    Archive {
         /// Path to session JSONL file (defaults to most recent non-agent session)
         #[arg(conflicts_with_all = ["all", "backfill"])]
         path: Option<String>,
@@ -1249,6 +1249,40 @@ pub enum CodexCommands {
         backfill: Option<String>,
     },
 
+    /// Deprecated alias for `mx codex archive`. Use `archive` instead.
+    #[command(hide = true)]
+    Save {
+        /// Path to session JSONL file (defaults to most recent non-agent session)
+        #[arg(conflicts_with_all = ["all", "backfill"])]
+        path: Option<String>,
+
+        /// Archive all unarchived sessions
+        #[arg(long, conflicts_with_all = ["backfill"])]
+        all: bool,
+
+        /// Save only conversation.md + manifest.json + images (no JSONL, no agent files)
+        #[arg(long)]
+        clean: bool,
+
+        /// Include agent sub-session conversations in clean transcript.
+        #[arg(long, requires = "clean")]
+        include_agents: bool,
+
+        /// Comma-separated list of optional source artifacts to capture.
+        #[arg(long, default_value = "subagents")]
+        include: String,
+
+        /// Ingest the legacy wonka vault snapshots into the codex.
+        #[arg(
+            long,
+            value_name = "VAULT_PATH",
+            num_args = 0..=1,
+            default_missing_value = "",
+            conflicts_with_all = ["all", "path"],
+        )]
+        backfill: Option<String>,
+    },
+
     /// Export an archived session as Markdown or structured JSON.
     ///
     /// The default with no flags is "the most recent codex session, as
@@ -1287,7 +1321,7 @@ pub enum CodexCommands {
         #[arg(long, default_value = "subagents")]
         include: String,
 
-        /// Run `mx codex save --all` before exporting and skip the
+        /// Run `mx codex archive --all` before exporting and skip the
         /// unarchived-data warning. Useful when you know live
         /// `~/.claude/projects/` data hasn't been ingested yet.
         #[arg(long)]

--- a/src/codex/archive/include.rs
+++ b/src/codex/archive/include.rs
@@ -1,4 +1,4 @@
-//! Opt-in source selection for `mx codex save`.
+//! Opt-in source selection for `mx codex archive`.
 //!
 //! `IncludeSet` controls which optional sidecars the writer captures.
 //! Today only `subagents` is on by default — the same artifact the
@@ -28,7 +28,7 @@ pub struct IncludeSet {
 }
 
 impl IncludeSet {
-    /// The set that reproduces today's `mx codex save` defaults
+    /// The set that reproduces today's `mx codex archive` defaults
     /// byte-for-byte: subagents on, everything else off.
     pub fn status_quo() -> Self {
         Self {

--- a/src/codex/archive/mod.rs
+++ b/src/codex/archive/mod.rs
@@ -18,7 +18,7 @@
 //! `archive::run` is the one canonical entry point. The historical
 //! `save_session` is a thin wrapper that builds an `ArchiveRequest` from
 //! CLI args and calls `run`. Status-quo invocations
-//! (`mx codex save` with no `--include`) produce byte-identical
+//! (`mx codex archive` with no `--include`) produce byte-identical
 //! output to the pre-PR-2 implementation.
 
 use anyhow::Result;
@@ -92,7 +92,7 @@ pub struct ArchiveResult {
 /// to `request` and `options`, returns a summary.
 ///
 /// Behavior with `IncludeSet::status_quo()` and `clean = false` is
-/// byte-identical to the pre-PR-2 `mx codex save` flow.
+/// byte-identical to the pre-PR-2 `mx codex archive` flow.
 ///
 /// After a successful write, the by-project index
 /// (`<codex_dir>/by-project/`) is rebuilt so subsequent reads can find

--- a/src/codex/archive/mod.rs
+++ b/src/codex/archive/mod.rs
@@ -3,7 +3,7 @@
 //! Splits across several files (was a single `archive.rs` until the
 //! codex unification PR 2). Layout:
 //!
-//! - `mod.rs` — public entry points (`save_session`, `collect_archives`,
+//! - `mod.rs` — public entry points (`archive_session`, `collect_archives`,
 //!   `get_codex_dir`, `get_base_archive_name`), plus the
 //!   `ArchiveRequest` / `ArchiveResult` plumbing and `archive::run`.
 //! - `include.rs` — `IncludeSet`, the opt-in source selector parsed from
@@ -15,8 +15,8 @@
 //! - `paths.rs` — archive-folder naming utilities (`determine_archive_dir`,
 //!   `parse_archive_name`, `extract_short_id`, `get_base_archive_name`).
 //!
-//! `archive::run` is the one canonical entry point. The historical
-//! `save_session` is a thin wrapper that builds an `ArchiveRequest` from
+//! `archive::run` is the one canonical entry point.
+//! `archive_session` is a thin wrapper that builds an `ArchiveRequest` from
 //! CLI args and calls `run`. Status-quo invocations
 //! (`mx codex archive` with no `--include`) produce byte-identical
 //! output to the pre-PR-2 implementation.
@@ -150,9 +150,9 @@ fn rebuild_project_index() -> Result<()> {
     Ok(())
 }
 
-/// Backwards-compatible CLI shim. Builds an `ArchiveRequest` from the
-/// flat CLI args and delegates to `run`.
-pub(crate) fn save_session(
+/// CLI shim. Builds an `ArchiveRequest` from the flat CLI args and
+/// delegates to `run`.
+pub(crate) fn archive_session(
     session_path: Option<String>,
     all: bool,
     clean: bool,

--- a/src/codex/export/detect.rs
+++ b/src/codex/export/detect.rs
@@ -78,7 +78,7 @@ impl DetectionReport {
         };
         let mut msg = head;
         msg.push_str(
-            "\n       Run `mx codex save --all` to ingest, or rerun with --archive-first.",
+            "\n       Run `mx codex archive --all` to ingest, or rerun with --archive-first.",
         );
         if !self.sample_unarchived_uuids.is_empty() {
             msg.push_str("\n       Sample: ");
@@ -460,7 +460,7 @@ mod tests {
         );
         assert!(warn.contains("/tmp/"), "should mention /tmp source: {warn}");
         assert!(
-            warn.contains("mx codex save --all"),
+            warn.contains("mx codex archive --all"),
             "should keep the remediation hint: {warn}"
         );
         assert!(

--- a/src/codex/export/filter.rs
+++ b/src/codex/export/filter.rs
@@ -301,7 +301,7 @@ pub fn resolve_latest(archives: Vec<ResolvedArchive>) -> Result<ResolvedArchive>
     archives
         .into_iter()
         .max_by_key(|a| a.manifest.session_start)
-        .context("no archived sessions in codex (run `mx codex save --all`)")
+        .context("no archived sessions in codex (run `mx codex archive --all`)")
 }
 
 #[cfg(test)]

--- a/src/codex/export/mod.rs
+++ b/src/codex/export/mod.rs
@@ -34,7 +34,7 @@ pub struct ExportRequest {
     pub selector: Selector,
     pub format: Format,
     pub include: ExportIncludeSet,
-    /// If set, run `mx codex save --all` before exporting and skip
+    /// If set, run `mx codex archive --all` before exporting and skip
     /// the unarchived-data warning.
     pub archive_first: bool,
     /// Output file path. `None` means stdout for markdown / JSON.

--- a/src/codex/mod.rs
+++ b/src/codex/mod.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 // Re-export public API
-pub(crate) use archive::{IncludeSet, run_backfill, save_session};
+pub(crate) use archive::{IncludeSet, archive_session, run_backfill};
 pub(crate) use export::run as run_export;
 pub(crate) use export::{ExportIncludeSet, ExportRequest, Format, Selector};
 pub(crate) use migrate::migrate_archives;

--- a/src/codex/notices.rs
+++ b/src/codex/notices.rs
@@ -11,7 +11,7 @@ use std::sync::OnceLock;
 
 /// Emit the vault-present warning at most once per process. Idempotent
 /// across repeated calls — the `OnceLock` guarantees a single fire even
-/// if `mx codex save` and `mx codex export` both run in the same
+/// if `mx codex archive` and `mx codex export` both run in the same
 /// process.
 ///
 /// Skipped when:
@@ -35,7 +35,7 @@ pub(crate) fn warn_if_vault_present(suppress: bool) {
     }
     eprintln!(
         "note: {} contains historical session data not in the codex.\n      \
-         Run `mx codex save --backfill` to ingest, then remove the vault directory.",
+         Run `mx codex archive --backfill` to ingest, then remove the vault directory.",
         vault.display()
     );
     let _ = FIRED.set(());
@@ -101,16 +101,12 @@ mod tests {
         assert!(vault_has_snapshots(&vault));
     }
 
-    /// Regression guard: the warning must reference the actual CLI verb
-    /// (`mx codex save --backfill`), not the architecturally-aspirational
-    /// `mx codex archive --backfill`. C1 from PR 272 review — the
-    /// non-existent subcommand string had been shipping to every operator
-    /// with a vault. We capture stderr by firing the warning against a
-    /// fake vault and assert the literal `mx codex save --backfill`
-    /// appears in the message body. If the verb ever gets renamed,
-    /// update both the message and this test.
+    /// Regression guard: the warning must reference the canonical CLI verb
+    /// (`mx codex archive --backfill`). C1 from PR 272 review caught a
+    /// mismatch where the string said one thing and the CLI said another.
+    /// Now that the verb IS `archive`, we just assert consistency.
     #[test]
-    fn warning_text_uses_real_save_subcommand() {
+    fn warning_text_uses_archive_subcommand() {
         // Build a vault with one snapshot so the warning fires.
         let tmp = tempfile::tempdir().unwrap();
         let vault = tmp.path().join("real-vault");
@@ -119,35 +115,31 @@ mod tests {
 
         // Format the message exactly as `warn_if_vault_present` would.
         // We don't go through `warn_if_vault_present` itself because its
-        // `OnceLock` makes the test order-sensitive across the suite —
+        // `OnceLock` makes the test order-sensitive across the suite --
         // this is an equivalent literal-string assertion.
         let msg = format!(
             "note: {} contains historical session data not in the codex.\n      \
-             Run `mx codex save --backfill` to ingest, then remove the vault directory.",
+             Run `mx codex archive --backfill` to ingest, then remove the vault directory.",
             vault.display()
         );
         assert!(
-            msg.contains("mx codex save --backfill"),
-            "vault-warning string must reference `mx codex save --backfill`: {msg}"
+            msg.contains("mx codex archive --backfill"),
+            "vault-warning string must reference `mx codex archive --backfill`: {msg}"
         );
 
-        // Also assert the bug-fix invariant directly against the source
-        // line that produces the warning: `eprintln!` body should never
-        // contain the broken `mx codex archive --backfill` string. We
-        // grep just the `warn_if_vault_present` function body, not the
-        // test module (where the string legitimately appears in
-        // assertion messages).
+        // Assert the function body uses the canonical verb.
         let src = include_str!("notices.rs");
         let func_start = src.find("pub(crate) fn warn_if_vault_present").unwrap();
         let func_end = src[func_start..].find("\n}\n").unwrap() + func_start;
         let func_body = &src[func_start..func_end];
         assert!(
-            !func_body.contains("mx codex archive"),
-            "warn_if_vault_present must not emit `mx codex archive` (C1 regression)"
+            func_body.contains("mx codex archive --backfill"),
+            "warn_if_vault_present must emit `mx codex archive --backfill`"
         );
+        // The old verb should no longer appear in the function body.
         assert!(
-            func_body.contains("mx codex save --backfill"),
-            "warn_if_vault_present must emit `mx codex save --backfill` (C1)"
+            !func_body.contains("mx codex save"),
+            "warn_if_vault_present must not reference deprecated `mx codex save`"
         );
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -92,11 +92,15 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
     let suppress_vault_warning = matches!(
         cmd,
         CodexCommands::Archive {
-            backfill: Some(_),
-            ..
+            args: ArchiveArgs {
+                backfill: Some(_),
+                ..
+            },
         } | CodexCommands::Save {
-            backfill: Some(_),
-            ..
+            args: ArchiveArgs {
+                backfill: Some(_),
+                ..
+            },
         }
     );
     codex::notices::warn_if_vault_present(suppress_vault_warning);
@@ -104,27 +108,13 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
     match cmd {
         // Deprecated alias: print a one-shot notice and fall through to
         // the canonical Archive handler.
-        CodexCommands::Save {
-            path,
-            all,
-            clean,
-            include_agents,
-            include,
-            backfill,
-        } => {
+        CodexCommands::Save { args } => {
             eprintln!(
                 "note: `mx codex save` is deprecated; use `mx codex archive` instead."
             );
-            handle_codex_archive(path, all, clean, include_agents, include, backfill)
+            handle_codex_archive(args)
         }
-        CodexCommands::Archive {
-            path,
-            all,
-            clean,
-            include_agents,
-            include,
-            backfill,
-        } => handle_codex_archive(path, all, clean, include_agents, include, backfill),
+        CodexCommands::Archive { args } => handle_codex_archive(args),
         CodexCommands::Export {
             session,
             project,
@@ -177,15 +167,16 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
 /// Shared implementation for `mx codex archive` (and its deprecated
 /// `save` alias). Extracted so both CLI variants dispatch to the same
 /// handler without duplicating the business logic.
-#[allow(clippy::too_many_arguments)]
-fn handle_codex_archive(
-    path: Option<String>,
-    all: bool,
-    clean: bool,
-    include_agents: bool,
-    include: String,
-    backfill: Option<String>,
-) -> Result<()> {
+fn handle_codex_archive(args: ArchiveArgs) -> Result<()> {
+    let ArchiveArgs {
+        path,
+        all,
+        clean,
+        include_agents,
+        include,
+        backfill,
+    } = args;
+
     let include_set = codex::IncludeSet::parse(&include)?;
     // W3: --include-agents only does anything when subagents are
     // also being captured. Silently doing nothing was confusing
@@ -228,7 +219,7 @@ fn handle_codex_archive(
         return Ok(());
     }
 
-    codex::save_session(path, all, clean, include_agents, include_set)?;
+    codex::archive_session(path, all, clean, include_agents, include_set)?;
     Ok(())
 }
 
@@ -1059,12 +1050,14 @@ mod codex_archive_validation_tests {
 
     fn archive_cmd(include_agents: bool, include: &str) -> CodexCommands {
         CodexCommands::Archive {
-            path: None,
-            all: false,
-            clean: true,
-            include_agents,
-            include: include.to_string(),
-            backfill: None,
+            args: ArchiveArgs {
+                path: None,
+                all: false,
+                clean: true,
+                include_agents,
+                include: include.to_string(),
+                backfill: None,
+            },
         }
     }
 
@@ -1096,20 +1089,24 @@ mod codex_archive_validation_tests {
     #[test]
     fn save_alias_routes_to_same_handler_as_archive() {
         let archive_result = handle_codex(CodexCommands::Archive {
-            path: None,
-            all: false,
-            clean: true,
-            include_agents: true,
-            include: "none".to_string(),
-            backfill: None,
+            args: ArchiveArgs {
+                path: None,
+                all: false,
+                clean: true,
+                include_agents: true,
+                include: "none".to_string(),
+                backfill: None,
+            },
         });
         let save_result = handle_codex(CodexCommands::Save {
-            path: None,
-            all: false,
-            clean: true,
-            include_agents: true,
-            include: "none".to_string(),
-            backfill: None,
+            args: ArchiveArgs {
+                path: None,
+                all: false,
+                clean: true,
+                include_agents: true,
+                include: "none".to_string(),
+                backfill: None,
+            },
         });
 
         let archive_err = archive_result

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -86,12 +86,15 @@ pub(crate) fn handle_session(cmd: SessionCommands) -> Result<()> {
 
 pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
     // Suppress the vault nag for the one invocation that's already
-    // mid-fix: `mx codex save --backfill`. Every other handler emits
+    // mid-fix: `mx codex archive --backfill`. Every other handler emits
     // the warning at most once per process via the OnceLock guard
     // inside `warn_if_vault_present`.
     let suppress_vault_warning = matches!(
         cmd,
-        CodexCommands::Save {
+        CodexCommands::Archive {
+            backfill: Some(_),
+            ..
+        } | CodexCommands::Save {
             backfill: Some(_),
             ..
         }
@@ -99,6 +102,8 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
     codex::notices::warn_if_vault_present(suppress_vault_warning);
 
     match cmd {
+        // Deprecated alias: print a one-shot notice and fall through to
+        // the canonical Archive handler.
         CodexCommands::Save {
             path,
             all,
@@ -107,51 +112,19 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
             include,
             backfill,
         } => {
-            let include_set = codex::IncludeSet::parse(&include)?;
-            // W3: --include-agents only does anything when subagents are
-            // also being captured. Silently doing nothing was confusing
-            // — fail-loud so the operator can correct the invocation.
-            if include_agents && !include_set.subagents {
-                anyhow::bail!(
-                    "--include-agents requires `subagents` in --include (got --include='{}'). \
-                     Either drop --include-agents or add `subagents` to --include.",
-                    include
-                );
-            }
-
-            if let Some(vault_arg) = backfill {
-                // `--backfill` with no value parses as `Some("")` thanks
-                // to `default_missing_value`. Resolve to the canonical
-                // `~/.wonka/vault/archives/` in that case.
-                let vault_path = if vault_arg.is_empty() {
-                    crate::paths::wonka_vault_archives_dir()
-                } else {
-                    std::path::PathBuf::from(vault_arg)
-                };
-                let options = codex::archive::ArchiveOptions {
-                    clean,
-                    include: include_set,
-                    include_agents_in_clean_md: include_agents,
-                };
-                let report = codex::run_backfill(&vault_path, options)?;
-                // Echo a final terse summary on stdout (the running
-                // progress lines went to stderr); stdout is the
-                // machine-readable channel for chaining in scripts.
-                println!(
-                    "vault={} snapshots={} found={} archived={} skipped={} errors={}",
-                    report.vault_path.display(),
-                    report.vault_snapshots_walked,
-                    report.sessions_found,
-                    report.sessions_archived,
-                    report.sessions_skipped_already_archived,
-                    report.errors.len()
-                );
-                return Ok(());
-            }
-
-            codex::save_session(path, all, clean, include_agents, include_set)?;
-            Ok(())
+            eprintln!(
+                "note: `mx codex save` is deprecated; use `mx codex archive` instead."
+            );
+            handle_codex_archive(path, all, clean, include_agents, include, backfill)
         }
+        CodexCommands::Archive {
+            path,
+            all,
+            clean,
+            include_agents,
+            include,
+            backfill,
+        } => handle_codex_archive(path, all, clean, include_agents, include, backfill),
         CodexCommands::Export {
             session,
             project,
@@ -199,6 +172,64 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
             Ok(())
         }
     }
+}
+
+/// Shared implementation for `mx codex archive` (and its deprecated
+/// `save` alias). Extracted so both CLI variants dispatch to the same
+/// handler without duplicating the business logic.
+#[allow(clippy::too_many_arguments)]
+fn handle_codex_archive(
+    path: Option<String>,
+    all: bool,
+    clean: bool,
+    include_agents: bool,
+    include: String,
+    backfill: Option<String>,
+) -> Result<()> {
+    let include_set = codex::IncludeSet::parse(&include)?;
+    // W3: --include-agents only does anything when subagents are
+    // also being captured. Silently doing nothing was confusing
+    // -- fail-loud so the operator can correct the invocation.
+    if include_agents && !include_set.subagents {
+        anyhow::bail!(
+            "--include-agents requires `subagents` in --include (got --include='{}'). \
+             Either drop --include-agents or add `subagents` to --include.",
+            include
+        );
+    }
+
+    if let Some(vault_arg) = backfill {
+        // `--backfill` with no value parses as `Some("")` thanks
+        // to `default_missing_value`. Resolve to the canonical
+        // `~/.wonka/vault/archives/` in that case.
+        let vault_path = if vault_arg.is_empty() {
+            crate::paths::wonka_vault_archives_dir()
+        } else {
+            std::path::PathBuf::from(vault_arg)
+        };
+        let options = codex::archive::ArchiveOptions {
+            clean,
+            include: include_set,
+            include_agents_in_clean_md: include_agents,
+        };
+        let report = codex::run_backfill(&vault_path, options)?;
+        // Echo a final terse summary on stdout (the running
+        // progress lines went to stderr); stdout is the
+        // machine-readable channel for chaining in scripts.
+        println!(
+            "vault={} snapshots={} found={} archived={} skipped={} errors={}",
+            report.vault_path.display(),
+            report.vault_snapshots_walked,
+            report.sessions_found,
+            report.sessions_archived,
+            report.sessions_skipped_already_archived,
+            report.errors.len()
+        );
+        return Ok(());
+    }
+
+    codex::save_session(path, all, clean, include_agents, include_set)?;
+    Ok(())
 }
 
 /// Build an `ExportRequest` from the flat CLI args and dispatch to
@@ -1018,7 +1049,7 @@ mod try_decode_commit_body_tests {
 }
 
 #[cfg(test)]
-mod codex_save_validation_tests {
+mod codex_archive_validation_tests {
     //! W3 from Verdictia's PR #268 review: `--include-agents` without
     //! `subagents` in `--include` was a silent no-op. The handler now
     //! errors at the seam between CLI parsing and the codex writer; we
@@ -1026,8 +1057,8 @@ mod codex_save_validation_tests {
     use super::*;
     use crate::cli::CodexCommands;
 
-    fn save_cmd(include_agents: bool, include: &str) -> CodexCommands {
-        CodexCommands::Save {
+    fn archive_cmd(include_agents: bool, include: &str) -> CodexCommands {
+        CodexCommands::Archive {
             path: None,
             all: false,
             clean: true,
@@ -1039,7 +1070,7 @@ mod codex_save_validation_tests {
 
     #[test]
     fn include_agents_without_subagents_errors() {
-        let result = handle_codex(save_cmd(true, "none"));
+        let result = handle_codex(archive_cmd(true, "none"));
         let err = result.expect_err("--include-agents + --include none must error");
         let msg = format!("{err:#}");
         assert!(
@@ -1050,11 +1081,48 @@ mod codex_save_validation_tests {
 
     #[test]
     fn include_agents_without_subagents_token_errors_even_with_others() {
-        // `mcp` alone — no subagents in the set — also fails.
-        let result = handle_codex(save_cmd(true, "mcp,history"));
+        // `mcp` alone -- no subagents in the set -- also fails.
+        let result = handle_codex(archive_cmd(true, "mcp,history"));
         assert!(
             result.is_err(),
             "--include-agents + --include without subagents must error"
+        );
+    }
+
+    /// Regression guard: both `mx codex archive` and the deprecated
+    /// `mx codex save` must route through the same `handle_codex_archive`
+    /// helper. We verify by asserting that both produce the same error
+    /// for the same invalid input -- if they diverge, the alias is broken.
+    #[test]
+    fn save_alias_routes_to_same_handler_as_archive() {
+        let archive_result = handle_codex(CodexCommands::Archive {
+            path: None,
+            all: false,
+            clean: true,
+            include_agents: true,
+            include: "none".to_string(),
+            backfill: None,
+        });
+        let save_result = handle_codex(CodexCommands::Save {
+            path: None,
+            all: false,
+            clean: true,
+            include_agents: true,
+            include: "none".to_string(),
+            backfill: None,
+        });
+
+        let archive_err = archive_result
+            .expect_err("archive with invalid args must error")
+            .to_string();
+        let save_err = save_result
+            .expect_err("save with invalid args must error")
+            .to_string();
+
+        assert_eq!(
+            archive_err, save_err,
+            "save alias must produce the same error as archive: \
+             archive={archive_err:?}, save={save_err:?}"
         );
     }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -109,9 +109,7 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
         // Deprecated alias: print a one-shot notice and fall through to
         // the canonical Archive handler.
         CodexCommands::Save { args } => {
-            eprintln!(
-                "note: `mx codex save` is deprecated; use `mx codex archive` instead."
-            );
+            eprintln!("note: `mx codex save` is deprecated; use `mx codex archive` instead.");
             handle_codex_archive(args)
         }
         CodexCommands::Archive { args } => handle_codex_archive(args),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -365,7 +365,7 @@ pub fn tmp_claude_tasks_dir(uid: u32, user_slug: &str, session_uuid: &str) -> Pa
 
 /// `~/.wonka/vault/archives/` -- the legacy vault snapshot directory.
 ///
-/// Walked by `mx codex save --backfill` (PR 5) to ingest the existing
+/// Walked by `mx codex archive --backfill` (PR 5) to ingest the existing
 /// vault snapshots into the codex. Note the literal `~/.wonka/` prefix:
 /// the wonka vault is a *separate* root from `MX_HOME` and intentionally
 /// does not derive from it. If the user has a wonka home override in the

--- a/src/session.rs
+++ b/src/session.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 /// stderr from a child process.
 pub const DEPRECATION_NOTICE: &str = "\
 note: `mx session export` is deprecated; use `mx codex export` instead.
-      The new command reads from the codex (run `mx codex save` first
+      The new command reads from the codex (run `mx codex archive` first
       if needed; this alias does that for you), supports filtering by
       --session, --project, --date, multiple output formats, and inlines
       sub-agent transcripts by default. Run `mx codex export --help` for
@@ -48,7 +48,7 @@ note: the new command selects \"most recent\" by session start time, not
 /// - `output` flows through verbatim.
 /// - `archive_first: true` is forced. The legacy command read live
 ///   data; the new command reads codex. Without `--archive-first`, an
-///   operator who has never run `mx codex save` would get a "no
+///   operator who has never run `mx codex archive` would get a "no
 ///   codex data" error here. Forcing archive-first preserves the
 ///   user-visible "I just ran the command and it worked" semantics.
 /// - `format: Markdown` — the only output the legacy command emitted.
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn alias_forces_archive_first() {
         // Load-bearing: without this, a user who has never run
-        // `mx codex save` would get "no codex data" instead of the
+        // `mx codex archive` would get "no codex data" instead of the
         // legacy "exported your latest session" behavior.
         let req = build_alias_request(None, None).unwrap();
         assert!(req.archive_first, "alias must force archive_first=true");


### PR DESCRIPTION
## Summary

- Renamed the CLI verb from `mx codex save` to `mx codex archive` for consistency with the architecture doc (#254) and internal module paths
- Added a deprecation alias so `mx codex save` still works but prints a deprecation notice on stderr; the old verb is hidden from `--help`
- Renamed `save_session` to `archive_session` internally and extracted an `ArchiveArgs` struct to eliminate field duplication between the `Save` and `Archive` variants
- Added a regression test verifying both verbs route through the same handler

Closes #273

## Test plan

- [x] `cargo test` passes (676 green)
- [ ] Run `mx codex archive` and confirm it archives the session as expected
- [ ] Run `mx codex save` and confirm it prints the deprecation notice on stderr, then archives normally
- [ ] Run `mx codex --help` and confirm `save` is not listed