### PR TITLE
kv: structured data (JSON blobs) on entries (#251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ mx kv inc builds
 mx kv push decisions "chose Typst for docs"
 mx kv last decisions --count 5
 
+# Structured data on entries
+mx kv push projects "palmtop DSI fix" \
+  --data '{"tags":["palmtop","i915"],"status":"active"}'
+
+# Query by structured data with --where
+mx kv search projects --where status=active
+mx kv search projects "DSI" --where status=active
+mx kv search projects --where tags=palmtop --where status=active
+mx kv last projects --where status=active --count 5
+mx kv count projects --where status=active
+
 # Time-range queries on history/list keys
 mx kv last shipped --day 2026-04-25
 mx kv last shipped --month 2026-04
@@ -147,6 +158,8 @@ mx kv random shipped --count 5
 mx kv random ideas --count 1
 mx kv random shipped --count 3 --since 30d
 ```
+
+Entries can carry structured JSON data via `--data` on push. Query entries by data fields with `--where key=value` (available on `search`, `last`, `random`, `count`). Multiple `--where` flags are ANDed. Supports exact string match, array-contains, and numeric/boolean comparison on top-level fields.
 
 Time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) are available on `last`, `search`, `count`, and `random`. All dates are UTC. The `--since` flag accepts relative times (`30d`, `1w`, `2h`, `30m`) and ISO-8601 timestamps. For a standalone relative-time query on history keys, use `mx kv since`.
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -583,8 +583,8 @@ Supported types:
   table.header([*Type*], [*Behavior*]),
   [`counter`], [Integer with optional `min`/`max` bounds. Supports `inc`, `dec`, `set`, `get`],
   [`string`], [Simple string value. Supports `set`, `get`],
-  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
-  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
+  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. Entries can carry optional structured JSON data (`--data` on push, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
+  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
   [`state`], [Named fields (like a struct). Supports `set <key> <field> <value>`, `get`],
 )
 
@@ -593,6 +593,12 @@ Supported types:
 The data file at `$MX_HOME/kv/data/{agent}.json` holds current values. All
 writes are atomic: serialize to a temp file, fsync, rename. The format is a
 flat JSON object keyed by the key names from the schema.
+
+History and list entries are stored as objects with `id`, `value`, `ts`, and an
+optional `data` field (arbitrary JSON object for structured metadata). The
+`data` field uses `#[serde(default, skip_serializing_if = "Option::is_none")]`
+for backward compatibility -- files written before structured data was added
+deserialize cleanly without migration.
 
 === Per-agent keying
 

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -129,8 +129,8 @@ mx codex search "migration"
 === KV
 
 The #link("kv.html")[kv] store provides fast local state per agent. Counters,
-strings, lists, and history with time-based queries. Schema-driven with
-defaults.
+strings, lists, and history with time-based queries and structured data
+filtering. Schema-driven with defaults.
 
 ```bash
 mx kv set session.goal "ship the docs"
@@ -140,6 +140,12 @@ mx kv last decisions --count 5
 mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
 mx kv random decisions --count 3
+
+# Attach structured data and query it
+mx kv push projects "palmtop DSI fix" \
+  --data '{"tags":["palmtop","i915"],"status":"active"}'
+mx kv search projects --where status=active
+mx kv search projects "DSI" --where tags=palmtop
 ```
 
 === State

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -65,13 +65,16 @@ mx codex read <archive-id> --clean
 === Local key-value store
 
 #link("kv.html")[KV] provides fast per-agent state: counters, strings, lists,
-and history with time-based queries.
+and history with time-based queries and structured data filtering.
 
 ```bash
 mx kv set session.goal "ship the docs"
 mx kv get session.goal
 mx kv push decisions "chose Typst over markdown"
 mx kv get shipped --id 35-64
+mx kv push projects "palmtop DSI fix" \
+  --data '{"tags":["palmtop","i915"],"status":"active"}'
+mx kv search projects --where status=active
 ```
 
 == Installation

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -7,6 +7,7 @@ for operational state that needs to be fast and local. Counters, strings, lists,
 timestamped history, and structured state fields -- all backed by a TOML schema
 file and a JSON data file. No networking, no database. Reads and writes are
 direct file operations with atomic saves (serialize to tmp, fsync, rename).
+History and list entries can carry structured JSON data for queryable metadata.
 
 Use KV for state that lives within a single agent session or across sessions:
 build counters, track decisions as a history log, maintain a todo list, or
@@ -21,8 +22,8 @@ Every key has a type declared in the schema. Five types are supported:
 
 / string: A single text value. Has an optional `default`.
 / counter: An integer with optional `min`, `max`, and `default`. Clamped on every write.
-/ history: A timestamped append-only log. Newest entries first. Has an optional `max_entries` cap that drops the oldest entries on overflow.
-/ list: An ordered collection with timestamps. Supports push and pop. Also has an optional `max_entries` cap.
+/ history: A timestamped append-only log. Newest entries first. Has an optional `max_entries` cap that drops the oldest entries on overflow. Entries can carry optional structured JSON data.
+/ list: An ordered collection with timestamps. Supports push and pop. Also has an optional `max_entries` cap. Entries can carry optional structured JSON data.
 / state: A structured record with named fields. Fields are declared in the schema and validated on write.
 
 === Schema files
@@ -211,7 +212,8 @@ The difference is semantic: history is append-only (newest first, no pop),
 while lists support push/pop and maintain insertion order.
 
 Both types support `push`, `last`, `search`, `count`, `random`, `remove`, and
-entry lookup by ID via `get --id`.
+entry lookup by ID via `get --id`. Both support structured data on entries
+(`--data` on push) and structured data filtering (`--where` on queries).
 Only lists support `pop`. Only history supports `since` (time-based queries).
 
 === push
@@ -226,10 +228,20 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   truncated after the push.
 
   For *list* keys, new entries are appended to the end. The same
-  `max_entries` truncation applies, dropping from the front.],
+  `max_entries` truncation applies, dropping from the front.
+
+  Use `--data` to attach a JSON object to the entry. The data is stored
+  alongside the value and timestamp, and is displayed inline in output.
+  See #link(<structured-data>)[Structured data] for details and query
+  examples.],
+  flags: (
+    ([`--data <json>`], [string], [Attach a JSON object to the entry. Must be a valid JSON object (not an array, string, or other type).]),
+  ),
   examples: (
     "mx kv push decisions \"chose Typst for docs\"",
     "mx kv push todos \"write tests for kv handler\"",
+    "mx kv push projects \"palmtop DSI fix\" --data '{\"tags\":[\"palmtop\",\"i915\"],\"status\":\"active\"}'",
+    "mx kv push shipped \"v0.1.156\" --data '{\"pr\":305,\"scope\":\"kv\"}'",
   ),
 )
 
@@ -258,10 +270,15 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   first). For list keys, "last" means the tail of the list.
 
   Time-range flags narrow the result set before `--count` is applied. See
-  #link(<time-range-queries>)[Time-range queries] for details and examples.],
+  #link(<time-range-queries>)[Time-range queries] for details and examples.
+
+  The `--where` flag filters entries by structured data fields. Multiple
+  `--where` flags are ANDed. See #link(<structured-data>)[Structured data]
+  for filtering semantics.],
   flags: (
     ([`--count <n>`], [integer], [Number of entries to return (default: 1)]),
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Entries from a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Entries from a specific month (UTC)]),
     ([`--week <YYYY-Www>`], [string], [Entries from an ISO week, Monday to Sunday]),
@@ -277,6 +294,8 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv last shipped --month 2026-04",
     "mx kv last shipped --month 2026-04 --count 5",
     "mx kv last shipped --since 1w",
+    "mx kv last projects --where status=active",
+    "mx kv last projects --where status=active --count 3",
   ),
 )
 
@@ -305,14 +324,23 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 === search
 
 #command(
-  "mx kv search <key> <query>",
-  [Search entries in a list or history by case-insensitive substring match.
-  Prints matching entries with their ID, value, and timestamp.
+  "mx kv search <key> [query]",
+  [Search entries in a list or history by case-insensitive substring match
+  and/or structured data filters. Prints matching entries with their ID,
+  value, timestamp, and any attached data.
+
+  The text query is optional when `--where` filters are provided. You can
+  search by text alone, by structured data alone, or by both. At least one
+  of a text query or `--where` filter must be given.
+
+  Multiple `--where` flags are ANDed. See
+  #link(<structured-data>)[Structured data] for filtering semantics.
 
   Time-range flags narrow the search to entries within the specified period.
   See #link(<time-range-queries>)[Time-range queries] for details.],
   flags: (
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Search within a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Search within a specific month (UTC)]),
     ([`--week <YYYY-Www>`], [string], [Search within an ISO week, Monday to Sunday]),
@@ -325,6 +353,9 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv search todos \"test\"",
     "mx kv search shipped \"feature\" --month 2026-04",
     "mx kv search shipped \"feature\" --since 30d",
+    "mx kv search projects --where status=active",
+    "mx kv search projects \"DSI\" --where status=active",
+    "mx kv search projects --where tags=palmtop --where status=active",
   ),
 )
 
@@ -332,20 +363,25 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 
 #command(
   "mx kv count <key> [value]",
-  [Count entries in a list or history. Without a value filter, prints the
-  total count. With a value filter, prints the matched count, total, and
-  percentage.
+  [Count entries in a list or history. Without a value filter or `--where`,
+  prints the total count. With a value filter, `--where`, or both, prints
+  the matched count, total, and percentage.
 
   Unfiltered output: `<count>` or `<count> (latest: <timestamp>)`.
 
   Filtered output: `<matched>/<total> (<pct>%) --- latest: <timestamp>`.
 
   The percentage display makes it easy to gauge ratios at a glance -- for
-  example, what fraction of your decisions mentioned a particular topic.
+  example, what fraction of your decisions mentioned a particular topic,
+  or how many entries have `status=active` in their structured data.
+
+  Multiple `--where` flags are ANDed. See
+  #link(<structured-data>)[Structured data] for filtering semantics.
 
   Time-range flags restrict the count to entries within the specified period.
   See #link(<time-range-queries>)[Time-range queries] for details.],
   flags: (
+    ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Count within a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Count within a specific month (UTC)]),
     ([`--week <YYYY-Www>`], [string], [Count within an ISO week, Monday to Sunday]),
@@ -360,6 +396,8 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv count shipped --day 2026-05-07",
     "mx kv count shipped --from 2026-04-01 --to 2026-04-15",
     "mx kv count shipped --since 1w",
+    "mx kv count projects --where status=active",
+    "mx kv count projects --where status=active --since 30d",
   ),
 )
 
@@ -374,12 +412,16 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   a large history), or building variety into automated workflows.
 
   When fewer entries are available than requested, all matching entries are
-  returned and a note is printed to stderr. If a time range is specified,
-  entries are filtered first, then random sampling is applied to the
-  filtered set.],
+  returned and a note is printed to stderr. If a time range or `--where`
+  filter is specified, entries are filtered first, then random sampling is
+  applied to the filtered set.
+
+  Multiple `--where` flags are ANDed. See
+  #link(<structured-data>)[Structured data] for filtering semantics.],
   flags: (
     ([`--count <n>`], [integer], [Number of random entries to return (default: 1, must be >= 1)]),
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Sample from entries on a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Sample from entries in a specific month (UTC)]),
     ([`--week <YYYY-Www>`], [string], [Sample from entries in an ISO week, Monday to Sunday]),
@@ -393,6 +435,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv random ideas --count 1",
     "mx kv random shipped --count 3 --since 30d",
     "mx kv random decisions --month 2026-04 --count 3",
+    "mx kv random projects --where status=active --count 3",
   ),
 )
 
