### PR TITLE
kv: random entry sampling with constraints (#249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,20 @@ mx kv last shipped --day 2026-04-25
 mx kv last shipped --month 2026-04
 mx kv last shipped --week 2026-W17
 mx kv last shipped --from 2026-04-01 --to 2026-04-15
+mx kv last shipped --since 1w
 mx kv search shipped "feature" --month 2026-04
 mx kv count shipped --day 2026-05-07
 
 # Time range composes with --count (filter first, then limit)
 mx kv last shipped --month 2026-04 --count 5
+
+# Random sampling from history/list keys
+mx kv random shipped --count 5
+mx kv random ideas --count 1
+mx kv random shipped --count 3 --since 30d
 ```
 
-Time-range flags (`--day`, `--month`, `--week`, `--from`/`--to`) are available on `last`, `search`, and `count`. All dates are UTC. For relative time queries (`1h`, `7d`), use `mx kv since`.
+Time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) are available on `last`, `search`, `count`, and `random`. All dates are UTC. The `--since` flag accepts relative times (`30d`, `1w`, `2h`, `30m`) and ISO-8601 timestamps. For a standalone relative-time query on history keys, use `mx kv since`.
 
 ### PR Merge
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -583,8 +583,8 @@ Supported types:
   table.header([*Type*], [*Behavior*]),
   [`counter`], [Integer with optional `min`/`max` bounds. Supports `inc`, `dec`, `set`, `get`],
   [`string`], [Simple string value. Supports `set`, `get`],
-  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`. The `last`, `search`, and `count` commands accept time-range flags (`--day`, `--month`, `--week`, `--from`/`--to`) for absolute date filtering.],
-  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`. The `last`, `search`, and `count` commands accept the same time-range flags as history.],
+  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
+  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
   [`state`], [Named fields (like a struct). Supports `set <key> <field> <value>`, `get`],
 )
 

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -137,8 +137,9 @@ mx kv set session.goal "ship the docs"
 mx kv inc builds
 mx kv push decisions "chose Typst for docs"
 mx kv last decisions --count 5
-mx kv last decisions --month 2026-04
+mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
+mx kv random decisions --count 3
 ```
 
 === State

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -183,8 +183,8 @@ History and list types both store timestamped entries with auto-assigned IDs.
 The difference is semantic: history is append-only (newest first, no pop),
 while lists support push/pop and maintain insertion order.
 
-Both types support `push`, `last`, `search`, `count`, and `remove`. Only
-lists support `pop`. Only history supports `since` (time-based queries).
+Both types support `push`, `last`, `search`, `count`, `random`, and `remove`.
+Only lists support `pop`. Only history supports `since` (time-based queries).
 
 === push
 
@@ -239,6 +239,7 @@ lists support `pop`. Only history supports `since` (time-based queries).
     ([`--week <YYYY-Www>`], [string], [Entries from an ISO week, Monday to Sunday]),
     ([`--from <YYYY-MM-DD>`], [string], [Start of date range, inclusive (UTC)]),
     ([`--to <YYYY-MM-DD>`], [string], [End of date range, inclusive (UTC)]),
+    ([`--since <relative-or-iso>`], [string], [Filter entries since a relative time (`30d`, `1w`, `2h`, `30m`) or ISO-8601 timestamp]),
   ),
   examples: (
     "mx kv last decisions",
@@ -247,6 +248,7 @@ lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv last shipped --day 2026-04-25",
     "mx kv last shipped --month 2026-04",
     "mx kv last shipped --month 2026-04 --count 5",
+    "mx kv last shipped --since 1w",
   ),
 )
 
@@ -288,11 +290,13 @@ lists support `pop`. Only history supports `since` (time-based queries).
     ([`--week <YYYY-Www>`], [string], [Search within an ISO week, Monday to Sunday]),
     ([`--from <YYYY-MM-DD>`], [string], [Start of date range, inclusive (UTC)]),
     ([`--to <YYYY-MM-DD>`], [string], [End of date range, inclusive (UTC)]),
