### PR TITLE
docs: add mx show documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ mx log
 mx log -n 20 --full
 ```
 
+### Decoded Git Show
+
+`mx show` is a drop-in replacement for `git show` that transparently decodes encoded commit messages. All `git show` flags work as expected.
+
+```bash
+# Show the latest commit, decoded
+mx show
+
+# Show a specific commit with diffstat
+mx show abc1234 --stat
+
+# Show just the commit message, no diff
+mx show --no-patch
+
+# View a file at a specific revision (passes through to git show)
+mx show HEAD:src/main.rs
+```
+
 ### Knowledge / Memory
 
 The memory system is a knowledge graph backed by SurrealDB (or embedded SurrealKV). Entries have categories, tags, resonance levels, embeddings, and relationships.

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -19,7 +19,7 @@ CROSSREF_FILTER="$BUILD_DIR/crossref.lua"
 
 # Ordered list for LLM output (getting-started first, architecture last)
 LLM_ORDER=(
-  index getting-started commit log memory codex kv state
+  index getting-started commit log show memory codex kv state
   sync pr github convert session wiki
   base-d paths architecture
 )

--- a/docs/build/template.html
+++ b/docs/build/template.html
@@ -37,6 +37,7 @@ $endif$
         <ul>
           <li$if(current-page)$$if(current-page.commit)$ class="active"$endif$$endif$><a href="commit.html">commit</a></li>
           <li$if(current-page)$$if(current-page.log)$ class="active"$endif$$endif$><a href="log.html">log</a></li>
+          <li$if(current-page)$$if(current-page.show)$ class="active"$endif$$endif$><a href="show.html">show</a></li>
           <li$if(current-page)$$if(current-page.memory)$ class="active"$endif$$endif$><a href="memory.html">memory</a></li>
           <li$if(current-page)$$if(current-page.codex)$ class="active"$endif$$endif$><a href="codex.html">codex</a></li>
           <li$if(current-page)$$if(current-page.kv)$ class="active"$endif$$endif$><a href="kv.html">kv</a></li>

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -73,7 +73,7 @@ src/
  cli.rs             # the full command tree (clap derive enums)
  paths.rs           # single source of path truth
  handlers/          # command handler routing
-   mod.rs           # top-level dispatchers (pr, github, codex, log, etc.)
+   mod.rs           # top-level dispatchers (pr, github, codex, log, show, etc.)
    memory.rs        # mx memory subcommand handler
    kv.rs            # mx kv subcommand handler
    metadata.rs      # metadata subcommand handler (categories, tags, etc.)
@@ -165,6 +165,7 @@ Some commands dispatch directly to domain functions from `main.rs`:
 ```rust
 Commands::Commit { .. } => commit::upload_commit(..),
 Commands::Log { .. } => handle_log(..),
+Commands::Show { .. } => handle_show(..),
 ```
 
 Others dispatch through `handlers/mod.rs`:
@@ -651,9 +652,10 @@ pub struct EncodedCommit {
 
 === `handlers/mod.rs` -- the decoding pipeline
 
-`mx log` decodes commits by:
+`mx log` and `mx show` decode commits by:
 
-+ Running `git log` with a structured format.
++ Running the underlying git command (`git log` or `git show`) with a
+  structured format.
 + For each commit body, calling `try_decode_commit_body()`.
 + The function scans for the last footer-shaped line (validated against the
   known compression algorithm vocabulary).
@@ -665,6 +667,12 @@ pub struct EncodedCommit {
 The scan uses a "last wins" heuristic: if multiple footer-shaped lines appear
 (e.g., from a user-amended commit that quotes a prior footer), the last one is
 used.
+
+`handle_show()` uses a two-pass approach: Pass 1 retrieves commit metadata
+and the encoded message (with `--no-patch`), decodes it, and prints the
+header. Pass 2 retrieves the diff output (with `--format=""`) and streams it
+as-is. Passthrough detection skips decoding entirely for `ref:path` syntax
+(file content viewing) and `--format`/`--pretty` (user-controlled output).
 
 === `commit.rs` -- PR merge encoding
 

--- a/docs/src/commit.typ
+++ b/docs/src/commit.typ
@@ -14,14 +14,16 @@ second (also random) dictionary. The result is a three-part commit:
 - *Footer* -- a tag identifying the hash algorithm, compression algorithm, and
   both dictionary names: `[hash:title_dict|compress:body_dict]`.
 
-Raw `git log` shows encoded glyphs. `mx log` decodes them back to plain text.
+Raw `git log` and `git show` display encoded glyphs. `mx log` and
+`mx show` decode them back to plain text.
 
 When both the title and body randomly land on the _same_ dictionary, a dejavu
 marker (`whoa.`) is appended to the footer -- a small easter egg that emerges
 from pure chance.
 
-#note[Always use `mx log` to read commit history. Raw `git log` output is
-intentionally unreadable.]
+#note[Always use `mx log` to read commit history and `mx show` to inspect
+individual commits. Raw `git log` and `git show` output is intentionally
+unreadable.]
 
 == Basic usage
 
@@ -178,8 +180,8 @@ system that maps binary data to tokens from randomly selected dictionaries.
   dictionary. This becomes the commit *body*.
 + A footer tag records the algorithms and dictionaries used:
   `[hash_algo:title_dict|compress_algo:body_dict]`.
-+ `mx log` reads the footer, looks up the dictionaries, and reverses the
-  process to recover the original message.
++ `mx log` and `mx show` read the footer, look up the dictionaries, and
+  reverse the process to recover the original message.
 
 If the encoded output contains NUL bytes or control characters (which would
 break git), the encoder retries with a different random dictionary, up to 5

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -55,6 +55,13 @@ This shows the last 10 commits with decoded messages. For more detail:
 mx log -n 20 --full
 ```
 