@@ -508,6 +551,103 @@ sampling, or when you need it on a list key.
 #note[Time-range flags (`--day`, `--month`, `--week`, `--since`,
 `--from`/`--to`) are available on `last`, `search`, `count`, and `random`.
 The `since` subcommand is unchanged and continues to work for history keys.]
+
+== Structured data <structured-data>
+
+History and list entries can carry structured JSON data alongside their text
+value. This turns each entry from a plain string into a string with queryable
+metadata -- tags, status, priority, or any key-value pairs relevant to the
+domain.
+
+=== Pushing data
+
+Use `--data` on `push` to attach a JSON object to the entry:
+
+```bash
+mx kv push projects "palmtop DSI fix" \
+  --data '{"tags":["palmtop","i915"],"status":"active"}'
+
+mx kv push shipped "v0.1.156" \
+  --data '{"pr":305,"scope":"kv"}'
+```
+
+The data must be a valid JSON object. Arrays, strings, numbers, and other
+non-object JSON types are rejected. If `--data` is omitted, the entry has no
+structured data (backward compatible with all existing entries).
+
+=== Output format
+
+Entries with structured data display the JSON inline after the timestamp:
+
+```
+42: palmtop DSI fix (2026-05-08T14:30:00Z) {"tags":["palmtop","i915"],"status":"active"}
+43: display rotation patch (2026-05-08T15:00:00Z)
+```
+
+Entries without data look exactly as they always have. The data suffix appears
+on all commands that display entries: `get`, `last`, `search`, `since`, `pop`,
+`random`, and `dump`.
+
+=== Filtering with `--where`
+
+The `--where` flag queries entries by their structured data fields. It is
+available on `search`, `last`, `random`, and `count`.
+
+```bash
+# Exact match on a string field
+mx kv search projects --where status=active
+
+# Array-contains: matches if the array includes the value
+mx kv search projects --where tags=palmtop
+
+# Combine text search with structured data filter
+mx kv search projects "DSI" --where status=active
+
+# Multiple --where flags are ANDed
+mx kv search projects --where tags=palmtop --where status=active
+
+# Works on last, random, and count too
+mx kv last projects --where status=active --count 5
+mx kv random projects --where status=active --count 3
+mx kv count projects --where status=active
+```
+
+=== Matching semantics
+
+Each `--where` clause has the form `key=value` (split on the first `=`). The
+match is evaluated against the top-level fields of the entry's JSON data:
+
+/ String field: The field value must equal the clause value exactly.
+/ Array field: The array must contain a string element equal to the clause value.
+/ Number field: The field's string representation must equal the clause value (e.g., `--where pr=305`).
+/ Boolean field: Matches against `true` or `false` as strings.
+/ Missing field: Does not match. Entries without data never match any `--where` clause.
+
+Only top-level fields are supported. Dot-path traversal (e.g.,
+`--where nested.field=value`) is not available.
+
+When multiple `--where` clauses are given, ALL must match (AND logic). There is
+no OR operator -- use separate queries if you need union semantics.
+
+=== Combining with other filters
+
+The `--where` flag composes with both text queries and time-range flags. All
+filters are applied together:
+
+```bash
+# Text + where + time range: all three must match
+mx kv search projects "DSI" --where status=active --since 30d
+```
+
+Filter application order: time range first, then `--where`, then text query.
+The `--count` limit is applied last.
+
+=== Backward compatibility
+
+Structured data is fully backward compatible. Existing data files written
+before this feature was added continue to work without migration. Entries
+without data are simply treated as having no structured fields -- they will
+not match any `--where` clause, but they are otherwise unaffected.
 
 == Management
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1754,7 +1754,7 @@ pub enum KvCommands {
         #[arg(long)]
         memory: bool,
 
-        /// Filter by structured data fields (key=value, repeatable)
+        /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]
         where_clauses: Vec<String>,
 
@@ -1821,7 +1821,7 @@ pub enum KvCommands {
         #[arg(long)]
         memory: bool,
 
-        /// Filter by structured data fields (key=value, repeatable)
+        /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]
         where_clauses: Vec<String>,
 
@@ -1842,7 +1842,7 @@ pub enum KvCommands {
         #[arg(long)]
         memory: bool,
 
-        /// Filter by structured data fields (key=value, repeatable)
+        /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]
         where_clauses: Vec<String>,
 
@@ -1858,7 +1858,7 @@ pub enum KvCommands {
         /// Count only entries matching this substring
         value: Option<String>,
 
-        /// Filter by structured data fields (key=value, repeatable)
+        /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]
         where_clauses: Vec<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1729,6 +1729,10 @@ pub enum KvCommands {
 
         /// Value to push
         value: String,
+
+        /// Attach structured JSON data to this entry
+        #[arg(long)]
+        data: Option<String>,
     },
 
     /// Pop the last value from a list