+    ([`--since <relative-or-iso>`], [string], [Search since a relative time (`30d`, `1w`, `2h`, `30m`) or ISO-8601 timestamp]),
   ),
   examples: (
     "mx kv search decisions \"typst\"",
     "mx kv search todos \"test\"",
     "mx kv search shipped \"feature\" --month 2026-04",
+    "mx kv search shipped \"feature\" --since 30d",
   ),
 )
 
@@ -319,6 +323,7 @@ lists support `pop`. Only history supports `since` (time-based queries).
     ([`--week <YYYY-Www>`], [string], [Count within an ISO week, Monday to Sunday]),
     ([`--from <YYYY-MM-DD>`], [string], [Start of date range, inclusive (UTC)]),
     ([`--to <YYYY-MM-DD>`], [string], [End of date range, inclusive (UTC)]),
+    ([`--since <relative-or-iso>`], [string], [Count since a relative time (`30d`, `1w`, `2h`, `30m`) or ISO-8601 timestamp]),
   ),
   examples: (
     "mx kv count decisions",
@@ -326,6 +331,40 @@ lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv count todos \"blocked\"",
     "mx kv count shipped --day 2026-05-07",
     "mx kv count shipped --from 2026-04-01 --to 2026-04-15",
+    "mx kv count shipped --since 1w",
+  ),
+)
+
+=== random
+
+#command(
+  "mx kv random <key>",
+  [Get N random entries from a history or list key. Entries are printed
+  with their ID, value, and timestamp.
+
+  Useful for inspiration (pick a random idea), spot-checking (sample from
+  a large history), or building variety into automated workflows.
+
+  When fewer entries are available than requested, all matching entries are
+  returned and a note is printed to stderr. If a time range is specified,
+  entries are filtered first, then random sampling is applied to the
+  filtered set.],
+  flags: (
+    ([`--count <n>`], [integer], [Number of random entries to return (default: 1, must be >= 1)]),
+    ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--day <YYYY-MM-DD>`], [string], [Sample from entries on a specific day (UTC)]),
+    ([`--month <YYYY-MM>`], [string], [Sample from entries in a specific month (UTC)]),
+    ([`--week <YYYY-Www>`], [string], [Sample from entries in an ISO week, Monday to Sunday]),
+    ([`--from <YYYY-MM-DD>`], [string], [Start of date range, inclusive (UTC)]),
+    ([`--to <YYYY-MM-DD>`], [string], [End of date range, inclusive (UTC)]),
+    ([`--since <relative-or-iso>`], [string], [Sample from entries since a relative time (`30d`, `1w`, `2h`, `30m`) or ISO-8601 timestamp]),
+  ),
+  examples: (
+    "mx kv random shipped",
+    "mx kv random shipped --count 5",
+    "mx kv random ideas --count 1",
+    "mx kv random shipped --count 3 --since 30d",
+    "mx kv random decisions --month 2026-04 --count 3",
   ),
 )
 
@@ -351,16 +390,16 @@ lists support `pop`. Only history supports `since` (time-based queries).
 
 == Time-range queries <time-range-queries>
 
-The `last`, `search`, and `count` subcommands accept time-range flags that
-filter entries by their timestamp before any other processing. This lets you
-answer questions like "what did I ship last Tuesday?" or "how many decisions
-were recorded in April?" without scanning the full history.
+The `last`, `search`, `count`, and `random` subcommands accept time-range
+flags that filter entries by their timestamp before any other processing. This
+lets you answer questions like "what did I ship last Tuesday?" or "how many
+decisions were recorded in April?" without scanning the full history.
 
 === Available flags
 
 All time-range flags are mutually exclusive -- you can use one shorthand
-(`--day`, `--month`, `--week`) or one explicit range (`--from`/`--to`), but
-not both.
+(`--day`, `--month`, `--week`, `--since`) or one explicit range
+(`--from`/`--to`), but not both.
 
 #table(
   columns: (auto, auto, 1fr),
@@ -368,6 +407,7 @@ not both.
   [`--day`], [`YYYY-MM-DD`], [All entries from that calendar day (00:00 to 23:59 UTC)],
   [`--month`], [`YYYY-MM`], [All entries from that calendar month (first day to last day, UTC)],
   [`--week`], [`YYYY-Www`], [All entries from that ISO week (Monday 00:00 to Sunday 23:59 UTC)],
+  [`--since`], [relative or ISO-8601], [All entries from the given point in time until now. Relative formats: `30d` (days), `1w` (weeks), `2h` (hours), `30m` (minutes). Also accepts full ISO-8601 timestamps.],
   [`--from`], [`YYYY-MM-DD`], [Start of range, inclusive (midnight UTC). Can be used alone (implies "to now")],
   [`--to`], [`YYYY-MM-DD`], [End of range, inclusive (end of day UTC). Can be used alone (implies "from the beginning")],
 )
@@ -378,11 +418,16 @@ any time on that day are included.
 === Interaction with `--count`
 
 When both a time range and `--count` are specified, the time range is applied
-first, then `--count` limits the result. For example:
+first, then `--count` limits the result. This applies to both `last` (which
+takes the N most recent from the filtered set) and `random` (which samples N
+entries from the filtered set).
 
 ```bash
 # The 5 most recent entries from April 2026
 mx kv last shipped --month 2026-04 --count 5
+
+# 3 random entries from the last 30 days
+mx kv random shipped --since 30d --count 3
 ```
 
 === Examples
@@ -400,24 +445,41 @@ mx kv last shipped --week 2026-W17
 # Everything shipped in the first half of April
 mx kv last shipped --from 2026-04-01 --to 2026-04-15
 
+# Everything shipped in the last week
+mx kv last shipped --since 1w
+
 # Search within a time window
 mx kv search shipped "feature" --month 2026-04
 
 # Count entries on a specific day
 mx kv count shipped --day 2026-05-07
+
+# Count entries from the last 30 days
+mx kv count shipped --since 30d
+
+# Random entry from the last 2 hours
+mx kv random shipped --since 2h
 ```
 
-=== Relationship to `since`
+=== Relationship to `since` subcommand
 
-The `since` subcommand handles _relative_ time queries (`1h`, `7d`, `2w`).
-Time-range flags handle _absolute_ time queries (specific dates, months,
-weeks). They are complementary tools -- `since` is for "what happened
-recently?" while time-range flags are for "what happened in this specific
-period?"
+The `since` subcommand (`mx kv since <key> <timeref>`) is a standalone command
+that returns all history entries since a time reference. It only works on
+history keys and predates the time-range flag system.
 
-#note[Time-range flags are only available on `last`, `search`, and `count`.
-The `since` subcommand is unchanged and continues to work with relative and
-ISO-8601 absolute timestamps.]
+The `--since` flag brings relative time filtering to all time-range-aware
+subcommands (`last`, `search`, `count`, `random`) and works on both history
+and list types. It accepts the same relative formats (`30d`, `1w`, `2h`, `30m`)
+and ISO-8601 timestamps.
+
+Use the `since` subcommand when you want a quick "everything since X" dump
+from a history key. Use the `--since` flag when you want to combine relative
+time filtering with other operations like counting, searching, or random
+sampling, or when you need it on a list key.
+
+#note[Time-range flags (`--day`, `--month`, `--week`, `--since`,
+`--from`/`--to`) are available on `last`, `search`, `count`, and `random`.
+The `since` subcommand is unchanged and continues to work for history keys.]
 
 == Management
 