+To inspect a single commit (decoded replacement for `git show`):
+
+```bash
+mx show
+mx show abc1234 --stat
+```
+
 === Preview without committing
 
 If you want to see what the encoding produces without actually committing:
@@ -69,9 +76,9 @@ Or to test title/body encoding separately:
 mx commit --encode-only --title "refactor store" --body "split backends"
 ```
 
-#note[Always use `mx log` to read commit history. Raw `git log` shows encoded
-output that is intentionally unreadable. See #link("base-d.html")[base-d] for
-how the encoding works.]
+#note[Always use `mx log` and `mx show` to read commit history. Raw `git log`
+and `git show` show encoded output that is intentionally unreadable. See
+#link("base-d.html")[base-d] for how the encoding works.]
 
 == Setting up MX_HOME
 
@@ -160,8 +167,8 @@ mx sync push owner/repo --dry-run
 
 == What's next
 
-- Read the #link("commit.html")[commit] and #link("log.html")[log] reference
-  pages for the full flag reference
+- Read the #link("commit.html")[commit], #link("log.html")[log], and
+  #link("show.html")[show] reference pages for the full flag reference
 - Explore the #link("memory.html")[memory] system for persistent knowledge
 - Check #link("paths.html")[filesystem layout] for configuration options
 - See #link("architecture.html")[architecture] for how mx is built internally

--- a/docs/src/log.typ
+++ b/docs/src/log.typ
@@ -74,17 +74,20 @@ mx log -n 5 --full -- docs/
 mx log -- --author="charlie"
 ```
 
-== Relationship to mx commit
+== Relationship to mx commit and mx show
 
-`mx commit` and `mx log` are two halves of the same round-trip:
+`mx commit`, `mx log`, and #link("show.html")[`mx show`] form the encoding
+round-trip:
 
 + `mx commit` compresses your message, encodes it through a random dictionary,
   and writes the encoded result as the git commit body with a footer tag.
 + `mx log` reads the footer tag, reverses the encoding, decompresses, and
-  displays your original message.
+  displays your original message across the commit history.
++ `mx show` does the same decoding for individual commits, replacing
+  `git show`.
 
 Non-encoded commits (e.g. commits made with raw `git commit`) pass through
-unchanged -- `mx log` detects the absence of a footer tag and displays the
-original subject line.
+unchanged -- both `mx log` and `mx show` detect the absence of a footer tag
+and display the original message.
 
 For the full encoding specification, see #link("commit.html")[commit].