@@ -1749,6 +1753,10 @@ pub enum KvCommands {
         /// Resolve and display linked memory entry (kn- reference)
         #[arg(long)]
         memory: bool,
+
+        /// Filter by structured data fields (key=value, repeatable)
+        #[arg(long = "where")]
+        where_clauses: Vec<String>,
 
         #[command(flatten)]
         time_range: TimeRangeArgs,
@@ -1801,17 +1809,21 @@ pub enum KvCommands {
         all: bool,
     },
 
-    /// Search entries in a list/history by substring
+    /// Search entries in a list/history by substring and/or structured data filters
     Search {
         /// Key name
         key: String,
 
-        /// Search query (case-insensitive substring)
-        query: String,
+        /// Search query (case-insensitive substring match on entry values)
+        query: Option<String>,
 
         /// Resolve and display linked memory entry (kn- reference)
         #[arg(long)]
         memory: bool,
+
+        /// Filter by structured data fields (key=value, repeatable)
+        #[arg(long = "where")]
+        where_clauses: Vec<String>,
 
         #[command(flatten)]
         time_range: TimeRangeArgs,
@@ -1830,6 +1842,10 @@ pub enum KvCommands {
         #[arg(long)]
         memory: bool,
 
+        /// Filter by structured data fields (key=value, repeatable)
+        #[arg(long = "where")]
+        where_clauses: Vec<String>,
+
         #[command(flatten)]
         time_range: TimeRangeArgs,
     },
@@ -1841,6 +1857,10 @@ pub enum KvCommands {
 
         /// Count only entries matching this substring
         value: Option<String>,
+
+        /// Filter by structured data fields (key=value, repeatable)
+        #[arg(long = "where")]
+        where_clauses: Vec<String>,
 
         #[command(flatten)]
         time_range: TimeRangeArgs,

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -157,6 +157,20 @@ fn parse_id_spec(spec: &str) -> Result<Vec<u64>, String> {
     Ok(ids)
 }
 
+/// Parse `--where` clause strings into `(key, value)` tuples.
+///
+/// Each clause is split on the first `=` character. Clauses without `=` are
+/// silently skipped (the CLI layer already validates format in practice).
+fn parse_where_clauses(clauses: &[String]) -> Vec<(String, String)> {
+    clauses
+        .iter()
+        .filter_map(|clause| {
+            let (k, v) = clause.split_once('=')?;
+            Some((k.to_string(), v.to_string()))
+        })
+        .collect()
+}
+
 /// Handle all `mx kv` subcommands. Returns the exit code directly.
 pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
     let mut store = match KvStore::from_env() {
@@ -188,10 +202,11 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         // History entries always have a timestamp; list entries may not.
                         // We check for empty ts to handle both types uniformly.
                         for hit in &hits {
+                            let data_suffix = kv::format_data_suffix(&hit.data);
                             if hit.ts.is_empty() {
-                                println!("{}: {}", hit.id, hit.value);
+                                println!("{}: {}{}", hit.id, hit.value, data_suffix);
                             } else {
-                                println!("{}: {} ({})", hit.id, hit.value, hit.ts);
+                                println!("{}: {} ({}){}", hit.id, hit.value, hit.ts, data_suffix);
                             }
                         }
 
@@ -325,21 +340,50 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             Err(e) => handle_kv_err(e),
         },
 
-        KvCommands::Push { key, value } => match store.push(&key, &value) {
-            Ok(()) => {
-                store.save()?;
-                Ok(kv::EXIT_OK)
+        KvCommands::Push { key, value, data } => {
+            // Parse --data as JSON object if provided
+            let parsed_data = match data {
+                Some(ref json_str) => {
+                    let val: serde_json::Value = match serde_json::from_str(json_str) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("Error: invalid JSON for --data: {}", e);
+                            return Ok(kv::EXIT_INVALID_INPUT);
+                        }
+                    };
+                    if !val.is_object() {
+                        eprintln!("Error: --data must be a JSON object, got {}", match val {
+                            serde_json::Value::Array(_) => "array",
+                            serde_json::Value::String(_) => "string",
+                            serde_json::Value::Number(_) => "number",
+                            serde_json::Value::Bool(_) => "boolean",
+                            serde_json::Value::Null => "null",
+                            _ => "non-object",
+                        });
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
+                    Some(val)
+                }
+                None => None,
+            };
+
+            match store.push(&key, &value, parsed_data) {
+                Ok(()) => {
+                    store.save()?;
+                    Ok(kv::EXIT_OK)
+                }
+                Err(e) => handle_kv_err(e),
             }
-            Err(e) => handle_kv_err(e),
-        },
+        }
 
         KvCommands::Pop { key } => match store.pop(&key) {
             Ok(Some(entry)) => {
                 store.save()?;
+                let data_suffix = kv::format_data_suffix(&entry.data);
                 if entry.ts.is_empty() {
-                    println!("{}: {}", entry.id, entry.value);
+                    println!("{}: {}{}", entry.id, entry.value, data_suffix);
                 } else {
-                    println!("{}: {} ({})", entry.id, entry.value, entry.ts);
+                    println!("{}: {} ({}){}", entry.id, entry.value, entry.ts, data_suffix);
                 }
                 Ok(kv::EXIT_OK)
             }
@@ -354,10 +398,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             key,
             count,
             memory,
+            where_clauses,
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            match store.last(&key, count, range.as_ref()) {
+            let parsed_where = parse_where_clauses(&where_clauses);
+            match store.last(&key, count, range.as_ref(), &parsed_where) {
                 Ok(items) => {
                     for item in &items {
                         println!("{}", item);
@@ -375,10 +421,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             key,
             count,
             memory,
+            where_clauses,
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            match store.random(&key, count, range.as_ref()) {
+            let parsed_where = parse_where_clauses(&where_clauses);
+            match store.random(&key, count, range.as_ref(), &parsed_where) {
                 Ok(items) => {
                     for item in &items {
                         println!("{}", item);
@@ -399,7 +447,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         } => match store.since(&key, &timeref) {
             Ok(entries) => {
                 for entry in &entries {
-                    println!("{}: {} ({})", entry.id, entry.value, entry.ts);
+                    println!(
+                        "{}: {} ({}){}",
+                        entry.id,
+                        entry.value,
+                        entry.ts,
+                        kv::format_data_suffix(&entry.data)
+                    );
                 }
                 if memory {
                     resolve_memory(&store, &key, verbose);
@@ -464,20 +518,30 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             key,
             query,
             memory,
+            where_clauses,
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            match store.search(&key, &query, range.as_ref()) {
+            let parsed_where = parse_where_clauses(&where_clauses);
+
+            // Must have at least a query or where clauses
+            if query.is_none() && parsed_where.is_empty() {
+                eprintln!("Error: provide a search query or --where filters");
+                return Ok(kv::EXIT_INVALID_INPUT);
+            }
+
+            match store.search(&key, query.as_deref(), range.as_ref(), &parsed_where) {
                 Ok(hits) => {
                     if hits.is_empty() {
                         eprintln!("No matching entries");
                         Ok(kv::EXIT_OK)
                     } else {
                         for hit in &hits {
+                            let data_suffix = kv::format_data_suffix(&hit.data);
                             if hit.ts.is_empty() {
-                                println!("{}: {}", hit.id, hit.value);
+                                println!("{}: {}{}", hit.id, hit.value, data_suffix);
                             } else {
-                                println!("{}: {} ({})", hit.id, hit.value, hit.ts);
+                                println!("{}: {} ({}){}", hit.id, hit.value, hit.ts, data_suffix);
                             }
                         }
                         if memory {
@@ -493,10 +557,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         KvCommands::Count {
             key,
             value,
+            where_clauses,
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            match store.count(&key, value.as_deref(), range.as_ref()) {
+            let parsed_where = parse_where_clauses(&where_clauses);
+            match store.count(&key, value.as_deref(), range.as_ref(), &parsed_where) {
                 Ok(result) => {
                     match result.total {
                         Some(total) => {
@@ -645,5 +711,43 @@ mod tests {
     #[test]
     fn parse_range_too_large() {
         assert!(parse_id_spec("1-20000").is_err());
+    }
+
+    // -- parse_where_clauses --
+
+    #[test]
+    fn parse_where_clauses_basic() {
+        let clauses = vec!["status=active".to_string(), "priority=high".to_string()];
+        let parsed = parse_where_clauses(&clauses);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0], ("status".to_string(), "active".to_string()));
+        assert_eq!(parsed[1], ("priority".to_string(), "high".to_string()));
+    }
+
+    #[test]
+    fn parse_where_clauses_value_with_equals() {
+        // Value might contain = sign (split on first only)
+        let clauses = vec!["query=key=value".to_string()];
+        let parsed = parse_where_clauses(&clauses);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0], ("query".to_string(), "key=value".to_string()));
+    }
+
+    #[test]
+    fn parse_where_clauses_empty() {
+        let clauses: Vec<String> = vec![];
+        let parsed = parse_where_clauses(&clauses);
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn parse_where_clauses_skips_invalid() {
+        let clauses = vec![
+            "valid=clause".to_string(),
+            "noequalssign".to_string(),
+            "also=valid".to_string(),
+        ];
+        let parsed = parse_where_clauses(&clauses);
+        assert_eq!(parsed.len(), 2);
     }
 }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -352,14 +352,17 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         }
                     };
                     if !val.is_object() {
-                        eprintln!("Error: --data must be a JSON object, got {}", match val {
-                            serde_json::Value::Array(_) => "array",
-                            serde_json::Value::String(_) => "string",
-                            serde_json::Value::Number(_) => "number",
-                            serde_json::Value::Bool(_) => "boolean",
-                            serde_json::Value::Null => "null",
-                            _ => "non-object",
-                        });
+                        eprintln!(
+                            "Error: --data must be a JSON object, got {}",
+                            match val {
+                                serde_json::Value::Array(_) => "array",
+                                serde_json::Value::String(_) => "string",
+                                serde_json::Value::Number(_) => "number",
+                                serde_json::Value::Bool(_) => "boolean",
+                                serde_json::Value::Null => "null",
+                                _ => "non-object",
+                            }
+                        );
                         return Ok(kv::EXIT_INVALID_INPUT);
                     }
                     Some(val)
@@ -383,7 +386,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 if entry.ts.is_empty() {
                     println!("{}: {}{}", entry.id, entry.value, data_suffix);
                 } else {
-                    println!("{}: {} ({}){}", entry.id, entry.value, entry.ts, data_suffix);
+                    println!(
+                        "{}: {} ({}){}",
+                        entry.id, entry.value, entry.ts, data_suffix
+                    );
                 }
                 Ok(kv::EXIT_OK)
             }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -159,16 +159,22 @@ fn parse_id_spec(spec: &str) -> Result<Vec<u64>, String> {
 
 /// Parse `--where` clause strings into `(key, value)` tuples.
 ///
-/// Each clause is split on the first `=` character. Clauses without `=` are
-/// silently skipped (the CLI layer already validates format in practice).
-fn parse_where_clauses(clauses: &[String]) -> Vec<(String, String)> {
-    clauses
-        .iter()
-        .filter_map(|clause| {
-            let (k, v) = clause.split_once('=')?;
-            Some((k.to_string(), v.to_string()))
-        })
-        .collect()
+/// Each clause is split on the first `=` character. A clause without `=`
+/// returns an error describing the expected format.
+fn parse_where_clauses(clauses: &[String]) -> Result<Vec<(String, String)>, String> {
+    let mut result = Vec::with_capacity(clauses.len());
+    for clause in clauses {
+        match clause.split_once('=') {
+            Some((k, v)) => result.push((k.to_string(), v.to_string())),
+            None => {
+                return Err(format!(
+                    "invalid --where clause '{}': expected format key=value",
+                    clause
+                ));
+            }
+        }
+    }
+    Ok(result)
 }
 
 /// Handle all `mx kv` subcommands. Returns the exit code directly.
@@ -360,7 +366,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                 serde_json::Value::Number(_) => "number",
                                 serde_json::Value::Bool(_) => "boolean",
                                 serde_json::Value::Null => "null",
-                                _ => "non-object",
+                                serde_json::Value::Object(_) => unreachable!(),
                             }
                         );
                         return Ok(kv::EXIT_INVALID_INPUT);
@@ -408,7 +414,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            let parsed_where = parse_where_clauses(&where_clauses);
+            let parsed_where = match parse_where_clauses(&where_clauses) {
+                Ok(w) => w,
+                Err(msg) => {
+                    eprintln!("Error: {}", msg);
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
+            };
             match store.last(&key, count, range.as_ref(), &parsed_where) {
                 Ok(items) => {
                     for item in &items {
@@ -431,7 +443,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            let parsed_where = parse_where_clauses(&where_clauses);
+            let parsed_where = match parse_where_clauses(&where_clauses) {
+                Ok(w) => w,
+                Err(msg) => {
+                    eprintln!("Error: {}", msg);
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
+            };
             match store.random(&key, count, range.as_ref(), &parsed_where) {
                 Ok(items) => {
                     for item in &items {
@@ -528,7 +546,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            let parsed_where = parse_where_clauses(&where_clauses);
+            let parsed_where = match parse_where_clauses(&where_clauses) {
+                Ok(w) => w,
+                Err(msg) => {
+                    eprintln!("Error: {}", msg);
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
+            };
 
             // Must have at least a query or where clauses
             if query.is_none() && parsed_where.is_empty() {
@@ -567,7 +591,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             time_range,
         } => {
             let range = resolve_time_range(&time_range).map_err(KvError::Other)?;
-            let parsed_where = parse_where_clauses(&where_clauses);
+            let parsed_where = match parse_where_clauses(&where_clauses) {
+                Ok(w) => w,
+                Err(msg) => {
+                    eprintln!("Error: {}", msg);
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
+            };
             match store.count(&key, value.as_deref(), range.as_ref(), &parsed_where) {
                 Ok(result) => {
                     match result.total {
@@ -724,7 +754,7 @@ mod tests {
     #[test]
     fn parse_where_clauses_basic() {
         let clauses = vec!["status=active".to_string(), "priority=high".to_string()];
-        let parsed = parse_where_clauses(&clauses);
+        let parsed = parse_where_clauses(&clauses).unwrap();
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0], ("status".to_string(), "active".to_string()));
         assert_eq!(parsed[1], ("priority".to_string(), "high".to_string()));
@@ -734,7 +764,7 @@ mod tests {
     fn parse_where_clauses_value_with_equals() {
         // Value might contain = sign (split on first only)
         let clauses = vec!["query=key=value".to_string()];
-        let parsed = parse_where_clauses(&clauses);
+        let parsed = parse_where_clauses(&clauses).unwrap();
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0], ("query".to_string(), "key=value".to_string()));
     }
@@ -742,18 +772,19 @@ mod tests {
     #[test]
     fn parse_where_clauses_empty() {
         let clauses: Vec<String> = vec![];
-        let parsed = parse_where_clauses(&clauses);
+        let parsed = parse_where_clauses(&clauses).unwrap();
         assert!(parsed.is_empty());
     }
 
     #[test]
-    fn parse_where_clauses_skips_invalid() {
+    fn parse_where_clauses_rejects_invalid() {
         let clauses = vec![
             "valid=clause".to_string(),
             "noequalssign".to_string(),
             "also=valid".to_string(),
         ];
-        let parsed = parse_where_clauses(&clauses);
-        assert_eq!(parsed.len(), 2);
+        let err = parse_where_clauses(&clauses).unwrap_err();
+        assert!(err.contains("noequalssign"));
+        assert!(err.contains("expected format key=value"));
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -330,6 +330,7 @@ impl<'de> Deserialize<'de> for DataValue {
                                 id: next_id,
                                 value: s,
                                 ts: String::new(),
+                                data: None,
                             }
                         }
                     })
@@ -349,6 +350,8 @@ pub struct HistoryEntry {
     pub id: u64,
     pub value: String,
     pub ts: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -356,6 +359,8 @@ pub struct ListEntry {
     pub id: u64,
     pub value: String,
     pub ts: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
 }
 
 /// Remove result for the CLI layer to format output.
@@ -370,6 +375,7 @@ pub struct SearchHit {
     pub id: u64,
     pub value: String,
     pub ts: String,
+    pub data: Option<serde_json::Value>,
 }
 
 /// Count result.
@@ -708,8 +714,13 @@ impl KvStore {
     }
 
     /// Push a value onto a history (with auto-timestamp) or list.
-    pub fn push(&mut self, key: &str, value: &str) -> Result<(), KvError> {
-        self.push_with_ts(key, value, Utc::now())
+    pub fn push(
+        &mut self,
+        key: &str,
+        value: &str,
+        data: Option<serde_json::Value>,
+    ) -> Result<(), KvError> {
+        self.push_with_ts(key, value, Utc::now(), data)
     }
 
     /// Push with an explicit timestamp (used by tests).
@@ -718,6 +729,7 @@ impl KvStore {
         key: &str,
         value: &str,
         ts: DateTime<Utc>,
+        data: Option<serde_json::Value>,
     ) -> Result<(), KvError> {
         let def = self.key_def(key)?.clone();
 
@@ -738,6 +750,7 @@ impl KvStore {
                                 id: next_id,
                                 value: value.to_string(),
                                 ts: ts.to_rfc3339(),
+                                data: data.clone(),
                             },
                         );
                         // Drop oldest at max_entries
@@ -767,6 +780,7 @@ impl KvStore {
                             id: next_id,
                             value: value.to_string(),
                             ts: ts.to_rfc3339(),
+                            data,
                         });
                         // Drop oldest at max_entries — single drain instead of O(n^2) remove loop
                         if let Some(max) = def.max_entries
@@ -813,11 +827,13 @@ impl KvStore {
     ///
     /// When `range` is provided, entries are filtered by timestamp first, then
     /// the `count` limit is applied to the filtered set.
+    /// When `where_clauses` is non-empty, entries must match all clauses.
     pub fn last(
         &self,
         key: &str,
         count: usize,
         range: Option<&TimeRange>,
+        where_clauses: &[(String, String)],
     ) -> Result<Vec<String>, KvError> {
         let def = self.key_def(key)?;
 
@@ -829,12 +845,23 @@ impl KvStore {
                     let filtered: Vec<_> = entries
                         .iter()
                         .rev()
-                        .filter(|e| range.is_none_or(|r| ts_in_range(&e.ts, r)))
+                        .filter(|e| {
+                            range.is_none_or(|r| ts_in_range(&e.ts, r))
+                                && where_matches(&e.data, where_clauses)
+                        })
                         .collect();
                     let start = filtered.len().saturating_sub(count);
                     Ok(filtered[start..]
                         .iter()
-                        .map(|e| format!("{}: {} ({})", e.id, e.value, e.ts))
+                        .map(|e| {
+                            format!(
+                                "{}: {} ({}){}",
+                                e.id,
+                                e.value,
+                                e.ts,
+                                format_data_suffix(&e.data)
+                            )
+                        })
                         .collect())
                 }
                 _ => Ok(vec![]),
@@ -843,16 +870,25 @@ impl KvStore {
                 Some(DataValue::List { items, .. }) => {
                     let filtered: Vec<_> = items
                         .iter()
-                        .filter(|e| range.is_none_or(|r| ts_in_range(&e.ts, r)))
+                        .filter(|e| {
+                            range.is_none_or(|r| ts_in_range(&e.ts, r))
+                                && where_matches(&e.data, where_clauses)
+                        })
                         .collect();
                     let start = filtered.len().saturating_sub(count);
                     Ok(filtered[start..]
                         .iter()
                         .map(|e| {
                             if e.ts.is_empty() {
-                                format!("{}: {}", e.id, e.value)
+                                format!("{}: {}{}", e.id, e.value, format_data_suffix(&e.data))
                             } else {
-                                format!("{}: {} ({})", e.id, e.value, e.ts)
+                                format!(
+                                    "{}: {} ({}){}",
+                                    e.id,
+                                    e.value,
+                                    e.ts,
+                                    format_data_suffix(&e.data)
+                                )
                             }
                         })
                         .collect())
@@ -873,19 +909,23 @@ impl KvStore {
     /// `count` random items are sampled from the filtered set. If fewer entries
     /// are available than requested, all matching entries are returned and a note
     /// is printed to stderr.
+    /// When `where_clauses` is non-empty, entries must match all clauses.
     pub fn random(
         &self,
         key: &str,
         count: usize,
         range: Option<&TimeRange>,
+        where_clauses: &[(String, String)],
     ) -> Result<Vec<String>, KvError> {
         use rand::seq::IndexedRandom;
 
         let def = self.key_def(key)?;
 
         // Shared sampling + formatting closure. Takes a filtered vec of
-        // (value, id, ts) tuples and returns formatted strings.
-        let sample = |filtered: Vec<(&str, u64, &str)>, n: usize| -> Vec<String> {
+        // (value, id, ts, data) tuples and returns formatted strings.
+        let sample = |filtered: Vec<(&str, u64, &str, &Option<serde_json::Value>)>,
+                      n: usize|
+         -> Vec<String> {
             if filtered.is_empty() {
                 return vec![];
             }
@@ -894,11 +934,11 @@ impl KvStore {
             let chosen: Vec<_> = filtered.choose_multiple(&mut rng, take).collect();
             chosen
                 .into_iter()
-                .map(|(value, id, ts)| {
+                .map(|(value, id, ts, data)| {
                     if ts.is_empty() {
-                        format!("{}: {}", id, value)
+                        format!("{}: {}{}", id, value, format_data_suffix(data))
                     } else {
-                        format!("{}: {} ({})", id, value, ts)
+                        format!("{}: {} ({}){}", id, value, ts, format_data_suffix(data))
                     }
                 })
                 .collect()
@@ -909,8 +949,11 @@ impl KvStore {
                 Some(DataValue::History { entries, .. }) => {
                     let filtered: Vec<_> = entries
                         .iter()
-                        .filter(|e| range.is_none_or(|r| ts_in_range(&e.ts, r)))
-                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str()))
+                        .filter(|e| {
+                            range.is_none_or(|r| ts_in_range(&e.ts, r))
+                                && where_matches(&e.data, where_clauses)
+                        })
+                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str(), &e.data))
                         .collect();
                     let available = filtered.len();
                     if available == 0 && !entries.is_empty() {
@@ -929,8 +972,11 @@ impl KvStore {
                 Some(DataValue::List { items, .. }) => {
                     let filtered: Vec<_> = items
                         .iter()
-                        .filter(|e| range.is_none_or(|r| ts_in_range(&e.ts, r)))
-                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str()))
+                        .filter(|e| {
+                            range.is_none_or(|r| ts_in_range(&e.ts, r))
+                                && where_matches(&e.data, where_clauses)
+                        })
+                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str(), &e.data))
                         .collect();
                     let available = filtered.len();
                     if available == 0 && !items.is_empty() {
@@ -1050,14 +1096,18 @@ impl KvStore {
         Ok(RemoveResult { removed })
     }
 
-    /// Search entries in a list or history by case-insensitive substring.
+    /// Search entries in a list or history by case-insensitive substring and/or
+    /// structured data filters.
     ///
+    /// When `query` is `Some`, entries must contain the substring.
+    /// When `where_clauses` is non-empty, entries must match all clauses.
     /// When `range` is provided, only entries within the time range are searched.
     pub fn search(
         &self,
         key: &str,
-        query: &str,
+        query: Option<&str>,
         range: Option<&TimeRange>,
+        where_clauses: &[(String, String)],
     ) -> Result<Vec<SearchHit>, KvError> {
         let def = self.key_def(key)?;
         match def.value_type {
@@ -1071,34 +1121,50 @@ impl KvStore {
             }
         }
 
-        let query_lower = query.to_lowercase();
+        let query_lower = query.map(|q| q.to_lowercase());
         let mut hits = Vec::new();
 
         match self.data.entries.get(key) {
             Some(DataValue::History { entries, .. }) => {
                 for e in entries {
-                    if range.is_none_or(|r| ts_in_range(&e.ts, r))
-                        && e.value.to_lowercase().contains(&query_lower)
-                    {
-                        hits.push(SearchHit {
-                            id: e.id,
-                            value: e.value.clone(),
-                            ts: e.ts.clone(),
-                        });
+                    if !range.is_none_or(|r| ts_in_range(&e.ts, r)) {
+                        continue;
                     }
+                    if let Some(ref q) = query_lower {
+                        if !e.value.to_lowercase().contains(q) {
+                            continue;
+                        }
+                    }
+                    if !where_matches(&e.data, where_clauses) {
+                        continue;
+                    }
+                    hits.push(SearchHit {
+                        id: e.id,
+                        value: e.value.clone(),
+                        ts: e.ts.clone(),
+                        data: e.data.clone(),
+                    });
                 }
             }
             Some(DataValue::List { items, .. }) => {
                 for e in items {
-                    if range.is_none_or(|r| ts_in_range(&e.ts, r))
-                        && e.value.to_lowercase().contains(&query_lower)
-                    {
-                        hits.push(SearchHit {
-                            id: e.id,
-                            value: e.value.clone(),
-                            ts: e.ts.clone(),
-                        });
+                    if !range.is_none_or(|r| ts_in_range(&e.ts, r)) {
+                        continue;
                     }
+                    if let Some(ref q) = query_lower {
+                        if !e.value.to_lowercase().contains(q) {
+                            continue;
+                        }
+                    }
+                    if !where_matches(&e.data, where_clauses) {
+                        continue;
+                    }
+                    hits.push(SearchHit {
+                        id: e.id,
+                        value: e.value.clone(),
+                        ts: e.ts.clone(),
+                        data: e.data.clone(),
+                    });
                 }
             }
             _ => {}
@@ -1135,6 +1201,7 @@ impl KvStore {
                             id: e.id,
                             value: e.value.clone(),
                             ts: e.ts.clone(),
+                            data: e.data.clone(),
                         });
                     }
                 }
@@ -1146,6 +1213,7 @@ impl KvStore {
                             id: e.id,
                             value: e.value.clone(),
                             ts: e.ts.clone(),
+                            data: e.data.clone(),
                         });
                     }
                 }
@@ -1156,16 +1224,19 @@ impl KvStore {
         Ok(hits)
     }
 
-    /// Count entries in a list or history, optionally filtered by substring and/or time range.
+    /// Count entries in a list or history, optionally filtered by substring,
+    /// time range, and/or structured data filters.
     ///
     /// When `range` is provided, only entries within the time range are counted.
+    /// When `where_clauses` is non-empty, entries must match all clauses.
     /// The `total` field in the result reflects entries that passed the time filter
-    /// (when a value filter is also active).
+    /// (when a value filter or where filter is active).
     pub fn count(
         &self,
         key: &str,
         value: Option<&str>,
         range: Option<&TimeRange>,
+        where_clauses: &[(String, String)],
     ) -> Result<CountResult, KvError> {
         let def = self.key_def(key)?;
         match def.value_type {
@@ -1180,7 +1251,7 @@ impl KvStore {
         }
 
         let query_lower = value.map(|v| v.to_lowercase());
-        let filtering = query_lower.is_some();
+        let filtering = query_lower.is_some() || !where_clauses.is_empty();
         let mut matched = 0usize;
         let mut entry_total = 0usize;
         let mut latest_ts: Option<String> = None;
@@ -1192,10 +1263,11 @@ impl KvStore {
                         continue;
                     }
                     entry_total += 1;
-                    let is_match = match &query_lower {
+                    let text_match = match &query_lower {
                         Some(q) => e.value.to_lowercase().contains(q),
                         None => true,
                     };
+                    let is_match = text_match && where_matches(&e.data, where_clauses);
                     if is_match {
                         matched += 1;
                         if latest_ts.is_none() || e.ts > *latest_ts.as_ref().unwrap() {
@@ -1210,10 +1282,11 @@ impl KvStore {
                         continue;
                     }
                     entry_total += 1;
-                    let is_match = match &query_lower {
+                    let text_match = match &query_lower {
                         Some(q) => e.value.to_lowercase().contains(q),
                         None => true,
                     };
+                    let is_match = text_match && where_matches(&e.data, where_clauses);
                     if is_match {
                         matched += 1;
                         if !e.ts.is_empty()
@@ -1334,6 +1407,48 @@ impl KvStore {
             v = v.min(hi);
         }
         v
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Structured data filter
+// ---------------------------------------------------------------------------
+
+/// Check whether an entry's structured data matches all `(key, value)` clauses.
+///
+/// Semantics:
+/// - If `data` is `None` and clauses is non-empty, return `false`.
+/// - For each `(key, value)` clause, `data[key]` must equal the string value
+///   OR `data[key]` must be an array that contains the string value.
+/// - ALL clauses must match (AND logic).
+pub fn where_matches(data: &Option<serde_json::Value>, clauses: &[(String, String)]) -> bool {
+    if clauses.is_empty() {
+        return true;
+    }
+
+    let obj = match data {
+        Some(serde_json::Value::Object(map)) => map,
+        _ => return false,
+    };
+
+    clauses.iter().all(|(key, value)| match obj.get(key) {
+        Some(serde_json::Value::String(s)) => s == value,
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .any(|v| matches!(v, serde_json::Value::String(s) if s == value)),
+        Some(serde_json::Value::Number(n)) => n.to_string() == *value,
+        Some(serde_json::Value::Bool(b)) => b.to_string() == *value,
+        _ => false,
+    })
+}
+
+/// Format the data suffix for display output.
+///
+/// When data is `Some`, returns ` {compact_json}`. When `None`, returns empty string.
+pub fn format_data_suffix(data: &Option<serde_json::Value>) -> String {
+    match data {
+        Some(v) => format!(" {}", serde_json::to_string(v).unwrap_or_default()),
+        None => String::new(),
     }
 }
 
@@ -1628,7 +1743,15 @@ pub fn format_value(value: &DataValue) -> String {
         DataValue::String { value } => value.clone(),
         DataValue::History { entries, .. } => entries
             .iter()
-            .map(|e| format!("{}: {} ({})", e.id, e.value, e.ts))
+            .map(|e| {
+                format!(
+                    "{}: {} ({}){}",
+                    e.id,
+                    e.value,
+                    e.ts,
+                    format_data_suffix(&e.data)
+                )
+            })
             .collect::<Vec<_>>()
             .join("\n"),
         DataValue::State { fields, .. } => {
@@ -1638,9 +1761,15 @@ pub fn format_value(value: &DataValue) -> String {
             .iter()
             .map(|e| {
                 if e.ts.is_empty() {
-                    format!("{}: {}", e.id, e.value)
+                    format!("{}: {}{}", e.id, e.value, format_data_suffix(&e.data))
                 } else {
-                    format!("{}: {} ({})", e.id, e.value, e.ts)
+                    format!(
+                        "{}: {} ({}){}",
+                        e.id,
+                        e.value,
+                        e.ts,
+                        format_data_suffix(&e.data)
+                    )
                 }
             })
             .collect::<Vec<_>>()
@@ -1827,15 +1956,15 @@ max_entries = 5
     #[test]
     fn history_push_and_last() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
-        store.push("flavor_history", "lapsang").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "lapsang", None).unwrap();
 
-        let last = store.last("flavor_history", 1, None).unwrap();
+        let last = store.last("flavor_history", 1, None, &[]).unwrap();
         assert_eq!(last.len(), 1);
         // last now includes id and ts
         assert!(last[0].contains("lapsang"));
 
-        let last2 = store.last("flavor_history", 2, None).unwrap();
+        let last2 = store.last("flavor_history", 2, None, &[]).unwrap();
         assert_eq!(last2.len(), 2);
     }
 
@@ -1843,10 +1972,10 @@ max_entries = 5
     fn history_max_entries_overflow() {
         let (mut store, _dir) = setup_store(test_schema());
         // max_entries = 3
-        store.push("flavor_history", "a").unwrap();
-        store.push("flavor_history", "b").unwrap();
-        store.push("flavor_history", "c").unwrap();
-        store.push("flavor_history", "d").unwrap();
+        store.push("flavor_history", "a", None).unwrap();
+        store.push("flavor_history", "b", None).unwrap();
+        store.push("flavor_history", "c", None).unwrap();
+        store.push("flavor_history", "d", None).unwrap();
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
@@ -1868,10 +1997,10 @@ max_entries = 5
         let new_time = Utc::now() - chrono::Duration::minutes(10);
 
         store
-            .push_with_ts("flavor_history", "old_one", old_time)
+            .push_with_ts("flavor_history", "old_one", old_time, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "new_one", new_time)
+            .push_with_ts("flavor_history", "new_one", new_time, None)
             .unwrap();
 
         let results = store.since("flavor_history", "1h").unwrap();
@@ -1884,11 +2013,11 @@ max_entries = 5
     #[test]
     fn list_push_pop_last() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "gamma").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "gamma", None).unwrap();
 
-        let last = store.last("tags", 2, None).unwrap();
+        let last = store.last("tags", 2, None, &[]).unwrap();
         assert_eq!(last.len(), 2);
         assert!(last[0].contains("beta"));
         assert!(last[1].contains("gamma"));
@@ -1903,7 +2032,7 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         // max_entries = 5
         for i in 0..8 {
-            store.push("tags", &format!("item_{}", i)).unwrap();
+            store.push("tags", &format!("item_{}", i), None).unwrap();
         }
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -1928,7 +2057,7 @@ max_entries = 5
     #[test]
     fn type_mismatch_push_on_counter() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("warmth", "value");
+        let result = store.push("warmth", "value", None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -1974,7 +2103,7 @@ max_entries = 5
     #[test]
     fn reset_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "test").unwrap();
+        store.push("flavor_history", "test", None).unwrap();
         store.reset("flavor_history").unwrap();
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => assert!(entries.is_empty()),
@@ -1999,7 +2128,7 @@ max_entries = 5
         store.data.schema_id = "test".to_string();
         store.inc("warmth", 7).unwrap();
         store.set("current_mood", "happy", None).unwrap();
-        store.push("flavor_history", "earl grey").unwrap();
+        store.push("flavor_history", "earl grey", None).unwrap();
         store.save().unwrap();
 
         // Reload and verify
@@ -2026,8 +2155,8 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T10:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "focus", ts).unwrap();
-        store.push_with_ts("tags", "rust", ts).unwrap();
+        store.push_with_ts("tags", "focus", ts, None).unwrap();
+        store.push_with_ts("tags", "rust", ts, None).unwrap();
 
         let compact = store.dump_compact();
 
@@ -2054,7 +2183,7 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
         store
-            .push_with_ts("flavor_history", "bergamot", ts)
+            .push_with_ts("flavor_history", "bergamot", ts, None)
             .unwrap();
 
         let compact = store.dump_compact();
@@ -2132,7 +2261,7 @@ max_entries = 5
     #[test]
     fn last_on_empty_returns_empty() {
         let (store, _dir) = setup_store(test_schema());
-        let last = store.last("flavor_history", 5, None).unwrap();
+        let last = store.last("flavor_history", 5, None, &[]).unwrap();
         assert!(last.is_empty());
     }
 
@@ -2151,9 +2280,9 @@ max_entries = 5
     #[test]
     fn remove_list_by_value_first_match() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "alpha-2").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "alpha-2", None).unwrap();
 
         let result = store.remove("tags", Some("alpha"), None, false).unwrap();
         assert_eq!(result.removed.len(), 1);
@@ -2173,9 +2302,9 @@ max_entries = 5
     #[test]
     fn remove_list_by_value_all_matches() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "alpha-2").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "alpha-2", None).unwrap();
 
         let result = store.remove("tags", Some("alpha"), None, true).unwrap();
         assert_eq!(result.removed.len(), 2);
@@ -2192,9 +2321,9 @@ max_entries = 5
     #[test]
     fn remove_list_by_id() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "gamma").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "gamma", None).unwrap();
 
         // Get the ID of "beta"
         let beta_id = match store.get("tags").unwrap() {
@@ -2210,9 +2339,9 @@ max_entries = 5
     #[test]
     fn remove_history_by_value() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
-        store.push("flavor_history", "lapsang").unwrap();
-        store.push("flavor_history", "bergamot vanilla").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "lapsang", None).unwrap();
+        store.push("flavor_history", "bergamot vanilla", None).unwrap();
 
         let result = store
             .remove("flavor_history", Some("bergamot"), None, false)
@@ -2230,8 +2359,8 @@ max_entries = 5
     #[test]
     fn remove_case_insensitive() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "Alpha").unwrap();
-        store.push("tags", "beta").unwrap();
+        store.push("tags", "Alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
 
         let result = store.remove("tags", Some("alpha"), None, false).unwrap();
         assert_eq!(result.removed.len(), 1);
@@ -2251,11 +2380,11 @@ max_entries = 5
     #[test]
     fn search_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "rust-lang").unwrap();
-        store.push("tags", "focus").unwrap();
-        store.push("tags", "rust-tools").unwrap();
+        store.push("tags", "rust-lang", None).unwrap();
+        store.push("tags", "focus", None).unwrap();
+        store.push("tags", "rust-tools", None).unwrap();
 
-        let hits = store.search("tags", "rust", None).unwrap();
+        let hits = store.search("tags", Some("rust"), None, &[]).unwrap();
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].value, "rust-lang");
         assert_eq!(hits[1].value, "rust-tools");
@@ -2264,38 +2393,38 @@ max_entries = 5
     #[test]
     fn search_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
-        store.push("flavor_history", "lapsang").unwrap();
-        store.push("flavor_history", "bergamot vanilla").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "lapsang", None).unwrap();
+        store.push("flavor_history", "bergamot vanilla", None).unwrap();
 
-        let hits = store.search("flavor_history", "bergamot", None).unwrap();
+        let hits = store.search("flavor_history", Some("bergamot"), None, &[]).unwrap();
         assert_eq!(hits.len(), 2);
     }
 
     #[test]
     fn search_case_insensitive() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "Rust").unwrap();
-        store.push("tags", "RUST-tools").unwrap();
-        store.push("tags", "python").unwrap();
+        store.push("tags", "Rust", None).unwrap();
+        store.push("tags", "RUST-tools", None).unwrap();
+        store.push("tags", "python", None).unwrap();
 
-        let hits = store.search("tags", "rust", None).unwrap();
+        let hits = store.search("tags", Some("rust"), None, &[]).unwrap();
         assert_eq!(hits.len(), 2);
     }
 
     #[test]
     fn search_no_matches() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
+        store.push("tags", "alpha", None).unwrap();
 
-        let hits = store.search("tags", "zzz", None).unwrap();
+        let hits = store.search("tags", Some("zzz"), None, &[]).unwrap();
         assert!(hits.is_empty());
     }
 
     #[test]
     fn search_type_mismatch() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.search("warmth", "x", None);
+        let result = store.search("warmth", Some("x"), None, &[]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2305,9 +2434,9 @@ max_entries = 5
     #[test]
     fn get_by_id_single_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
-        store.push("flavor_history", "lapsang").unwrap();
-        store.push("flavor_history", "earl grey").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "lapsang", None).unwrap();
+        store.push("flavor_history", "earl grey", None).unwrap();
 
         // Get the ID of the second entry
         let target_id = match store.get("flavor_history").unwrap() {
@@ -2326,9 +2455,9 @@ max_entries = 5
     #[test]
     fn get_by_id_single_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "gamma").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "gamma", None).unwrap();
 
         // Read the actual ID of the second entry from the store
         let target_id = match store.get("tags").unwrap() {
@@ -2345,9 +2474,9 @@ max_entries = 5
     #[test]
     fn get_by_id_range_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "gamma").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "gamma", None).unwrap();
 
         let hits = store.get_entries_by_id("tags", &[1, 2, 3]).unwrap();
         assert_eq!(hits.len(), 3);
@@ -2359,9 +2488,9 @@ max_entries = 5
     #[test]
     fn get_by_id_multi_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "gamma").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "gamma", None).unwrap();
 
         let hits = store.get_entries_by_id("tags", &[1, 3]).unwrap();
         assert_eq!(hits.len(), 2);
@@ -2372,8 +2501,8 @@ max_entries = 5
     #[test]
     fn get_by_id_partial_match() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
 
         // Request IDs 1, 2, 99 — only 1 and 2 exist
         let hits = store.get_entries_by_id("tags", &[1, 2, 99]).unwrap();
@@ -2383,7 +2512,7 @@ max_entries = 5
     #[test]
     fn get_by_id_all_not_found() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
+        store.push("tags", "alpha", None).unwrap();
 
         let hits = store.get_entries_by_id("tags", &[99, 100]).unwrap();
         assert!(hits.is_empty());
@@ -2432,11 +2561,11 @@ max_entries = 5
     #[test]
     fn count_list_total() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "a").unwrap();
-        store.push("tags", "b").unwrap();
-        store.push("tags", "c").unwrap();
+        store.push("tags", "a", None).unwrap();
+        store.push("tags", "b", None).unwrap();
+        store.push("tags", "c", None).unwrap();
 
-        let result = store.count("tags", None, None).unwrap();
+        let result = store.count("tags", None, None, &[]).unwrap();
         assert_eq!(result.matched, 3);
         assert!(result.total.is_none()); // no filter => no total
     }
@@ -2444,11 +2573,11 @@ max_entries = 5
     #[test]
     fn count_list_filtered() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "rust-lang").unwrap();
-        store.push("tags", "focus").unwrap();
-        store.push("tags", "rust-tools").unwrap();
+        store.push("tags", "rust-lang", None).unwrap();
+        store.push("tags", "focus", None).unwrap();
+        store.push("tags", "rust-tools", None).unwrap();
 
-        let result = store.count("tags", Some("rust"), None).unwrap();
+        let result = store.count("tags", Some("rust"), None, &[]).unwrap();
         assert_eq!(result.matched, 2);
         assert_eq!(result.total, Some(3)); // 2 of 3 match
     }
@@ -2464,17 +2593,17 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot", ts1)
+            .push_with_ts("flavor_history", "bergamot", ts1, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "bergamot vanilla", ts2)
+            .push_with_ts("flavor_history", "bergamot vanilla", ts2, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "lapsang", ts1)
+            .push_with_ts("flavor_history", "lapsang", ts1, None)
             .unwrap();
 
         let result = store
-            .count("flavor_history", Some("bergamot"), None)
+            .count("flavor_history", Some("bergamot"), None, &[])
             .unwrap();
         assert_eq!(result.matched, 2);
         assert_eq!(result.total, Some(3)); // 2 of 3 match
@@ -2485,7 +2614,7 @@ max_entries = 5
     #[test]
     fn count_empty() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.count("tags", None, None).unwrap();
+        let result = store.count("tags", None, None, &[]).unwrap();
         assert_eq!(result.matched, 0);
         assert!(result.total.is_none());
         assert!(result.latest_ts.is_none());
@@ -2494,7 +2623,7 @@ max_entries = 5
     #[test]
     fn count_filtered_empty_total() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.count("tags", Some("rust"), None).unwrap();
+        let result = store.count("tags", Some("rust"), None, &[]).unwrap();
         assert_eq!(result.matched, 0);
         assert_eq!(result.total, Some(0)); // 0 of 0
     }
@@ -2502,7 +2631,7 @@ max_entries = 5
     #[test]
     fn count_type_mismatch() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.count("warmth", None, None);
+        let result = store.count("warmth", None, None, &[]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2512,9 +2641,9 @@ max_entries = 5
     #[test]
     fn history_ids_auto_increment() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "a").unwrap();
-        store.push("flavor_history", "b").unwrap();
-        store.push("flavor_history", "c").unwrap();
+        store.push("flavor_history", "a", None).unwrap();
+        store.push("flavor_history", "b", None).unwrap();
+        store.push("flavor_history", "c", None).unwrap();
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
@@ -2534,9 +2663,9 @@ max_entries = 5
     #[test]
     fn list_ids_auto_increment() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "a").unwrap();
-        store.push("tags", "b").unwrap();
-        store.push("tags", "c").unwrap();
+        store.push("tags", "a", None).unwrap();
+        store.push("tags", "b", None).unwrap();
+        store.push("tags", "c", None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2551,15 +2680,15 @@ max_entries = 5
     #[test]
     fn list_ids_stable_after_remove() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "a").unwrap();
-        store.push("tags", "b").unwrap();
-        store.push("tags", "c").unwrap();
+        store.push("tags", "a", None).unwrap();
+        store.push("tags", "b", None).unwrap();
+        store.push("tags", "c", None).unwrap();
 
         // Remove "b"
         store.remove("tags", Some("b"), None, false).unwrap();
 
         // Push "d" — should get id=4, not reuse id=2
-        store.push("tags", "d").unwrap();
+        store.push("tags", "d", None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2655,7 +2784,7 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T10:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "focus", ts).unwrap();
+        store.push_with_ts("tags", "focus", ts, None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2675,8 +2804,8 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T10:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "focus", ts).unwrap();
-        store.push_with_ts("tags", "rust", ts).unwrap();
+        store.push_with_ts("tags", "focus", ts, None).unwrap();
+        store.push_with_ts("tags", "rust", ts, None).unwrap();
 
         let output = format_value(store.get("tags").unwrap());
         assert!(output.contains("1: focus"));
@@ -2687,7 +2816,7 @@ max_entries = 5
     #[test]
     fn format_value_history_shows_ids() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
 
         let output = format_value(store.get("flavor_history").unwrap());
         // Should contain "N: bergamot (timestamp)"
@@ -2703,8 +2832,8 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T14:15:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "dsi-panel", ts).unwrap();
-        store.push_with_ts("tags", "anytype", ts).unwrap();
+        store.push_with_ts("tags", "dsi-panel", ts, None).unwrap();
+        store.push_with_ts("tags", "anytype", ts, None).unwrap();
 
         let compact = store.dump_compact();
         assert!(compact.contains("tags=[dsi-panel@14:15,anytype@14:15]"));
@@ -2717,7 +2846,7 @@ max_entries = 5
     #[test]
     fn set_get_memory_on_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
 
         // Initially no memory pointer
         assert_eq!(store.get_memory("flavor_history").unwrap(), None);
@@ -2741,7 +2870,7 @@ max_entries = 5
     #[test]
     fn set_get_memory_on_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
+        store.push("tags", "alpha", None).unwrap();
 
         store
             .set_memory("tags", Some("kn-def456".to_string()))
@@ -2788,7 +2917,7 @@ max_entries = 5
     #[test]
     fn clear_memory_with_empty_string() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
 
         // Set then clear
         store
@@ -2809,7 +2938,7 @@ max_entries = 5
     #[test]
     fn clear_memory_with_none() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
+        store.push("tags", "alpha", None).unwrap();
 
         store
             .set_memory("tags", Some("kn-abc123".to_string()))
@@ -2821,7 +2950,7 @@ max_entries = 5
     #[test]
     fn memory_not_serialized_when_none() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
         store.data.schema_id = "test".to_string();
         store.save().unwrap();
 
@@ -2923,7 +3052,7 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
         store
-            .push_with_ts("flavor_history", "bergamot", ts)
+            .push_with_ts("flavor_history", "bergamot", ts, None)
             .unwrap();
         store
             .set_memory("flavor_history", Some("kn-def456".to_string()))
@@ -2949,7 +3078,7 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
         store
-            .push_with_ts("flavor_history", "bergamot", ts)
+            .push_with_ts("flavor_history", "bergamot", ts, None)
             .unwrap();
         // No memory pointer set
 
@@ -2982,13 +3111,13 @@ max_entries = 5
     #[test]
     fn memory_survives_push() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
         store
             .set_memory("flavor_history", Some("kn-abc123".to_string()))
             .unwrap();
 
         // Push another entry
-        store.push("flavor_history", "lapsang").unwrap();
+        store.push("flavor_history", "lapsang", None).unwrap();
 
         // Memory pointer should still be set
         assert_eq!(
@@ -3000,7 +3129,7 @@ max_entries = 5
     #[test]
     fn memory_survives_reset() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot").unwrap();
+        store.push("flavor_history", "bergamot", None).unwrap();
         store
             .set_memory("flavor_history", Some("kn-abc123".to_string()))
             .unwrap();
@@ -3428,14 +3557,14 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "inside", ts_in)
+            .push_with_ts("flavor_history", "inside", ts_in, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "outside", ts_out)
+            .push_with_ts("flavor_history", "outside", ts_out, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
-        let results = store.last("flavor_history", 10, Some(&range)).unwrap();
+        let results = store.last("flavor_history", 10, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].contains("inside"));
     }
@@ -3448,12 +3577,12 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("flavor_history", "a", ts).unwrap();
-        store.push_with_ts("flavor_history", "b", ts).unwrap();
+        store.push_with_ts("flavor_history", "a", ts, None).unwrap();
+        store.push_with_ts("flavor_history", "b", ts, None).unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         // Both entries match the range, but count=1 limits output
-        let results = store.last("flavor_history", 1, Some(&range)).unwrap();
+        let results = store.last("flavor_history", 1, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
     }
 
@@ -3468,11 +3597,11 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "rust-in", ts_in).unwrap();
-        store.push_with_ts("tags", "rust-out", ts_out).unwrap();
+        store.push_with_ts("tags", "rust-in", ts_in, None).unwrap();
+        store.push_with_ts("tags", "rust-out", ts_out, None).unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
-        let hits = store.search("tags", "rust", Some(&range)).unwrap();
+        let hits = store.search("tags", Some("rust"), Some(&range), &[]).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].value, "rust-in");
     }
@@ -3488,18 +3617,18 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "inside", ts_in).unwrap();
-        store.push_with_ts("tags", "outside", ts_out).unwrap();
-        store.push_with_ts("tags", "also-inside", ts_in).unwrap();
+        store.push_with_ts("tags", "inside", ts_in, None).unwrap();
+        store.push_with_ts("tags", "outside", ts_out, None).unwrap();
+        store.push_with_ts("tags", "also-inside", ts_in, None).unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
-        let results = store.last("tags", 10, Some(&range)).unwrap();
+        let results = store.last("tags", 10, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 2);
         assert!(results[0].contains("inside"));
         assert!(results[1].contains("also-inside"));
 
         // count limit applies after time filter
-        let results = store.last("tags", 1, Some(&range)).unwrap();
+        let results = store.last("tags", 1, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].contains("also-inside"));
     }
@@ -3516,15 +3645,15 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot-in", ts_in)
+            .push_with_ts("flavor_history", "bergamot-in", ts_in, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "bergamot-out", ts_out)
+            .push_with_ts("flavor_history", "bergamot-out", ts_out, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         let hits = store
-            .search("flavor_history", "bergamot", Some(&range))
+            .search("flavor_history", Some("bergamot"), Some(&range), &[])
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].value, "bergamot-in");
@@ -3542,23 +3671,23 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot", ts_in)
+            .push_with_ts("flavor_history", "bergamot", ts_in, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "lapsang", ts_in)
+            .push_with_ts("flavor_history", "lapsang", ts_in, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "bergamot earl", ts_out)
+            .push_with_ts("flavor_history", "bergamot earl", ts_out, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         // Count all in range (no value filter)
-        let result = store.count("flavor_history", None, Some(&range)).unwrap();
+        let result = store.count("flavor_history", None, Some(&range), &[]).unwrap();
         assert_eq!(result.matched, 2);
 
         // Count with value filter + time range
         let result = store
-            .count("flavor_history", Some("bergamot"), Some(&range))
+            .count("flavor_history", Some("bergamot"), Some(&range), &[])
             .unwrap();
         assert_eq!(result.matched, 1);
         assert_eq!(result.total, Some(2)); // 1 of 2 in-range entries match
@@ -3576,12 +3705,12 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "april", ts_apr)
+            .push_with_ts("flavor_history", "april", ts_apr, None)
             .unwrap();
-        store.push_with_ts("flavor_history", "may", ts_may).unwrap();
+        store.push_with_ts("flavor_history", "may", ts_may, None).unwrap();
 
         let range = parse_month("2026-04").unwrap();
-        let result = store.count("flavor_history", None, Some(&range)).unwrap();
+        let result = store.count("flavor_history", None, Some(&range), &[]).unwrap();
         assert_eq!(result.matched, 1);
     }
 
@@ -3590,35 +3719,35 @@ max_entries = 5
     #[test]
     fn random_on_empty_returns_empty() {
         let (store, _dir) = setup_store(test_schema());
-        let results = store.random("flavor_history", 5, None).unwrap();
+        let results = store.random("flavor_history", 5, None, &[]).unwrap();
         assert!(results.is_empty());
     }
 
     #[test]
     fn random_returns_requested_count() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
-        store.push("tags", "gamma").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "gamma", None).unwrap();
 
-        let results = store.random("tags", 2, None).unwrap();
+        let results = store.random("tags", 2, None, &[]).unwrap();
         assert_eq!(results.len(), 2);
     }
 
     #[test]
     fn random_returns_all_when_count_exceeds_available() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha").unwrap();
-        store.push("tags", "beta").unwrap();
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
 
-        let results = store.random("tags", 10, None).unwrap();
+        let results = store.random("tags", 10, None, &[]).unwrap();
         assert_eq!(results.len(), 2);
     }
 
     #[test]
     fn random_type_mismatch_on_counter() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.random("warmth", 1, None);
+        let result = store.random("warmth", 1, None, &[]);
         assert!(result.is_err());
         match result.unwrap_err() {
             KvError::TypeMismatch { key, .. } => assert_eq!(key, "warmth"),
@@ -3634,11 +3763,11 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot", ts)
+            .push_with_ts("flavor_history", "bergamot", ts, None)
             .unwrap();
-        store.push_with_ts("flavor_history", "vanilla", ts).unwrap();
+        store.push_with_ts("flavor_history", "vanilla", ts, None).unwrap();
 
-        let results = store.random("flavor_history", 1, None).unwrap();
+        let results = store.random("flavor_history", 1, None, &[]).unwrap();
         assert_eq!(results.len(), 1);
         // Result must contain one of the pushed values
         assert!(results[0].contains("bergamot") || results[0].contains("vanilla"));
@@ -3655,11 +3784,11 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "inside", ts_in).unwrap();
-        store.push_with_ts("tags", "outside", ts_out).unwrap();
+        store.push_with_ts("tags", "inside", ts_in, None).unwrap();
+        store.push_with_ts("tags", "outside", ts_out, None).unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
-        let results = store.random("tags", 10, Some(&range)).unwrap();
+        let results = store.random("tags", 10, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].contains("inside"));
     }
@@ -3676,14 +3805,14 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "inside", ts_in)
+            .push_with_ts("flavor_history", "inside", ts_in, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "outside", ts_out)
+            .push_with_ts("flavor_history", "outside", ts_out, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
-        let results = store.random("flavor_history", 10, Some(&range)).unwrap();
+        let results = store.random("flavor_history", 10, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].contains("inside"));
     }
@@ -3717,5 +3846,573 @@ max_entries = 5
         let range = range.unwrap();
         let thirty_days_ago = Utc::now() - chrono::Duration::days(30);
         assert!((range.from - thirty_days_ago).num_seconds().abs() < 5);
+    }
+
+    // -----------------------------------------------------------------------
+    // Structured data tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn push_with_data_stores_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let data = serde_json::json!({"status": "active", "tags": ["rust", "kv"]});
+        store.push("tags", "my-item", Some(data.clone())).unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0].value, "my-item");
+                assert_eq!(items[0].data, Some(data));
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn push_without_data_stores_none() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "bare-item", None).unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items.len(), 1);
+                assert!(items[0].data.is_none());
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn push_history_with_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let data = serde_json::json!({"mood": "focused"});
+        store
+            .push("flavor_history", "bergamot", Some(data.clone()))
+            .unwrap();
+
+        match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries[0].data, Some(data));
+            }
+            _ => panic!("Expected history"),
+        }
+    }
+
+    #[test]
+    fn data_round_trip_through_save() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let data = serde_json::json!({"priority": 1, "tags": ["a", "b"]});
+        store.push("tags", "item", Some(data.clone())).unwrap();
+        store.data.schema_id = "test".to_string();
+        store.save().unwrap();
+
+        // Reload
+        let data_str = fs::read_to_string(&store.data_path).unwrap();
+        let reloaded: DataFile = serde_json::from_str(&data_str).unwrap();
+        match &reloaded.entries["tags"] {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].data, Some(data));
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn backward_compat_missing_data_field() {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        // Write data without any "data" fields
+        let old_data = r#"{
+            "_schema": "test",
+            "_updated": "2026-04-20T00:00:00Z",
+            "tags": { "items": [{"id": 1, "value": "alpha", "ts": "2026-04-20T00:00:00Z"}] },
+            "flavor_history": { "entries": [{"id": 1, "value": "bergamot", "ts": "2026-04-20T00:00:00Z"}] }
+        }"#;
+        fs::write(&data_path, old_data).unwrap();
+
+        let store = KvStore::load(&schema_path, &data_path).unwrap();
+
+        // List entry should have data=None
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert!(items[0].data.is_none());
+            }
+            _ => panic!("Expected list"),
+        }
+
+        // History entry should have data=None
+        match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => {
+                assert!(entries[0].data.is_none());
+            }
+            _ => panic!("Expected history"),
+        }
+    }
+
+    #[test]
+    fn backward_compat_bare_string_list_gets_none_data() {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        let old_data = r#"{
+            "_schema": "test",
+            "_updated": "2026-04-20T00:00:00Z",
+            "tags": { "items": ["alpha", "beta"] }
+        }"#;
+        fs::write(&data_path, old_data).unwrap();
+
+        let store = KvStore::load(&schema_path, &data_path).unwrap();
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items.len(), 2);
+                assert!(items[0].data.is_none());
+                assert!(items[1].data.is_none());
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    // -- where_matches unit tests --
+
+    #[test]
+    fn where_matches_empty_clauses() {
+        assert!(where_matches(&None, &[]));
+        assert!(where_matches(
+            &Some(serde_json::json!({"a": "b"})),
+            &[]
+        ));
+    }
+
+    #[test]
+    fn where_matches_none_data_nonempty_clauses() {
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        assert!(!where_matches(&None, &clauses));
+    }
+
+    #[test]
+    fn where_matches_exact_string() {
+        let data = Some(serde_json::json!({"status": "active", "priority": "high"}));
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        assert!(where_matches(&data, &clauses));
+    }
+
+    #[test]
+    fn where_matches_exact_string_no_match() {
+        let data = Some(serde_json::json!({"status": "closed"}));
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        assert!(!where_matches(&data, &clauses));
+    }
+
+    #[test]
+    fn where_matches_array_contains() {
+        let data = Some(serde_json::json!({"tags": ["rust", "cli", "kv"]}));
+        let clauses = vec![("tags".to_string(), "rust".to_string())];
+        assert!(where_matches(&data, &clauses));
+    }
+
+    #[test]
+    fn where_matches_array_not_contains() {
+        let data = Some(serde_json::json!({"tags": ["rust", "cli"]}));
+        let clauses = vec![("tags".to_string(), "python".to_string())];
+        assert!(!where_matches(&data, &clauses));
+    }
+
+    #[test]
+    fn where_matches_multiple_clauses_and_logic() {
+        let data = Some(serde_json::json!({"status": "active", "priority": "high"}));
+
+        // Both match
+        let clauses = vec![
+            ("status".to_string(), "active".to_string()),
+            ("priority".to_string(), "high".to_string()),
+        ];
+        assert!(where_matches(&data, &clauses));
+
+        // One fails
+        let clauses = vec![
+            ("status".to_string(), "active".to_string()),
+            ("priority".to_string(), "low".to_string()),
+        ];
+        assert!(!where_matches(&data, &clauses));
+    }
+
+    #[test]
+    fn where_matches_missing_key() {
+        let data = Some(serde_json::json!({"status": "active"}));
+        let clauses = vec![("nonexistent".to_string(), "value".to_string())];
+        assert!(!where_matches(&data, &clauses));
+    }
+
+    #[test]
+    fn where_matches_number_as_string() {
+        let data = Some(serde_json::json!({"count": 42}));
+        let clauses = vec![("count".to_string(), "42".to_string())];
+        assert!(where_matches(&data, &clauses));
+    }
+
+    #[test]
+    fn where_matches_bool_as_string() {
+        let data = Some(serde_json::json!({"active": true}));
+        let clauses = vec![("active".to_string(), "true".to_string())];
+        assert!(where_matches(&data, &clauses));
+    }
+
+    // -- search with where_clauses --
+
+    #[test]
+    fn search_with_where_exact_match() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "task-1",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "task-2",
+                Some(serde_json::json!({"status": "closed"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "task-3",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        let hits = store.search("tags", None, None, &clauses).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].value, "task-1");
+        assert_eq!(hits[1].value, "task-3");
+    }
+
+    #[test]
+    fn search_with_where_array_contains() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "item-a",
+                Some(serde_json::json!({"labels": ["bug", "urgent"]})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "item-b",
+                Some(serde_json::json!({"labels": ["feature"]})),
+            )
+            .unwrap();
+
+        let clauses = vec![("labels".to_string(), "bug".to_string())];
+        let hits = store.search("tags", None, None, &clauses).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "item-a");
+    }
+
+    #[test]
+    fn search_with_where_excludes_entries_without_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "no-data", None).unwrap();
+        store
+            .push(
+                "tags",
+                "has-data",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        let hits = store.search("tags", None, None, &clauses).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "has-data");
+    }
+
+    #[test]
+    fn search_with_query_and_where() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "rust-fix",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "rust-feature",
+                Some(serde_json::json!({"status": "closed"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "python-fix",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        // Text query "rust" AND where status=active
+        let hits = store
+            .search("tags", Some("rust"), None, &clauses)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "rust-fix");
+    }
+
+    #[test]
+    fn search_with_only_where_no_query() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "a",
+                Some(serde_json::json!({"type": "bug"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "b",
+                Some(serde_json::json!({"type": "feature"})),
+            )
+            .unwrap();
+
+        let clauses = vec![("type".to_string(), "bug".to_string())];
+        let hits = store.search("tags", None, None, &clauses).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "a");
+    }
+
+    #[test]
+    fn search_multiple_where_clauses_and() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "match-both",
+                Some(serde_json::json!({"status": "active", "priority": "high"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "match-one",
+                Some(serde_json::json!({"status": "active", "priority": "low"})),
+            )
+            .unwrap();
+
+        let clauses = vec![
+            ("status".to_string(), "active".to_string()),
+            ("priority".to_string(), "high".to_string()),
+        ];
+        let hits = store.search("tags", None, None, &clauses).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "match-both");
+    }
+
+    // -- last with where_clauses --
+
+    #[test]
+    fn last_with_where() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "a",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "b",
+                Some(serde_json::json!({"status": "closed"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "c",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        let items = store.last("tags", 10, None, &clauses).unwrap();
+        assert_eq!(items.len(), 2);
+        assert!(items[0].contains("a"));
+        assert!(items[1].contains("c"));
+    }
+
+    // -- random with where_clauses --
+
+    #[test]
+    fn random_with_where() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "active-1",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "closed-1",
+                Some(serde_json::json!({"status": "closed"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "active-2",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        let items = store.random("tags", 10, None, &clauses).unwrap();
+        assert_eq!(items.len(), 2);
+        // All returned items should contain "active-"
+        for item in &items {
+            assert!(
+                item.contains("active-"),
+                "Expected active item, got: {}",
+                item
+            );
+        }
+    }
+
+    // -- count with where_clauses --
+
+    #[test]
+    fn count_with_where() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "tags",
+                "a",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "b",
+                Some(serde_json::json!({"status": "closed"})),
+            )
+            .unwrap();
+        store
+            .push(
+                "tags",
+                "c",
+                Some(serde_json::json!({"status": "active"})),
+            )
+            .unwrap();
+
+        let clauses = vec![("status".to_string(), "active".to_string())];
+        let result = store.count("tags", None, None, &clauses).unwrap();
+        assert_eq!(result.matched, 2);
+        assert_eq!(result.total, Some(3)); // where_clauses count as filtering
+    }
+
+    // -- search hits carry data field --
+
+    #[test]
+    fn search_hits_carry_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let data = serde_json::json!({"status": "active"});
+        store
+            .push("tags", "item", Some(data.clone()))
+            .unwrap();
+
+        let hits = store.search("tags", Some("item"), None, &[]).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].data, Some(data));
+    }
+
+    #[test]
+    fn get_entries_by_id_carries_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let data = serde_json::json!({"priority": "high"});
+        store
+            .push("tags", "item", Some(data.clone()))
+            .unwrap();
+
+        let hits = store.get_entries_by_id("tags", &[1]).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].data, Some(data));
+    }
+
+    // -- format_data_suffix --
+
+    #[test]
+    fn format_data_suffix_none() {
+        assert_eq!(format_data_suffix(&None), "");
+    }
+
+    #[test]
+    fn format_data_suffix_some() {
+        let data = Some(serde_json::json!({"status": "active"}));
+        let suffix = format_data_suffix(&data);
+        assert!(suffix.starts_with(' '));
+        // Should be compact JSON (no pretty printing)
+        assert!(!suffix.contains('\n'));
+        assert!(suffix.contains("\"status\""));
+        assert!(suffix.contains("\"active\""));
+    }
+
+    // -- format_value includes data --
+
+    #[test]
+    fn format_value_includes_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let data = serde_json::json!({"k": "v"});
+        store.push("tags", "item", Some(data)).unwrap();
+
+        let formatted = format_value(store.get("tags").unwrap());
+        assert!(formatted.contains("{\"k\":\"v\"}"));
+    }
+
+    #[test]
+    fn format_value_no_data_unchanged() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "plain-item", None).unwrap();
+
+        let formatted = format_value(store.get("tags").unwrap());
+        assert!(formatted.contains("plain-item"));
+        // Should NOT have trailing JSON
+        assert!(!formatted.contains('{'));
+    }
+
+    // -- last output includes data suffix --
+
+    #[test]
+    fn last_output_includes_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let data = serde_json::json!({"x": 1});
+        store.push("tags", "item", Some(data)).unwrap();
+
+        let items = store.last("tags", 1, None, &[]).unwrap();
+        assert_eq!(items.len(), 1);
+        assert!(items[0].contains("{\"x\":1}"));
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -261,6 +261,11 @@ enum RawListItem {
 }
 
 /// Mirror of DataValue for deserialization, with backward compat glue.
