### PR TITLE
Docs-as-code system: Typst source, Pandoc build, GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,44 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/src/**'
+      - 'docs/build/**'
+      - 'docs/build.sh'
+      - '.github/workflows/deploy-docs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Pandoc
+        uses: pandoc/actions/setup@v1
+
+      - name: Build docs
+        run: bash docs/build.sh
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/out/html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 **/*.rs.bk
 *.pdb
 
+# Docs build output
+docs/out/
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mx docs build script
+# Converts Typst source files to HTML (site) and Markdown (LLM context).
+#
+# LOCAL PREVIEW: ruby -run -e httpd docs/out/html -p 8080
+
+DOCS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_DIR="$DOCS_DIR/src"
+BUILD_DIR="$DOCS_DIR/build"
+OUT_HTML="$DOCS_DIR/out/html"
+OUT_LLM="$DOCS_DIR/out/llm"
+
+TEMPLATE="$BUILD_DIR/template.html"
+STYLESHEET="$BUILD_DIR/style.css"
+ADMONITION_FILTER="$BUILD_DIR/admonition.lua"
+CROSSREF_FILTER="$BUILD_DIR/crossref.lua"
+
+# Ordered list for LLM output (getting-started first, architecture last)
+LLM_ORDER=(
+  getting-started index commit log memory codex kv state
+  sync pr github convert session wiki heartbeat
+  base-d paths architecture
+)
+
+# --- Setup ---
+
+mkdir -p "$OUT_HTML" "$OUT_LLM"
+cp "$STYLESHEET" "$OUT_HTML/style.css"
+
+# Temp dir for per-page metadata files (nested YAML keys needed for
+# Pandoc template conditionals — --metadata "a.b=true" doesn't nest)
+META_TMP="$(mktemp -d)"
+trap 'rm -rf "$META_TMP"' EXIT
+
+# --- HTML build ---
+
+count=0
+for src in "$SRC_DIR"/*.typ; do
+  name="$(basename "$src" .typ)"
+
+  # Skip lib.typ — it's a shared component file, not a page
+  [ "$name" = "lib" ] && continue
+
+  # Write a tiny YAML file so the template can test current-page.<name>
+  meta_file="$META_TMP/$name.yaml"
+  printf 'current-page:\n  %s: true\n' "$name" > "$meta_file"
+
+  pandoc "$src" \
+    -f typst \
+    -t html \
+    --standalone \
+    --mathml \
+    --toc \
+    --section-divs \
+    --template "$TEMPLATE" \
+    --css style.css \
+    --lua-filter "$ADMONITION_FILTER" \
+    --lua-filter "$CROSSREF_FILTER" \
+    --metadata-file "$meta_file" \
+    -o "$OUT_HTML/$name.html"
+
+  count=$((count + 1))
+done
+
+# --- LLM markdown build ---
+
+# Collect only the source files that exist, in the specified order
+llm_sources=()
+for name in "${LLM_ORDER[@]}"; do
+  src="$SRC_DIR/$name.typ"
+  [ -f "$src" ] && llm_sources+=("$src")
+done
+
+if [ ${#llm_sources[@]} -gt 0 ]; then
+  pandoc "${llm_sources[@]}" \
+    -f typst \
+    -t markdown \
+    --lua-filter "$ADMONITION_FILTER" \
+    --lua-filter "$CROSSREF_FILTER" \
+    -o "$OUT_LLM/mx-docs.md"
+fi
+
+# --- Summary ---
+
+echo "mx docs build complete"
+echo "  HTML: $count pages -> $OUT_HTML/"
+echo "  LLM:  $([ -f "$OUT_LLM/mx-docs.md" ] && echo "$OUT_LLM/mx-docs.md" || echo "(none)")"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -19,7 +19,7 @@ CROSSREF_FILTER="$BUILD_DIR/crossref.lua"
 
 # Ordered list for LLM output (getting-started first, architecture last)
 LLM_ORDER=(
-  getting-started index commit log memory codex kv state
+  index getting-started commit log memory codex kv state
   sync pr github convert session wiki heartbeat
   base-d paths architecture
 )
@@ -44,8 +44,10 @@ for src in "$SRC_DIR"/*.typ; do
   [ "$name" = "lib" ] && continue
 
   # Write a tiny YAML file so the template can test current-page.<name>
+  # Also derive a human-readable title from the filename for <title>.
   meta_file="$META_TMP/$name.yaml"
-  printf 'current-page:\n  %s: true\n' "$name" > "$meta_file"
+  page_title="$(echo "$name" | sed 's/-/ /g; s/\b\(.\)/\u\1/g')"
+  printf 'current-page:\n  %s: true\ntitle: "%s"\n' "$name" "$page_title" > "$meta_file"
 
   pandoc "$src" \
     -f typst \
@@ -79,6 +81,7 @@ if [ ${#llm_sources[@]} -gt 0 ]; then
     -t markdown \
     --lua-filter "$ADMONITION_FILTER" \
     --lua-filter "$CROSSREF_FILTER" \
+    --lua-filter "$BUILD_DIR/strip-links.lua" \
     -o "$OUT_LLM/mx-docs.md"
 fi
 

--- a/docs/build/admonition.lua
+++ b/docs/build/admonition.lua
@@ -4,46 +4,50 @@
 -- Instead, lib.typ admonitions render as a Para whose first inline
 -- is Strong containing "NOTE:" (or WARNING:, DEPRECATED:, TIP:).
 --
--- This filter wraps those paragraphs in a styled Div with appropriate
--- CSS classes for the site stylesheet.
+-- This filter operates at the Blocks level so that multi-paragraph
+-- admonitions are fully captured. When an admonition Para is found,
+-- all consecutive following Paras (that are not themselves admonitions)
+-- are collected into the same Div.
 
 local KINDS = {"NOTE", "WARNING", "DEPRECATED", "TIP"}
 
-function Para(el)
-  -- Check if first inline is a Strong element
-  if #el.content == 0 then return nil end
-  local first = el.content[1]
+-- Check if a Para block starts with a Strong element matching an
+-- admonition kind. Returns the kind string or nil.
+local function detect_admonition(block)
+  if block.t ~= "Para" then return nil end
+  if #block.content == 0 then return nil end
+  local first = block.content[1]
   if first == nil or first.t ~= "Strong" then return nil end
 
   local strong_text = pandoc.utils.stringify(first)
-
   for _, kind in ipairs(KINDS) do
     if strong_text == kind .. ":" then
-      -- Build the content: everything after the Strong and the
-      -- space that follows it
-      local inlines = pandoc.List()
-      local skip_space = true
-      for i = 2, #el.content do
-        if skip_space and el.content[i].t == "Space" then
-          skip_space = false
-        else
-          skip_space = false
-          inlines:insert(el.content[i])
-        end
-      end
-
-      -- Create the admonition div
-      local label = pandoc.Para({
-        pandoc.Strong({pandoc.Str(kind .. ":")}),
-        pandoc.Space(),
-        table.unpack(inlines)
-      })
-      return pandoc.Div(
-        {label},
-        pandoc.Attr("", {"admonition", kind:lower()})
-      )
+      return kind
     end
   end
-
   return nil
+end
+
+function Blocks(blocks)
+  local result = pandoc.List()
+  local i = 1
+  while i <= #blocks do
+    local block = blocks[i]
+    local kind = detect_admonition(block)
+    if kind then
+      -- Collect this para and all following non-admonition paras
+      local collected = pandoc.List({block})
+      local j = i + 1
+      while j <= #blocks and blocks[j].t == "Para" and not detect_admonition(blocks[j]) do
+        collected:insert(blocks[j])
+        j = j + 1
+      end
+      result:insert(pandoc.Div(collected, pandoc.Attr("", {"admonition", kind:lower()})))
+      i = j
+    else
+      result:insert(block)
+      i = i + 1
+    end
+  end
+  return result
 end

--- a/docs/build/admonition.lua
+++ b/docs/build/admonition.lua
@@ -1,0 +1,49 @@
+-- admonition.lua — Pandoc Lua filter for mx docs
+--
+-- Typst's block() function does not produce a Div in Pandoc's AST.
+-- Instead, lib.typ admonitions render as a Para whose first inline
+-- is Strong containing "NOTE:" (or WARNING:, DEPRECATED:, TIP:).
+--
+-- This filter wraps those paragraphs in a styled Div with appropriate
+-- CSS classes for the site stylesheet.
+
+local KINDS = {"NOTE", "WARNING", "DEPRECATED", "TIP"}
+
+function Para(el)
+  -- Check if first inline is a Strong element
+  if #el.content == 0 then return nil end
+  local first = el.content[1]
+  if first == nil or first.t ~= "Strong" then return nil end
+
+  local strong_text = pandoc.utils.stringify(first)
+
+  for _, kind in ipairs(KINDS) do
+    if strong_text == kind .. ":" then
+      -- Build the content: everything after the Strong and the
+      -- space that follows it
+      local inlines = pandoc.List()
+      local skip_space = true
+      for i = 2, #el.content do
+        if skip_space and el.content[i].t == "Space" then
+          skip_space = false
+        else
+          skip_space = false
+          inlines:insert(el.content[i])
+        end
+      end
+
+      -- Create the admonition div
+      local label = pandoc.Para({
+        pandoc.Strong({pandoc.Str(kind .. ":")}),
+        pandoc.Space(),
+        table.unpack(inlines)
+      })
+      return pandoc.Div(
+        {label},
+        pandoc.Attr("", {"admonition", kind:lower()})
+      )
+    end
+  end
+
+  return nil
+end

--- a/docs/build/crossref.lua
+++ b/docs/build/crossref.lua
@@ -3,6 +3,13 @@
 -- Fix cross-reference display text. When Pandoc produces links with
 -- bracket-wrapped display text like "[getting-started]", clean them
 -- up to human-readable form: "getting started".
+--
+-- STATUS: Forward-looking. Currently no Typst source pages use @label
+-- cross-references, so this filter is effectively inert. It does no
+-- harm in the pipeline and will activate automatically when future
+-- pages use Typst @label references, which Pandoc renders with
+-- bracket-wrapped display text. Kept in the build to avoid a gap
+-- when that day comes.
 
 function Link(el)
   local display = pandoc.utils.stringify(el.content)

--- a/docs/build/crossref.lua
+++ b/docs/build/crossref.lua
@@ -1,0 +1,14 @@
+-- crossref.lua — Pandoc Lua filter for mx docs
+--
+-- Fix cross-reference display text. When Pandoc produces links with
+-- bracket-wrapped display text like "[getting-started]", clean them
+-- up to human-readable form: "getting started".
+
+function Link(el)
+  local display = pandoc.utils.stringify(el.content)
+  if display:match("^%[.*%]$") then
+    local clean = display:sub(2, -2):gsub("-", " ")
+    el.content = {pandoc.Str(clean)}
+  end
+  return el
+end

--- a/docs/build/strip-links.lua
+++ b/docs/build/strip-links.lua
@@ -1,0 +1,9 @@
+-- strip-links.lua — Pandoc Lua filter for mx docs LLM output
+--
+-- Replaces hyperlinks with their display text. The LLM markdown
+-- output has no HTML pages to link to, so .html hrefs are meaningless.
+-- Stripping links keeps the prose readable without dead references.
+
+function Link(el)
+  return el.content
+end

--- a/docs/build/style.css
+++ b/docs/build/style.css
@@ -181,6 +181,7 @@ hr {
   margin: 0 auto;
   padding: 2em 2em 4em;
   flex: 1;
+  overflow-x: auto;
 }
 
 /* ----- Sidebar ----- */