--- a/docs/src/show.typ
+++ b/docs/src/show.typ
@@ -1,0 +1,154 @@
+#import "lib.typ": *
+
+#page-header("show", "Decoded git show for encoded commits.")
+
+== Overview
+
+`mx show` decodes the output of `git show` the same way
+#link("log.html")[`mx log`] decodes `git log`. Because
+#link("commit.html")[`mx commit`] encodes every commit message through a
+randomly selected #link("base-d.html")[base-d] dictionary, raw `git show`
+displays unreadable glyphs where the commit message should be. `mx show`
+reverses the encoding and displays your original message while passing
+everything else -- diffs, stats, file content -- through unchanged.
+
+It is a drop-in replacement for `git show`. Every flag that `git show`
+accepts works with `mx show`.
+
+#note[Always use `mx show` to inspect commits. Raw `git show` will show
+encoded noise for any commit made with `mx commit`.]
+
+== Basic usage
+
+Show the most recent commit with its diff:
+
+```bash
+mx show
+```
+
+Show a specific commit:
+
+```bash
+mx show abc1234
+```
+
+Show a commit with diffstat instead of the full diff:
+
+```bash
+mx show --stat
+```
+
+Show only the commit message (no diff):
+
+```bash
+mx show --no-patch
+```
+
+Show only filenames changed:
+
+```bash
+mx show --name-only
+```
+
+== How it works
+
+`mx show` uses a two-pass approach:
+
++ *Pass 1* runs `git show` with `--no-patch` and a structured format to
+  retrieve commit metadata (hash, author, date, parent hashes) and the
+  encoded message body. The body is decoded using the same pipeline as
+  `mx log` -- the footer tag identifies the dictionary and compression
+  algorithm, and the body is decompressed back to your original message.
+
++ *Pass 2* runs `git show` with an empty format string to retrieve just
+  the diff output. This is streamed to your terminal as-is, identical to
+  what `git show` would produce.
+
+The result looks exactly like `git show` output, except the commit message
+is readable.
+
+=== Passthrough modes
+
+In certain cases, `mx show` skips decoding entirely and runs raw
+`git show`:
+
+- *File content* (`ref:path` syntax) -- when you use `mx show HEAD:src/main.rs`
+  to view a file at a specific revision, there is no commit message to
+  decode. The command passes through to `git show` directly.
+
+- *Custom format* (`--format` or `--pretty`) -- when you control the output
+  format yourself, decoding would interfere. The command passes through
+  unchanged.
+
+=== Fallback behavior
+
+If decoding fails for any reason -- the commit was not made with
+`mx commit`, the footer is missing, or the dictionary lookup fails --
+`mx show` falls back to displaying the raw message exactly as `git show`
+would. It is always safe to use `mx show` in place of `git show`, even in
+repositories with a mix of encoded and non-encoded commits.
+
+== Merge commits
+
+Merge commits display a `Merge:` line showing the parent hashes, matching
+the default `git show` format:
+
+```
+commit abc1234def5678...
+Merge:  aaa1111 bbb2222
+Author: Charlie <charlie@example.com>
+Date:   Wed May 7 2026
+
+    the decoded merge commit message
+```
+
+== Multiple refs
+
+You can pass multiple refs and `mx show` will decode each one:
+
+```bash
+mx show HEAD HEAD~1 HEAD~2
+```
+
+== Tags
+
+When showing a tag, `mx show` displays the tag metadata followed by the
+decoded commit it points to. If the tag object itself is not a commit (e.g.
+an annotated tag preamble), its content is printed as-is.
+
+== Flags reference
+
+`mx show` accepts all flags that `git show` accepts. There are no
+mx-specific flags -- the command is designed to be a transparent wrapper.
+
+Common flags:
+
+#table(
+  columns: (auto, 1fr),
+  table.header([*Flag*], [*Description*]),
+  [`--stat`], [Show a diffstat summary instead of the full diff.],
+  [`--no-patch`], [Show only the commit header and message, no diff.],
+  [`-s`], [Shorthand for `--no-patch`.],
+  [`--name-only`], [Show only the names of changed files.],
+  [`--name-status`], [Show names and status (added, modified, deleted) of changed files.],
+  [`--raw`], [Show the diff in raw format.],
+  [`--format=<fmt>`], [Custom format string (passthrough -- skips decoding).],
+  [`--pretty=<fmt>`], [Alias for `--format` (passthrough -- skips decoding).],
+)
+
+Any arguments not listed here are passed directly to `git show`.
+
+== Relationship to mx log and mx commit
+
+`mx commit`, `mx log`, and `mx show` form a complete encoding round-trip:
+
++ `mx commit` encodes your message and writes it as an encoded git commit.
++ `mx log` decodes the commit history (replaces `git log`).
++ `mx show` decodes individual commit details (replaces `git show`).
+
+All three use the same decoding pipeline: read the footer tag, look up the
+dictionary, decompress, and display the original message. Non-encoded
+commits pass through unchanged in all three commands.
+
+For the full encoding specification, see #link("commit.html")[commit].
+For the decoding pipeline details, see #link("log.html")[log].


### PR DESCRIPTION
## Summary

- Adds complete documentation for the new `mx show` command (merged in PR #295)
- New `show.typ` reference page with usage examples, two-pass architecture, passthrough modes, and flags
- Updates 7 existing doc surfaces: nav, build config, getting-started, commit, log, architecture, and README

## Changes

- **New:** `docs/src/show.typ` — full reference page
- **Updated:** `docs/build/template.html` — nav sidebar
- **Updated:** `docs/build.sh` — LLM_ORDER
- **Updated:** `docs/src/getting-started.typ` — examples and links
- **Updated:** `docs/src/commit.typ` — mentions mx show as decoding tool
- **Updated:** `docs/src/log.typ` — three-command round-trip
- **Updated:** `docs/src/architecture.typ` — dispatch and pipeline docs
- **Updated:** `README.md` — Decoded Git Show section

## Test plan

- [x] `docs/build.sh` produces 18 pages clean
- [x] `cargo build` / `cargo test` / `cargo clippy` unaffected (docs only)