+///
+/// The `data` field on `HistoryEntry` and `ListEntry` was added after initial
+/// release. Backward compatibility for files written before that field existed
+/// is handled by `#[serde(default)]` on each entry struct's `data` field, so
+/// `DataValueDe` itself needs no special handling for it.
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum DataValueDe {
@@ -750,7 +755,7 @@ impl KvStore {
                                 id: next_id,
                                 value: value.to_string(),
                                 ts: ts.to_rfc3339(),
-                                data: data.clone(),
+                                data,
                             },
                         );
                         // Drop oldest at max_entries

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -2341,7 +2341,9 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         store.push("flavor_history", "bergamot", None).unwrap();
         store.push("flavor_history", "lapsang", None).unwrap();
-        store.push("flavor_history", "bergamot vanilla", None).unwrap();
+        store
+            .push("flavor_history", "bergamot vanilla", None)
+            .unwrap();
 
         let result = store
             .remove("flavor_history", Some("bergamot"), None, false)
@@ -2395,9 +2397,13 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         store.push("flavor_history", "bergamot", None).unwrap();
         store.push("flavor_history", "lapsang", None).unwrap();
-        store.push("flavor_history", "bergamot vanilla", None).unwrap();
+        store
+            .push("flavor_history", "bergamot vanilla", None)
+            .unwrap();
 