@@ -401,12 +402,9 @@ th {
   font-weight: 600;
 }
 
-/* Horizontal scroll for wide tables on mobile */
-.content table {
-  display: block;
-  overflow-x: auto;
-  white-space: nowrap;
-}
+/* Wide tables scroll within the content container (overflow-x on
+   .content above).  No display:block override needed — that breaks
+   table semantics (column widths, row alignment). */
 
 /* ----- Admonitions ----- */
 

--- a/docs/build/style.css
+++ b/docs/build/style.css
@@ -1,0 +1,510 @@
+/* ================================================================
+   mx docs — stylesheet
+   Clean, minimal, responsive. CSS variables for theming.
+   ================================================================ */
+
+/* ----- Reset ----- */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+/* ----- Theme variables ----- */
+
+/* Default: light */
+:root {
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --fg-muted: #555;
+  --nav-bg: #f5f5f5;
+  --code-bg: #f0f0f0;
+  --code-fg: #1a1a1a;
+  --link: #0066cc;
+  --link-hover: #004499;
+  --border: #ddd;
+  --header-bg: #fafafa;
+  --header-border: #e0e0e0;
+  --admonition-note-bg: #e7f2fa;
+  --admonition-note-border: #2196f3;
+  --admonition-warning-bg: #fff3cd;
+  --admonition-warning-border: #ff9800;
+  --admonition-deprecated-bg: #f8d7da;
+  --admonition-deprecated-border: #f44336;
+  --admonition-tip-bg: #d4edda;
+  --admonition-tip-border: #4caf50;
+  --active-bg: #e8e8e8;
+}
+
+/* User chose dark */
+:root[data-theme="dark"] {
+  --bg: #1a1a1a;
+  --fg: #e0e0e0;
+  --fg-muted: #999;
+  --nav-bg: #242424;
+  --code-bg: #2d2d2d;
+  --code-fg: #e0e0e0;
+  --link: #6db3f2;
+  --link-hover: #9dcbf5;
+  --border: #444;
+  --header-bg: #222;
+  --header-border: #333;
+  --admonition-note-bg: #1a3a4a;
+  --admonition-note-border: #2196f3;
+  --admonition-warning-bg: #4a3a1a;
+  --admonition-warning-border: #ff9800;
+  --admonition-deprecated-bg: #4a1a1a;
+  --admonition-deprecated-border: #f44336;
+  --admonition-tip-bg: #1a3a1a;
+  --admonition-tip-border: #4caf50;
+  --active-bg: #333;
+}
+
+/* System prefers dark, user hasn't chosen */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #1a1a1a;
+    --fg: #e0e0e0;
+    --fg-muted: #999;
+    --nav-bg: #242424;
+    --code-bg: #2d2d2d;
+    --code-fg: #e0e0e0;
+    --link: #6db3f2;
+    --link-hover: #9dcbf5;
+    --border: #444;
+    --header-bg: #222;
+    --header-border: #333;
+    --admonition-note-bg: #1a3a4a;
+    --admonition-note-border: #2196f3;
+    --admonition-warning-bg: #4a3a1a;
+    --admonition-warning-border: #ff9800;
+    --admonition-deprecated-bg: #4a1a1a;
+    --admonition-deprecated-border: #f44336;
+    --admonition-tip-bg: #1a3a1a;
+    --admonition-tip-border: #4caf50;
+    --active-bg: #333;
+  }
+}
+
+/* User chose light (overrides system dark) */
+:root[data-theme="light"] {
+  --bg: #ffffff;
+  --fg: #1a1a1a;
+  --fg-muted: #555;
+  --nav-bg: #f5f5f5;
+  --code-bg: #f0f0f0;
+  --code-fg: #1a1a1a;
+  --link: #0066cc;
+  --link-hover: #004499;
+  --border: #ddd;
+  --header-bg: #fafafa;
+  --header-border: #e0e0e0;
+  --admonition-note-bg: #e7f2fa;
+  --admonition-note-border: #2196f3;
+  --admonition-warning-bg: #fff3cd;
+  --admonition-warning-border: #ff9800;
+  --admonition-deprecated-bg: #f8d7da;
+  --admonition-deprecated-border: #f44336;
+  --admonition-tip-bg: #d4edda;
+  --admonition-tip-border: #4caf50;
+  --active-bg: #e8e8e8;
+}
+
+/* ----- Typography ----- */
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial,
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--fg);
+  background: var(--bg);
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+h1 { font-size: 1.8em; }
+h2 { font-size: 1.4em; border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
+h3 { font-size: 1.15em; }
+h4 { font-size: 1em; }
+
+p {
+  margin: 0.8em 0;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 1.5em 0;
+}
+
+/* ----- Layout ----- */
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 240px;
+  background: var(--nav-bg);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.main {
+  margin-left: 240px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  max-width: 800px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2em 2em 4em;
+  flex: 1;
+}
+
+/* ----- Sidebar ----- */
+
+.sidebar-toggle {
+  height: 100%;
+}
+
+.sidebar-toggle > summary {
+  display: none;
+}
+
+.sidebar-content {
+  padding: 1em 0;
+}
+
+.sidebar-header {
+  padding: 0 1.2em 0.5em;
+  margin-bottom: 0.5em;
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-title {
+  font-size: 1.3em;
+  font-weight: 700;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.sidebar-title:hover {
+  color: var(--link);
+  text-decoration: none;
+}
+
+.sidebar-group {
+  margin-bottom: 0.5em;
+}
+
+.sidebar-group-title {
+  font-size: 0.75em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+  padding: 0.5em 1.6em 0.2em;
+}
+
+.sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar li a {
+  display: block;
+  padding: 0.3em 1.6em;
+  color: var(--fg);
+  text-decoration: none;
+  font-size: 0.9em;
+}
+
+.sidebar li a:hover {
+  background: var(--active-bg);
+  text-decoration: none;
+}
+
+.sidebar li.active a {
+  background: var(--active-bg);
+  font-weight: 600;
+  color: var(--link);
+}
+
+/* ----- Header ----- */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6em 2em;
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--header-border);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.header-title {
+  font-weight: 700;
+  font-size: 1.1em;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.header-title:hover {
+  color: var(--link);
+  text-decoration: none;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+
+.header-link {
+  font-size: 0.9em;
+  color: var(--fg-muted);
+}
+
+.header-link:hover {
+  color: var(--link);
+}
+
+.theme-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.2em 0.5em;
+  font-size: 1.1em;
+  cursor: pointer;
+  color: var(--fg);
+  line-height: 1;
+}
+
+.theme-toggle:hover {
+  background: var(--active-bg);
+}
+
+/* ----- Footer ----- */
+
+.site-footer {
+  padding: 1em 2em;
+  border-top: 1px solid var(--border);
+  text-align: center;
+  font-size: 0.85em;
+  color: var(--fg-muted);
+}
+
+/* ----- TOC ----- */
+
+.toc {
+  margin-bottom: 2em;
+  padding: 1em 1.2em;
+  background: var(--nav-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.toc summary {
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 0.5em;
+}
+
+.toc ul {
+  margin: 0.3em 0;
+  padding-left: 1.5em;
+}
+
+.toc li {
+  margin: 0.2em 0;
+}
+
+.toc a {
+  color: var(--fg);
+}
+
+.toc a:hover {
+  color: var(--link);
+}
+
+/* ----- Code ----- */
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.88em;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+}
+
+pre {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 1em;
+  border-radius: 4px;
+  overflow-x: auto;
+  line-height: 1.45;
+  border: 1px solid var(--border);
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.88em;
+}
+
+/* ----- Tables ----- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1em 0;
+  font-size: 0.9em;
+}
+
+th, td {
+  padding: 0.5em 0.8em;
+  text-align: left;
+  border: 1px solid var(--border);
+}
+
+th {
+  background: var(--nav-bg);
+  font-weight: 600;
+}
+
+/* Horizontal scroll for wide tables on mobile */
+.content table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+/* ----- Admonitions ----- */
+
+.admonition {
+  padding: 0.8em 1em;
+  margin: 1em 0;
+  border-left: 4px solid var(--border);
+  border-radius: 0 4px 4px 0;
+}
+
+.admonition p {
+  margin: 0.3em 0;
+}
+
+.admonition p:first-child strong {
+  text-transform: uppercase;
+  font-size: 0.85em;
+  letter-spacing: 0.03em;
+}
+
+.admonition.note {
+  background: var(--admonition-note-bg);
+  border-left-color: var(--admonition-note-border);
+}
+
+.admonition.warning {
+  background: var(--admonition-warning-bg);
+  border-left-color: var(--admonition-warning-border);
+}
+
+.admonition.deprecated {
+  background: var(--admonition-deprecated-bg);
+  border-left-color: var(--admonition-deprecated-border);
+}
+
+.admonition.tip {
+  background: var(--admonition-tip-bg);
+  border-left-color: var(--admonition-tip-border);
+}
+
+/* ----- Lists ----- */
+
+ul, ol {
+  padding-left: 1.5em;
+}
+
+li {
+  margin: 0.3em 0;
+}
+
+li > ul, li > ol {
+  margin-top: 0.2em;
+}
+
+/* ----- Images ----- */
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ----- Mobile (< 768px): sidebar collapses ----- */
+
+@media (max-width: 768px) {
+  .sidebar {
+    position: relative;
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .sidebar-toggle > summary {
+    display: block;
+    padding: 0.8em 1.2em;
+    font-weight: 600;
+    cursor: pointer;
+    background: var(--nav-bg);
+  }
+
+  /* Closed by default on mobile via JS-free approach:
+     the <details open> attribute is set in HTML for desktop,
+     but on mobile we rely on the user toggling it. The 'open'
+     attribute means it starts expanded on desktop. On mobile
+     the summary is visible so users can toggle. */
+
+  .main {
+    margin-left: 0;
+  }
+
+  .content {
+    padding: 1em;
+  }
+
+  .site-header {
+    padding: 0.6em 1em;
+  }
+
+  .site-footer {
+    padding: 1em;
+  }
+}

--- a/docs/build/template.html
+++ b/docs/build/template.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>$if(title)$$title$ - mx docs$else$mx docs$endif$</title>
+  <script>const t=localStorage.getItem('theme');if(t)document.documentElement.dataset.theme=t;</script>
+$for(css)$
+  <link rel="stylesheet" href="$css$" />
+$endfor$
+$if(math)$
+  $math$
+$endif$
+</head>
+<body>
+
+<nav class="sidebar" id="sidebar">
+  <details class="sidebar-toggle" open>
+    <summary class="sidebar-toggle-label">Menu</summary>
+    <div class="sidebar-content">
+      <div class="sidebar-header">
+        <a href="index.html" class="sidebar-title">mx docs</a>
+      </div>
+
+      <div class="sidebar-group">
+        <div class="sidebar-group-title">Intro</div>
+        <ul>
+          <li$if(current-page)$$if(current-page.index)$ class="active"$endif$$endif$><a href="index.html">Overview</a></li>
+          <li$if(current-page)$$if(current-page.getting-started)$ class="active"$endif$$endif$><a href="getting-started.html">Getting Started</a></li>
+        </ul>
+      </div>
+
+      <div class="sidebar-group">
+        <div class="sidebar-group-title">Commands</div>
+        <ul>
+          <li$if(current-page)$$if(current-page.commit)$ class="active"$endif$$endif$><a href="commit.html">commit</a></li>
+          <li$if(current-page)$$if(current-page.log)$ class="active"$endif$$endif$><a href="log.html">log</a></li>
+          <li$if(current-page)$$if(current-page.memory)$ class="active"$endif$$endif$><a href="memory.html">memory</a></li>
+          <li$if(current-page)$$if(current-page.codex)$ class="active"$endif$$endif$><a href="codex.html">codex</a></li>
+          <li$if(current-page)$$if(current-page.kv)$ class="active"$endif$$endif$><a href="kv.html">kv</a></li>
+          <li$if(current-page)$$if(current-page.state)$ class="active"$endif$$endif$><a href="state.html">state</a></li>
+          <li$if(current-page)$$if(current-page.sync)$ class="active"$endif$$endif$><a href="sync.html">sync</a></li>
+          <li$if(current-page)$$if(current-page.pr)$ class="active"$endif$$endif$><a href="pr.html">pr</a></li>
+          <li$if(current-page)$$if(current-page.github)$ class="active"$endif$$endif$><a href="github.html">github</a></li>
+          <li$if(current-page)$$if(current-page.convert)$ class="active"$endif$$endif$><a href="convert.html">convert</a></li>
+          <li$if(current-page)$$if(current-page.heartbeat)$ class="active"$endif$$endif$><a href="heartbeat.html">heartbeat</a></li>
+        </ul>
+      </div>
+
+      <div class="sidebar-group">
+        <div class="sidebar-group-title">Reference</div>
+        <ul>
+          <li$if(current-page)$$if(current-page.paths)$ class="active"$endif$$endif$><a href="paths.html">paths</a></li>
+          <li$if(current-page)$$if(current-page.base-d)$ class="active"$endif$$endif$><a href="base-d.html">base-d</a></li>
+          <li$if(current-page)$$if(current-page.architecture)$ class="active"$endif$$endif$><a href="architecture.html">architecture</a></li>
+        </ul>
+      </div>
+    </div>
+  </details>
+</nav>
+
+<div class="main">
+  <header class="site-header">
+    <a href="index.html" class="header-title">mx docs</a>
+    <div class="header-right">
+      <a href="https://github.com/coryzibell/mx" class="header-link">GitHub</a>
+      <button class="theme-toggle" onclick="let t=document.documentElement.dataset.theme==='dark'?'light':'dark';document.documentElement.dataset.theme=t;localStorage.setItem('theme',t)" aria-label="Toggle theme">&#9684;</button>
+    </div>
+  </header>
+
+  <article class="content">
+$if(toc)$
+    <nav class="toc" role="doc-toc">
+      <details open>
+        <summary>Contents</summary>
+        $table-of-contents$
+      </details>
+    </nav>
+$endif$
+    $body$
+  </article>
+
+  <footer class="site-footer">
+    <p>mx docs &middot; Built with Typst + Pandoc</p>
+  </footer>
+</div>
+
+</body>
+</html>

--- a/docs/build/template.html
+++ b/docs/build/template.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>$if(title)$$title$ - mx docs$else$mx docs$endif$</title>
   <script>const t=localStorage.getItem('theme');if(t)document.documentElement.dataset.theme=t;</script>
+  <script>if(window.innerWidth<769)document.addEventListener('DOMContentLoaded',function(){var d=document.getElementById('sidebar');if(d)d.querySelector('details').removeAttribute('open')})</script>
 $for(css)$
   <link rel="stylesheet" href="$css$" />
 $endfor$

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -1,0 +1,168 @@
+#import "lib.typ": *
+
+#page-header(
+  "Getting Started",
+  "Install mx, make your first encoded commit, and explore the subsystems."
+)
+
+== Installation
+
+=== From crates.io
+
+```bash
+cargo install mx
+```
+
+=== From source
+
+```bash
+git clone https://github.com/coryzibell/mx.git
+cd mx
+cargo install --path .
+```
+
+Requires Rust 2024 edition. The binary is named `mx`.
+
+#tip[Run `mx --version` to verify the installation.]
+
+== Your first encoded commit
+
+The core workflow that makes mx unique is encoded commits. Every commit message
+is hashed and compressed through randomly selected dictionaries, producing
+output that looks like hieroglyphs in raw `git log` but decodes cleanly with
+`mx log`.
+
+=== Make a change and commit
+
+```bash
+echo "hello" > test.txt
+mx commit "add test file" -a
+```
+
+The `-a` flag stages all changes before committing, just like `git commit -a`.
+You will see a footer line showing which algorithms and dictionaries were used,
+something like `[sha256:ocean|zstd:forest]`.
+
+=== Read it back
+
+```bash
+mx log
+```
+
+This shows the last 10 commits with decoded messages. For more detail:
+
+```bash
+mx log -n 20 --full
+```
+
+=== Preview without committing
+
+If you want to see what the encoding produces without actually committing:
+
+```bash
+mx commit "your message" --dry-run
+```
+
+Or to test title/body encoding separately:
+
+```bash
+mx commit --encode-only --title "refactor store" --body "split backends"
+```
+
+#note[Always use `mx log` to read commit history. Raw `git log` shows encoded
+output that is intentionally unreadable. See #link("base-d.html")[base-d] for
+how the encoding works.]
+
+== Setting up MX_HOME
+
+By default, mx stores everything under `~/.mx/`. To move the entire tree:
+
+```bash
+export MX_HOME=/data/mx
+```
+
+Add this to your shell profile (`.bashrc`, `.zshrc`, etc.) to make it
+permanent. Individual subsystems can be overridden separately -- see
+#link("paths.html")[Filesystem Layout] for the full reference.
+
+== Subsystems at a glance
+
+=== Memory
+
+The #link("memory.html")[memory] system is a knowledge graph backed by SurrealDB.
+Store patterns, insights, decisions, and reference material with categories,
+tags, resonance levels, and semantic search via embeddings.
+
+```bash
+mx memory search "retry pattern" --semantic
+mx memory add --category insight --title "Always check timeouts" \
+  --content "Connection pools need explicit timeout config" \
+  --tags "reliability,networking"
+mx memory stats
+```
+
+=== Codex
+
+The #link("codex.html")[codex] archives Claude Code sessions to permanent storage.
+Clean markdown transcripts, extracted images, and searchable manifests.
+
+```bash
+mx codex archive           # archive current session
+mx codex archive --all     # archive everything unarchived
+mx codex list              # see what you have
+mx codex search "migration"
+```
+
+=== KV
+
+The #link("kv.html")[kv] store provides fast local state per agent. Counters,
+strings, lists, and history with time-based queries. Schema-driven with
+defaults.
+
+```bash
+mx kv set session.goal "ship the docs"
+mx kv inc builds
+mx kv push decisions "chose Typst for docs"
+mx kv last decisions --count 5
+```
+
+=== State
+
+The #link("state.html")[state] system encodes emotional state tensors -- multi-
+dimensional values compressed into a compact string format. Used for agent
+co-regulation and identity tracking.
+
+```bash
+mx state encode -d "temp=0.8 entropy=0.75 agency=0.4"
+mx state decode "@state:tensor|0.8|0.75|0.4"
+mx state schemas
+```
+
+=== PR
+
+#link("pr.html")[PR merge] handles pull request merging with encoded commit
+messages. Supports squash (default), rebase, and standard merge commits.
+
+```bash
+mx pr merge 42             # squash merge
+mx pr merge 42 --rebase    # rebase merge
+```
+
+=== Sync
+
+#link("sync.html")[Sync] pulls and pushes GitHub issues and discussions as local
+YAML files for offline editing and batch operations.
+
+```bash
+mx sync pull owner/repo
+mx sync push owner/repo --dry-run
+mx sync labels owner/repo
+```
+
+== What's next
+
+- Read the #link("commit.html")[commit] and #link("log.html")[log] reference
+  pages for the full flag reference
+- Explore the #link("memory.html")[memory] system for persistent knowledge
+- Check #link("paths.html")[filesystem layout] for configuration options
+- See #link("architecture.html")[architecture] for how mx is built internally

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -1,0 +1,105 @@
+#import "lib.typ": *
+
+#page-header(
+  "mx",
+  "A Swiss army knife for Claude Code and multi-agent toolkits."
+)
+
+mx is a Rust CLI providing encoded git operations, a SurrealDB-backed knowledge
+graph, session archival, GitHub sync, and emotional state tensors. Designed for
+use with Claude Code, but works with any multi-agent workflow that needs
+persistent memory, encoded commits, or session management.
+
+== Quick links
+
+- #link("getting-started.html")[Getting Started] -- install mx and make your first encoded commit
+- #link("commit.html")[Commit] -- encoded git commits
+- #link("log.html")[Log] -- decoded git log
+- #link("memory.html")[Memory] -- knowledge graph operations
+- #link("codex.html")[Codex] -- session archival
+- #link("kv.html")[KV] -- local key-value store
+- #link("state.html")[State] -- emotional state tensors
+- #link("sync.html")[Sync] -- GitHub sync
+- #link("pr.html")[PR] -- pull request merge
+- #link("github.html")[GitHub] -- GitHub operations
+- #link("convert.html")[Convert] -- conversion utilities
+- #link("heartbeat.html")[Heartbeat] -- calming co-regulation prompt
+
+== Features
+
+=== Encoded commits
+
+`mx commit` wraps `git commit` but encodes the message using
+#link("base-d.html")[base-d]. The commit title is hashed and the body is
+compressed, each encoded through a randomly selected dictionary. The result
+looks like hieroglyphs in `git log` but decodes cleanly with `mx log`.
+
+```bash
+mx commit "fix session export crash on empty JSONL" -a
+mx log
+```
+
+=== Knowledge graph
+
+The #link("memory.html")[memory] system is a knowledge graph backed by SurrealDB
+(or embedded SurrealKV). Entries have categories, tags, resonance levels,
+embeddings, and relationships.
+
+```bash
+mx memory search "session bootstrap"
+mx memory search "how to handle state" --semantic
+mx memory add --category pattern --title "Retry pattern" \
+  --content "Use exponential backoff..." --tags "reliability"
+```
+
+=== Session archival
+
+The #link("codex.html")[codex] archives Claude session JSONL files to permanent
+storage with transcripts, extracted images, and manifests.
+
+```bash
+mx codex archive
+mx codex list
+mx codex read <archive-id> --clean
+```
+
+=== Local key-value store
+
+#link("kv.html")[KV] provides fast per-agent state: counters, strings, lists,
+and history with time-based queries.
+
+```bash
+mx kv set session.goal "ship the docs"
+mx kv get session.goal
+mx kv push decisions "chose Typst over markdown"
+```
+
+== Installation
+
+From #link("https://crates.io/crates/mx")[crates.io]:
+
+```bash
+cargo install mx
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/coryzibell/mx.git
+cd mx
+cargo install --path .
+```
+
+Requires Rust 2024 edition.
+
+== Configuration
+
+Everything mx writes lives under a single base directory: `$MX_HOME`, which
+defaults to `~/.mx/`. See #link("paths.html")[Filesystem Layout] for the full
+reference.
+
+== Start here
+
+New to mx? Start with #link("getting-started.html")[Getting Started] for a
+hands-on walkthrough of installation, your first encoded commit, and a tour
+of the subsystems.

--- a/docs/src/lib.typ
+++ b/docs/src/lib.typ
@@ -25,8 +25,13 @@
 // Command reference formatting
 // ---------------------------------------------------------------------------
 
+// Heading level is hardcoded to h2. This is intentional: each command page
+// uses h1 for the page title, h2 for individual commands, and h3 for
+// sub-sections like flags and examples. If the page structure changes (e.g.,
+// grouping commands under h2 categories), this level may need to become a
+// configurable parameter.
 #let command(name, description, flags: (), examples: ()) = {
-  [== `#name`]
+  heading(level: 2, raw(name))
   [#description]
 
   if flags.len() > 0 {
@@ -56,7 +61,7 @@
 
 #let deprecated-since(version, replacement) = {
   admonition("deprecated",
-    [Deprecated since v#version. Use `#replacement` instead.])
+    [Deprecated since v#version. Use #raw(replacement) instead.])
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/src/lib.typ
+++ b/docs/src/lib.typ
@@ -1,0 +1,70 @@
+// lib.typ — Shared components for mx documentation
+//
+// Usage: #import "lib.typ": *
+
+// ---------------------------------------------------------------------------
+// Admonitions
+// ---------------------------------------------------------------------------
+
+// Generic admonition block. Maps to styled HTML via admonition.lua.
+#let admonition(kind, body) = {
+  block(
+    width: 100%,
+    inset: 12pt,
+    stroke: 0.5pt,
+    [*#upper(kind):* #body]
+  )
+}
+
+#let note(body) = admonition("note", body)
+#let warning(body) = admonition("warning", body)
+#let deprecated(body) = admonition("deprecated", body)
+#let tip(body) = admonition("tip", body)
+
+// ---------------------------------------------------------------------------
+// Command reference formatting
+// ---------------------------------------------------------------------------
+
+#let command(name, description, flags: (), examples: ()) = {
+  [== `#name`]
+  [#description]
+
+  if flags.len() > 0 {
+    [=== Flags]
+    table(
+      columns: (auto, auto, auto),
+      table.header([*Flag*], [*Type*], [*Description*]),
+      ..flags.flatten()
+    )
+  }
+
+  if examples.len() > 0 {
+    [=== Examples]
+    for ex in examples {
+      raw(ex, lang: "bash", block: true)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Version markers
+// ---------------------------------------------------------------------------
+
+#let since(version) = {
+  text(size: 0.85em, fill: rgb("#666"))[_since v#version _]
+}
+
+#let deprecated-since(version, replacement) = {
+  admonition("deprecated",
+    [Deprecated since v#version. Use `#replacement` instead.])
+}
+
+// ---------------------------------------------------------------------------
+// Page header
+// ---------------------------------------------------------------------------
+
+#let page-header(title, description) = {
+  [= #title]
+  [#description]
+  line(length: 100%)
+}


### PR DESCRIPTION
## Summary

Replaces the stale GitHub wiki with a docs-as-code system that lives in-repo and deploys to GitHub Pages.

**Architecture:** Typst source files → Pandoc → static HTML site + LLM-friendly concatenated markdown (with links stripped). The pipeline runs via a `docs/build.sh` script and a GitHub Actions workflow on push to `main`.

**Phase 1 scope (this PR):**
- `docs/lib.typ` — shared Typst components (admonitions, metadata, reusable blocks)
- Build tooling — HTML template, CSS (dark/light theme toggle via `localStorage`), Lua filters (admonition rendering, LLM link stripping, per-page title injection)
- `docs/build.sh` — orchestrates the Typst → Pandoc → HTML pipeline
- GitHub Actions workflow for automated build and deploy
- Two seed pages: index and getting-started

**Key features:**
- Dark/light toggle respecting user preference (`localStorage`), no flash on load
- Responsive sidebar with mobile hamburger menu
- Per-page `<title>` tags derived from Typst metadata
- Admonition blocks (note, warning, tip, etc.) with multi-paragraph support
- Code syntax highlighting via highlight.js
- Single concatenated markdown output for LLM consumption (links stripped to plain text)

**What is NOT in this PR:**
- Command reference pages (Phases 2–4)
- Wiki deprecation and redirect (Phase 5)
- README trim (Phase 5)

Refs #283. See also #285 (manifest-driven nav, planned for a future phase).

## Test plan

- [ ] Run `docs/build.sh` locally and verify HTML output renders correctly
- [ ] Confirm dark/light toggle works and persists across page loads
- [ ] Verify responsive sidebar collapses on mobile viewports
- [ ] Check that per-page `<title>` tags reflect each page's Typst title metadata
- [ ] Validate admonition rendering (single-paragraph and multi-paragraph)
- [ ] Inspect LLM markdown output — confirm links are stripped to plain text
- [ ] Push to a test branch and confirm the GitHub Actions workflow builds and deploys