@@ -464,8 +526,8 @@ History, list, and state keys can be linked to a memory graph entry via the
 (a `kn-` ID), bridging fast local state with the persistent knowledge graph.
 
 When a memory link is set, commands that read the key (`get`, `last`, `since`,
-`search`, `dump`) can resolve the link with `--memory`, which fetches the
-linked entry from SurrealDB and prints its title, category, and body.
+`search`, `random`, `dump`) can resolve the link with `--memory`, which fetches
+the linked entry from SurrealDB and prints its title, category, and body.
 
 === Setting a memory link
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,13 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
+fn parse_nonzero_usize(s: &str) -> Result<usize, String> {
+    let n: usize = s.parse().map_err(|e| format!("{e}"))?;
+    if n == 0 {
+        return Err("value must be at least 1".to_string());
+    }
+    Ok(n)
+}
+
 #[derive(Parser)]
 #[command(name = "mx")]
 #[command(about = "Tsunderground CLI - memory, workflow, and identity tooling")]
@@ -1657,7 +1665,7 @@ pub struct TimeRangeArgs {
     #[arg(long = "to", conflicts_with_all = ["day", "month", "week", "since"])]
     pub range_to: Option<String>,
 
-    /// Filter to entries since a relative time (e.g. 30d, 1w, 2h, 30m)
+    /// Filter entries since a relative time (e.g. 30d, 1w, 2h) or ISO-8601 timestamp
     #[arg(long, conflicts_with_all = ["day", "month", "week", "range_from", "range_to"])]
     pub since: Option<String>,
 }