-        let hits = store.search("flavor_history", Some("bergamot"), None, &[]).unwrap();
+        let hits = store
+            .search("flavor_history", Some("bergamot"), None, &[])
+            .unwrap();
         assert_eq!(hits.len(), 2);
     }
 
@@ -3598,10 +3604,14 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store.push_with_ts("tags", "rust-in", ts_in, None).unwrap();
-        store.push_with_ts("tags", "rust-out", ts_out, None).unwrap();
+        store
+            .push_with_ts("tags", "rust-out", ts_out, None)
+            .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
-        let hits = store.search("tags", Some("rust"), Some(&range), &[]).unwrap();
+        let hits = store
+            .search("tags", Some("rust"), Some(&range), &[])
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].value, "rust-in");
     }
@@ -3619,7 +3629,9 @@ max_entries = 5
 
         store.push_with_ts("tags", "inside", ts_in, None).unwrap();
         store.push_with_ts("tags", "outside", ts_out, None).unwrap();
-        store.push_with_ts("tags", "also-inside", ts_in, None).unwrap();
+        store
+            .push_with_ts("tags", "also-inside", ts_in, None)
+            .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         let results = store.last("tags", 10, Some(&range), &[]).unwrap();
@@ -3682,7 +3694,9 @@ max_entries = 5
 
         let range = parse_day("2026-04-25").unwrap();
         // Count all in range (no value filter)
-        let result = store.count("flavor_history", None, Some(&range), &[]).unwrap();
+        let result = store
+            .count("flavor_history", None, Some(&range), &[])
+            .unwrap();
         assert_eq!(result.matched, 2);
 
         // Count with value filter + time range
@@ -3707,10 +3721,14 @@ max_entries = 5
         store
             .push_with_ts("flavor_history", "april", ts_apr, None)
             .unwrap();
-        store.push_with_ts("flavor_history", "may", ts_may, None).unwrap();
+        store
+            .push_with_ts("flavor_history", "may", ts_may, None)
+            .unwrap();
 
         let range = parse_month("2026-04").unwrap();
-        let result = store.count("flavor_history", None, Some(&range), &[]).unwrap();
+        let result = store
+            .count("flavor_history", None, Some(&range), &[])
+            .unwrap();
         assert_eq!(result.matched, 1);
     }
 
@@ -3765,7 +3783,9 @@ max_entries = 5
         store
             .push_with_ts("flavor_history", "bergamot", ts, None)
             .unwrap();
-        store.push_with_ts("flavor_history", "vanilla", ts, None).unwrap();
+        store
+            .push_with_ts("flavor_history", "vanilla", ts, None)
+            .unwrap();
 
         let results = store.random("flavor_history", 1, None, &[]).unwrap();
         assert_eq!(results.len(), 1);