@@ -1805,13 +1813,13 @@ pub enum KvCommands {
         time_range: TimeRangeArgs,
     },
 
-    /// Get random entries from a history or list
+    /// Get N random entries from a history or list
     Random {
         /// Key name
         key: String,
 
         /// Number of random entries (default: 1)
-        #[arg(long, default_value = "1")]
+        #[arg(long, default_value = "1", value_parser = parse_nonzero_usize)]
         count: usize,
 
         /// Resolve and display linked memory entry

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1631,31 +1631,35 @@ pub enum DumpFormat {
     Compact,
 }
 
-/// Time-range filters for kv `last`, `search`, and `count` subcommands.
+/// Time-range filters for kv `last`, `search`, `count`, and `random` subcommands.
 ///
-/// All flags are mutually exclusive: `--day`, `--month`, `--week` conflict
-/// with each other and with `--from`/`--to`.
+/// All flags are mutually exclusive: `--day`, `--month`, `--week`, `--since`
+/// conflict with each other and with `--from`/`--to`.
 #[derive(Args, Clone, Default, Debug)]
 pub struct TimeRangeArgs {
     /// Filter by specific day (YYYY-MM-DD, UTC)
-    #[arg(long, conflicts_with_all = ["month", "week", "range_from", "range_to"])]
+    #[arg(long, conflicts_with_all = ["month", "week", "range_from", "range_to", "since"])]
     pub day: Option<String>,
 
     /// Filter by month (YYYY-MM, UTC)
-    #[arg(long, conflicts_with_all = ["day", "week", "range_from", "range_to"])]
+    #[arg(long, conflicts_with_all = ["day", "week", "range_from", "range_to", "since"])]
     pub month: Option<String>,
 
     /// Filter by ISO week (YYYY-Www, e.g. 2026-W17)
-    #[arg(long, conflicts_with_all = ["day", "month", "range_from", "range_to"])]
+    #[arg(long, conflicts_with_all = ["day", "month", "range_from", "range_to", "since"])]
     pub week: Option<String>,
 
     /// Start of date range, inclusive (YYYY-MM-DD, UTC)
-    #[arg(long = "from", conflicts_with_all = ["day", "month", "week"])]
+    #[arg(long = "from", conflicts_with_all = ["day", "month", "week", "since"])]
     pub range_from: Option<String>,
 
     /// End of date range, inclusive (YYYY-MM-DD, UTC)
-    #[arg(long = "to", conflicts_with_all = ["day", "month", "week"])]
+    #[arg(long = "to", conflicts_with_all = ["day", "month", "week", "since"])]
     pub range_to: Option<String>,
+
+    /// Filter to entries since a relative time (e.g. 30d, 1w, 2h, 30m)
+    #[arg(long, conflicts_with_all = ["day", "month", "week", "range_from", "range_to"])]
+    pub since: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -1794,6 +1798,23 @@ pub enum KvCommands {
         query: String,
 
         /// Resolve and display linked memory entry (kn- reference)
+        #[arg(long)]
+        memory: bool,
+
+        #[command(flatten)]
+        time_range: TimeRangeArgs,
+    },
+
+    /// Get random entries from a history or list
+    Random {
+        /// Key name
+        key: String,
+
+        /// Number of random entries (default: 1)
+        #[arg(long, default_value = "1")]
+        count: usize,
+
+        /// Resolve and display linked memory entry
         #[arg(long)]
         memory: bool,
 

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -253,6 +253,27 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             }
         }
 
+        KvCommands::Random {
+            key,
+            count,
+            memory,
+            time_range,
+        } => {
+            let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
+            match store.random(&key, count, range.as_ref()) {
+                Ok(items) => {
+                    for item in &items {
+                        println!("{}", item);
+                    }
+                    if memory {
+                        resolve_memory(&store, &key, verbose);
+                    }
+                    Ok(kv::EXIT_OK)
+                }
+                Err(e) => handle_kv_err(e),
+            }
+        }
+
         KvCommands::Since {
             key,
             timeref,

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -866,6 +866,88 @@ impl KvStore {
         }
     }
 
+    /// Get random entries from a history or list, formatted with IDs and timestamps.
+    ///
+    /// When `range` is provided, entries are filtered by timestamp first, then
+    /// `count` random items are sampled from the filtered set. If fewer entries
+    /// are available than requested, all matching entries are returned and a note
+    /// is printed to stderr.
+    pub fn random(
+        &self,
+        key: &str,
+        count: usize,
+        range: Option<&TimeRange>,
+    ) -> Result<Vec<String>, KvError> {
+        use rand::seq::IndexedRandom;
+
+        let def = self.key_def(key)?;
+
+        // Shared sampling + formatting closure. Takes a filtered vec of
+        // (value, id, ts) tuples and returns formatted strings.
+        let sample = |filtered: Vec<(&str, u64, &str)>, count: usize| -> Vec<String> {
+            if filtered.is_empty() {
+                return vec![];
+            }
+            let take = count.min(filtered.len());
+            let mut rng = rand::rng();
+            let chosen: Vec<_> = filtered.choose_multiple(&mut rng, take).collect();
+            chosen
+                .into_iter()
+                .map(|(value, id, ts)| {
+                    if ts.is_empty() {
+                        format!("{}: {}", id, value)
+                    } else {
+                        format!("{}: {} ({})", id, value, ts)
+                    }
+                })
+                .collect()
+        };
+
+        match def.value_type {
+            ValueType::History => match self.data.entries.get(key) {
+                Some(DataValue::History { entries, .. }) => {
+                    let filtered: Vec<_> = entries
+                        .iter()
+                        .filter(|e| range.is_none_or(|r| ts_in_range(&e.ts, r)))
+                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str()))
+                        .collect();
+                    let available = filtered.len();
+                    if available > 0 && available < count {
+                        eprintln!(
+                            "note: only {} entries available (requested {})",
+                            available, count
+                        );
+                    }
+                    Ok(sample(filtered, count))
+                }
+                _ => Ok(vec![]),
+            },
+            ValueType::List => match self.data.entries.get(key) {
+                Some(DataValue::List { items, .. }) => {
+                    let filtered: Vec<_> = items
+                        .iter()
+                        .filter(|e| range.is_none_or(|r| ts_in_range(&e.ts, r)))
+                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str()))
+                        .collect();
+                    let available = filtered.len();
+                    if available > 0 && available < count {
+                        eprintln!(
+                            "note: only {} entries available (requested {})",
+                            available, count
+                        );
+                    }
+                    Ok(sample(filtered, count))
+                }
+                _ => Ok(vec![]),
+            },
+            _ => Err(KvError::TypeMismatch {
+                key: key.to_string(),
+                expected: "history or list".to_string(),
+                got: def.value_type.to_string(),
+            }),
+        }
+    }
+
     /// Get history entries since a given time reference.
     pub fn since(&self, key: &str, timeref: &str) -> Result<Vec<&HistoryEntry>, KvError> {
         self.assert_type(key, ValueType::History)?;
@@ -1457,6 +1539,11 @@ pub fn resolve_time_range(args: &TimeRangeArgs) -> Result<Option<TimeRange>> {
     }
     if let Some(ref week) = args.week {
         return parse_week(week).map(Some);
+    }
+    if let Some(ref since) = args.since {
+        let from = parse_timeref(since)?;
+        let to = Utc::now();
+        return Ok(Some(TimeRange { from, to }));
     }
     if args.range_from.is_some() || args.range_to.is_some() {
         return parse_date_range(args.range_from.as_deref(), args.range_to.as_deref()).map(Some);
@@ -3315,5 +3402,133 @@ max_entries = 5
         let range = parse_month("2026-04").unwrap();
         let result = store.count("flavor_history", None, Some(&range)).unwrap();
         assert_eq!(result.matched, 1);
+    }
+
+    // -- Random sampling --
+
+    #[test]
+    fn random_on_empty_returns_empty() {
+        let (store, _dir) = setup_store(test_schema());
+        let results = store.random("flavor_history", 5, None).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn random_returns_requested_count() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha").unwrap();
+        store.push("tags", "beta").unwrap();
+        store.push("tags", "gamma").unwrap();
+
+        let results = store.random("tags", 2, None).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn random_returns_all_when_count_exceeds_available() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha").unwrap();
+        store.push("tags", "beta").unwrap();
+
+        let results = store.random("tags", 10, None).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn random_type_mismatch_on_counter() {
+        let (store, _dir) = setup_store(test_schema());
+        let result = store.random("warmth", 1, None);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            KvError::TypeMismatch { key, .. } => assert_eq!(key, "warmth"),
+            other => panic!("Expected TypeMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn random_works_on_history() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let ts = DateTime::parse_from_rfc3339("2026-04-25T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        store.push_with_ts("flavor_history", "bergamot", ts).unwrap();
+        store.push_with_ts("flavor_history", "vanilla", ts).unwrap();
+
+        let results = store.random("flavor_history", 1, None).unwrap();
+        assert_eq!(results.len(), 1);
+        // Result must contain one of the pushed values
+        assert!(results[0].contains("bergamot") || results[0].contains("vanilla"));
+    }
+
+    #[test]
+    fn random_with_time_range_filters() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let ts_in = DateTime::parse_from_rfc3339("2026-04-25T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let ts_out = DateTime::parse_from_rfc3339("2026-04-20T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        store.push_with_ts("tags", "inside", ts_in).unwrap();
+        store.push_with_ts("tags", "outside", ts_out).unwrap();
+
+        let range = parse_day("2026-04-25").unwrap();
+        let results = store.random("tags", 10, Some(&range)).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].contains("inside"));
+    }
+
+    #[test]
+    fn random_with_time_range_filters_history() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let ts_in = DateTime::parse_from_rfc3339("2026-04-25T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let ts_out = DateTime::parse_from_rfc3339("2026-04-24T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        store.push_with_ts("flavor_history", "inside", ts_in).unwrap();
+        store.push_with_ts("flavor_history", "outside", ts_out).unwrap();
+
+        let range = parse_day("2026-04-25").unwrap();
+        let results = store.random("flavor_history", 10, Some(&range)).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].contains("inside"));
+    }
+
+    // -- --since resolver --
+
+    #[test]
+    fn resolve_time_range_since_relative() {
+        let args = TimeRangeArgs {
+            since: Some("1h".to_string()),
+            ..Default::default()
+        };
+        let range = resolve_time_range(&args).unwrap();
+        assert!(range.is_some());
+        let range = range.unwrap();
+        // "since 1h" means from ~1 hour ago to now
+        let one_hour_ago = Utc::now() - chrono::Duration::hours(1);
+        // Allow a few seconds of drift
+        assert!((range.from - one_hour_ago).num_seconds().abs() < 5);
+        assert!((range.to - Utc::now()).num_seconds().abs() < 5);
+    }
+
+    #[test]
+    fn resolve_time_range_since_days() {
+        let args = TimeRangeArgs {
+            since: Some("30d".to_string()),
+            ..Default::default()
+        };
+        let range = resolve_time_range(&args).unwrap();
+        assert!(range.is_some());
+        let range = range.unwrap();
+        let thirty_days_ago = Utc::now() - chrono::Duration::days(30);
+        assert!((range.from - thirty_days_ago).num_seconds().abs() < 5);
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -884,11 +884,11 @@ impl KvStore {
 
         // Shared sampling + formatting closure. Takes a filtered vec of
         // (value, id, ts) tuples and returns formatted strings.
-        let sample = |filtered: Vec<(&str, u64, &str)>, count: usize| -> Vec<String> {
+        let sample = |filtered: Vec<(&str, u64, &str)>, n: usize| -> Vec<String> {
             if filtered.is_empty() {
                 return vec![];
             }
-            let take = count.min(filtered.len());
+            let take = n.min(filtered.len());
             let mut rng = rand::rng();
             let chosen: Vec<_> = filtered.choose_multiple(&mut rng, take).collect();
             chosen
@@ -912,7 +912,9 @@ impl KvStore {
                         .map(|e| (e.value.as_str(), e.id, e.ts.as_str()))
                         .collect();
                     let available = filtered.len();
-                    if available > 0 && available < count {
+                    if available == 0 && !entries.is_empty() {
+                        eprintln!("note: no entries match the time range");
+                    } else if available > 0 && available < count {
                         eprintln!(
                             "note: only {} entries available (requested {})",
                             available, count
@@ -930,7 +932,9 @@ impl KvStore {
                         .map(|e| (e.value.as_str(), e.id, e.ts.as_str()))
                         .collect();
                     let available = filtered.len();
-                    if available > 0 && available < count {
+                    if available == 0 && !items.is_empty() {
+                        eprintln!("note: no entries match the time range");
+                    } else if available > 0 && available < count {
                         eprintln!(
                             "note: only {} entries available (requested {})",
                             available, count

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -3452,7 +3452,9 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("flavor_history", "bergamot", ts).unwrap();
+        store
+            .push_with_ts("flavor_history", "bergamot", ts)
+            .unwrap();
         store.push_with_ts("flavor_history", "vanilla", ts).unwrap();
 
         let results = store.random("flavor_history", 1, None).unwrap();
@@ -3492,8 +3494,12 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("flavor_history", "inside", ts_in).unwrap();
-        store.push_with_ts("flavor_history", "outside", ts_out).unwrap();
+        store
+            .push_with_ts("flavor_history", "inside", ts_in)
+            .unwrap();
+        store
+            .push_with_ts("flavor_history", "outside", ts_out)
+            .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         let results = store.random("flavor_history", 10, Some(&range)).unwrap();


### PR DESCRIPTION
Closes #249

## Summary

New `mx kv random` subcommand for random entry sampling from histories and lists. Supports `--count N` and time-range filtering. Also adds `--since <relative>` convenience flag to `TimeRangeArgs` (benefits `last`, `search`, `count`, and `random`).

## Files changed

- `src/cli.rs` — CLI argument definitions and subcommand wiring
- `src/kv.rs` — Core random sampling logic with constraint support
- `src/handlers/kv.rs` — Handler integration for the new subcommand

## Usage examples

```bash
mx kv random shipped --count 5
mx kv random ideas --count 1
mx kv random shipped --count 3 --since 30d
```

## Tests

- 8 new tests, 753 total passing
- Edge cases handled:
  - `count > available` returns all entries with a stderr note
  - Empty key returns empty result
  - Type mismatch errors cleanly for non-history/list types