@@ -3812,7 +3832,9 @@ max_entries = 5
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
-        let results = store.random("flavor_history", 10, Some(&range), &[]).unwrap();
+        let results = store
+            .random("flavor_history", 10, Some(&range), &[])
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].contains("inside"));
     }
@@ -3986,10 +4008,7 @@ max_entries = 5
     #[test]
     fn where_matches_empty_clauses() {
         assert!(where_matches(&None, &[]));
-        assert!(where_matches(
-            &Some(serde_json::json!({"a": "b"})),
-            &[]
-        ));
+        assert!(where_matches(&Some(serde_json::json!({"a": "b"})), &[]));
     }
 
     #[test]
@@ -4169,9 +4188,7 @@ max_entries = 5
 
         let clauses = vec![("status".to_string(), "active".to_string())];
         // Text query "rust" AND where status=active
-        let hits = store
-            .search("tags", Some("rust"), None, &clauses)
-            .unwrap();
+        let hits = store.search("tags", Some("rust"), None, &clauses).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].value, "rust-fix");
     }
@@ -4180,18 +4197,10 @@ max_entries = 5
     fn search_with_only_where_no_query() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push(
-                "tags",
-                "a",
-                Some(serde_json::json!({"type": "bug"})),
-            )
+            .push("tags", "a", Some(serde_json::json!({"type": "bug"})))
             .unwrap();
         store
-            .push(
-                "tags",
-                "b",
-                Some(serde_json::json!({"type": "feature"})),
-            )
+            .push("tags", "b", Some(serde_json::json!({"type": "feature"})))
             .unwrap();
 
         let clauses = vec![("type".to_string(), "bug".to_string())];
@@ -4233,25 +4242,13 @@ max_entries = 5
     fn last_with_where() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push(
-                "tags",
-                "a",
-                Some(serde_json::json!({"status": "active"})),
-            )
+            .push("tags", "a", Some(serde_json::json!({"status": "active"})))
             .unwrap();
         store
-            .push(
-                "tags",
-                "b",
-                Some(serde_json::json!({"status": "closed"})),
-            )
+            .push("tags", "b", Some(serde_json::json!({"status": "closed"})))
             .unwrap();
         store
-            .push(
-                "tags",
-                "c",
-                Some(serde_json::json!({"status": "active"})),
-            )
+            .push("tags", "c", Some(serde_json::json!({"status": "active"})))
             .unwrap();
 
         let clauses = vec![("status".to_string(), "active".to_string())];
@@ -4307,25 +4304,13 @@ max_entries = 5
     fn count_with_where() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push(
-                "tags",
-                "a",
-                Some(serde_json::json!({"status": "active"})),
-            )
+            .push("tags", "a", Some(serde_json::json!({"status": "active"})))
             .unwrap();
         store
-            .push(
-                "tags",
-                "b",
-                Some(serde_json::json!({"status": "closed"})),
-            )
+            .push("tags", "b", Some(serde_json::json!({"status": "closed"})))
             .unwrap();
         store
-            .push(
-                "tags",
-                "c",
-                Some(serde_json::json!({"status": "active"})),
-            )
+            .push("tags", "c", Some(serde_json::json!({"status": "active"})))
             .unwrap();
 
         let clauses = vec![("status".to_string(), "active".to_string())];
@@ -4340,9 +4325,7 @@ max_entries = 5
     fn search_hits_carry_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"status": "active"});
-        store
-            .push("tags", "item", Some(data.clone()))
-            .unwrap();
+        store.push("tags", "item", Some(data.clone())).unwrap();
 
         let hits = store.search("tags", Some("item"), None, &[]).unwrap();
         assert_eq!(hits.len(), 1);
@@ -4353,9 +4336,7 @@ max_entries = 5
     fn get_entries_by_id_carries_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"priority": "high"});
-        store
-            .push("tags", "item", Some(data.clone()))
-            .unwrap();
+        store.push("tags", "item", Some(data.clone())).unwrap();
 
         let hits = store.get_entries_by_id("tags", &[1]).unwrap();
         assert_eq!(hits.len(), 1);

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1130,10 +1130,10 @@ impl KvStore {
                     if !range.is_none_or(|r| ts_in_range(&e.ts, r)) {
                         continue;
                     }
-                    if let Some(ref q) = query_lower {
-                        if !e.value.to_lowercase().contains(q) {
-                            continue;
-                        }
+                    if let Some(ref q) = query_lower
+                        && !e.value.to_lowercase().contains(q)
+                    {
+                        continue;
                     }
                     if !where_matches(&e.data, where_clauses) {
                         continue;
@@ -1151,10 +1151,10 @@ impl KvStore {
                     if !range.is_none_or(|r| ts_in_range(&e.ts, r)) {
                         continue;
                     }
-                    if let Some(ref q) = query_lower {
-                        if !e.value.to_lowercase().contains(q) {
-                            continue;
-                        }
+                    if let Some(ref q) = query_lower
+                        && !e.value.to_lowercase().contains(q)
+                    {
+                        continue;
                     }
                     if !where_matches(&e.data, where_clauses) {
                         continue;


### PR DESCRIPTION
Closes #251

## Summary

Adds `data: Option<serde_json::Value>` to history and list entries, enabling structured JSON metadata on kv entries. Entries can be pushed with `--data '{...}'` and filtered with `--where key=value` across search, last, random, and count commands.

## Key changes

- **Data model:** `data` field on `HistoryEntry`, `ListEntry`, `SearchHit`
- **Push:** `--data` flag accepts JSON objects
- **Query:** `--where key=value` (equality + array-contains, AND logic, repeatable)
- **Search query now optional** -- can filter purely by `--where`
- **Output:** compact JSON appended after timestamp when data present

## Compatibility

Zero migration: backward compatible via `serde(default)` / `skip_serializing_if`. No new dependencies (serde_json already present).

## Files changed

- `src/cli.rs` -- new CLI args (`--data`, `--where`)
- `src/kv.rs` -- data model, storage, query/filter logic
- `src/handlers/kv.rs` -- handler wiring, output formatting

## Tests

36 new tests, 817 total passing.

## Usage examples

```bash
mx kv push projects "palmtop DSI fix" --data '{"tags":["palmtop","i915"],"status":"active"}'
mx kv search projects --where status=active
mx kv search projects --where tags=palmtop
mx kv search projects "DSI" --where status=active
mx kv last projects --count 5 --where status=active
mx kv count projects --where tags=palmtop
```