### PR TITLE
kv: short unique hash IDs and push output (#269, #299)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Fast local key-value state per agent. Counters, strings, lists, timestamped hist
 # Basic operations
 mx kv set session_goal "ship the docs"
 mx kv inc builds
-mx kv push decisions "chose Typst for docs"
+mx kv push decisions "chose Typst for docs"    # prints: kv-A3fB (1)
 mx kv last decisions --count 5
 
 # Structured data on entries
@@ -148,16 +148,22 @@ mx kv count shipped --day 2026-05-07
 # Time range composes with --count (filter first, then limit)
 mx kv last shipped --month 2026-04 --count 5
 
-# Entry lookup by ID on history/list keys
+# Entry lookup by numeric ID or hash ID
 mx kv get shipped --id 35
+mx kv get shipped --id kv-A3fB
 mx kv get shipped --id 35-64
-mx kv get shipped --id 1,5,12,35
+mx kv get shipped --id 1,kv-A3fB,12
+
+# Remove by hash ID
+mx kv remove shipped --id kv-A3fB
 
 # Random sampling from history/list keys
 mx kv random shipped --count 5
 mx kv random ideas --count 1
 mx kv random shipped --count 3 --since 30d
 ```
+
+Every entry gets a stable hash ID (e.g. `kv-A3fB`) alongside its numeric ID. Push prints both: `kv-A3fB (42)`. Anywhere a numeric ID works, a hash ID also works -- `--id kv-A3fB`, mixed comma lists, remove. Ranges remain numeric only. Old data files are back-filled on first load.
 
 Entries can carry structured JSON data via `--data` on push. Query entries by data fields with `--where key=value` (available on `search`, `last`, `random`, `count`). Multiple `--where` flags are ANDed. Supports exact string match, array-contains, and numeric/boolean comparison on top-level fields.
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -583,8 +583,8 @@ Supported types:
   table.header([*Type*], [*Behavior*]),
   [`counter`], [Integer with optional `min`/`max` bounds. Supports `inc`, `dec`, `set`, `get`],
   [`string`], [Simple string value. Supports `set`, `get`],
-  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. Entries can carry optional structured JSON data (`--data` on push, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
-  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
+  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. Each entry gets a numeric ID and a stable base58 hash ID (`kv-` prefix). Entries can carry optional structured JSON data (`--data` on push, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
+  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. Each entry gets a numeric ID and a stable base58 hash ID. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
   [`state`], [Named fields (like a struct). Supports `set <key> <field> <value>`, `get`],
 )
 
@@ -594,11 +594,14 @@ The data file at `$MX_HOME/kv/data/{agent}.json` holds current values. All
 writes are atomic: serialize to a temp file, fsync, rename. The format is a
 flat JSON object keyed by the key names from the schema.
 
-History and list entries are stored as objects with `id`, `value`, `ts`, and an
-optional `data` field (arbitrary JSON object for structured metadata). The
-`data` field uses `#[serde(default, skip_serializing_if = "Option::is_none")]`
-for backward compatibility -- files written before structured data was added
-deserialize cleanly without migration.
+History and list entries are stored as objects with `id`, `hash`, `value`,
+`ts`, and an optional `data` field (arbitrary JSON object for structured
+metadata). The `hash` field is a short base58 string generated from
+`blake3(key + timestamp + id)` via base-d, providing a stable identifier
+independent of numeric ordering. Both `hash` and `data` use
+`#[serde(default)]` for backward compatibility -- files written before these
+fields existed are back-filled on first load (hashes are generated, data
+defaults to `None`) and saved automatically.
 
 === Per-agent keying
 

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -135,11 +135,11 @@ filtering. Schema-driven with defaults.
 ```bash
 mx kv set session.goal "ship the docs"
 mx kv inc builds
-mx kv push decisions "chose Typst for docs"
+mx kv push decisions "chose Typst for docs"  # prints: kv-A3fB (1)
 mx kv last decisions --count 5
 mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
-mx kv random decisions --count 3
+mx kv get decisions --id kv-A3fB              # look up by hash ID
 
 # Attach structured data and query it
 mx kv push projects "palmtop DSI fix" \

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -70,7 +70,8 @@ and history with time-based queries and structured data filtering.
 ```bash
 mx kv set session.goal "ship the docs"
 mx kv get session.goal
-mx kv push decisions "chose Typst over markdown"
+mx kv push decisions "chose Typst over markdown"  # prints: kv-A3fB (1)
+mx kv get shipped --id kv-A3fB
 mx kv get shipped --id 35-64
 mx kv push projects "palmtop DSI fix" \
   --data '{"tags":["palmtop","i915"],"status":"active"}'

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -22,8 +22,8 @@ Every key has a type declared in the schema. Five types are supported:
 
 / string: A single text value. Has an optional `default`.
 / counter: An integer with optional `min`, `max`, and `default`. Clamped on every write.
-/ history: A timestamped append-only log. Newest entries first. Has an optional `max_entries` cap that drops the oldest entries on overflow. Entries can carry optional structured JSON data.
-/ list: An ordered collection with timestamps. Supports push and pop. Also has an optional `max_entries` cap. Entries can carry optional structured JSON data.
+/ history: A timestamped append-only log. Newest entries first. Has an optional `max_entries` cap that drops the oldest entries on overflow. Each entry gets a numeric ID and a stable hash ID. Entries can carry optional structured JSON data.
+/ list: An ordered collection with timestamps. Supports push and pop. Also has an optional `max_entries` cap. Each entry gets a numeric ID and a stable hash ID. Entries can carry optional structured JSON data.
 / state: A structured record with named fields. Fields are declared in the schema and validated on write.
 
 === Schema files
@@ -100,7 +100,7 @@ KV commands use structured exit codes for scripting:
 / `1`: Key not found (or no data yet for that key).
 / `2`: Type mismatch (e.g., `inc` on a string key, or `get --id` on a non-history/list key).
 / `3`: Schema file not found.
-/ `4`: Invalid input (e.g., non-numeric ID in `--id` spec, reversed range, empty spec).
+/ `4`: Invalid input (e.g., reversed range, empty spec, empty hash after `kv-` prefix).
 
 == Basic operations
 
@@ -112,23 +112,23 @@ KV commands use structured exit codes for scripting:
   counters, all entries with IDs and timestamps for history and list types,
   and fields as JSON for state types.
 
-  With `--id`, retrieves specific entries from a history or list by their
-  numeric ID. Three ID formats are supported:
+  With `--id`, retrieves specific entries from a history or list by numeric
+  ID or hash ID. Four ID formats are supported:
 
-  / Single ID: `--id 35` -- returns exactly one entry.
-  / Range: `--id 35-64` -- returns all entries with IDs 35 through 64 inclusive. Maximum range size is 10,000 entries.
-  / Comma-separated: `--id 1,5,12` -- returns the listed entries. Duplicates are ignored.
+  / Single numeric ID: `--id 35` -- returns exactly one entry.
+  / Single hash ID: `--id kv-A3fB` -- returns the entry matching that hash. Hash matching is prefix-based: `kv-A3f` will match if the prefix is unambiguous.
+  / Numeric range: `--id 35-64` -- returns all entries with numeric IDs 35 through 64 inclusive. Maximum range size is 10,000 entries. Ranges are numeric only.
+  / Comma-separated: `--id 1,kv-A3fB,12` -- returns the listed entries. Numeric and hash IDs can be mixed freely in comma lists.
 
-  Formats cannot be combined (e.g., `--id 1,5-10` is not valid). If any
-  requested IDs are not found, a note listing the missing IDs is printed to
-  stderr. The found entries are still printed to stdout.
+  If any requested IDs are not found, a note listing the missing IDs is
+  printed to stderr. The found entries are still printed to stdout.
 
   The `--id` flag only works on history and list types. Using it on a
   string, counter, or state key returns exit code 2 (type mismatch).
-  Parse failures (non-numeric IDs, reversed ranges, empty specs) return
-  exit code 4 (invalid input).],
+  Parse failures (reversed ranges, empty specs) return exit code 4
+  (invalid input).],
   flags: (
-    ([`--id <spec>`], [string], [Entry ID (`35`), range (`35-64`), or comma-separated IDs (`1,5,12`)]),
+    ([`--id <spec>`], [string], [Entry ID: numeric (`35`), hash (`kv-A3fB`), range (`35-64`), or comma-separated (`1,kv-A3fB,12`)]),
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
   ),
   examples: (
@@ -137,8 +137,9 @@ KV commands use structured exit codes for scripting:
     "mx kv get decisions",
     "mx kv get context --memory",
     "mx kv get shipped --id 35",
+    "mx kv get shipped --id kv-A3fB",
     "mx kv get shipped --id 35-64",
-    "mx kv get shipped --id 1,5,12,35",
+    "mx kv get shipped --id 1,kv-A3fB,12",
     "mx kv get shipped --id 35 --memory",
   ),
 )
@@ -211,6 +212,11 @@ History and list types both store timestamped entries with auto-assigned IDs.
 The difference is semantic: history is append-only (newest first, no pop),
 while lists support push/pop and maintain insertion order.
 
+Every entry gets two identifiers: a numeric ID (sequential, per-key) and a
+hash ID (a stable base58 string prefixed with `kv-`, e.g. `kv-A3fB`). Both
+can be used anywhere an ID is accepted. See #link(<hash-ids>)[Hash IDs] for
+details.
+
 Both types support `push`, `last`, `search`, `count`, `random`, `remove`, and
 entry lookup by ID via `get --id`. Both support structured data on entries
 (`--data` on push) and structured data filtering (`--where` on queries).
@@ -221,7 +227,15 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv push <key> <value>",
   [Push a value onto a history or list key. The entry is automatically
-  timestamped and assigned a unique ID.
+  timestamped and assigned both a numeric ID and a hash ID.
+
+  On success, prints the new entry's identifiers:
+
+  ```
+  kv-A3fB (42)
+  ```
+
+  Hash first (the primary stable identifier), numeric ID in parentheses.
 
   For *history* keys, new entries are inserted at the front (newest first).
   If the key has a `max_entries` schema constraint, the oldest entries are
@@ -249,8 +263,9 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 
 #command(
   "mx kv pop <key>",
-  [Pop the last item from a list key. Prints the removed entry with its ID,
-  value, and timestamp. Returns silently if the list is empty.
+  [Pop the last item from a list key. Prints the removed entry with its
+  numeric ID, hash ID, value, and timestamp. Returns silently if the list
+  is empty.
 
   Only works on list types. History keys are append-only and do not support
   pop.],
@@ -264,7 +279,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv last <key>",
   [Get the last N entries from a history or list key. Entries are printed
-  with their ID, value, and timestamp.
+  with their numeric ID, hash ID, value, and timestamp.
 
   For history keys, "last" means the most recent (entries are stored newest
   first). For list keys, "last" means the tail of the list.
@@ -309,7 +324,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   - Relative: `30m` (minutes), `1h` (hours), `7d` (days), `2w` (weeks)
   - Absolute: ISO-8601 format (e.g., `2025-01-15T10:00:00Z`)
 
-  Entries are printed with their ID, value, and timestamp.],
+  Entries are printed with their numeric ID, hash ID, value, and timestamp.],
   flags: (
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
   ),
@@ -326,8 +341,8 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv search <key> [query]",
   [Search entries in a list or history by case-insensitive substring match
-  and/or structured data filters. Prints matching entries with their ID,
-  value, timestamp, and any attached data.
+  and/or structured data filters. Prints matching entries with their numeric
+  ID, hash ID, value, timestamp, and any attached data.
 
   The text query is optional when `--where` filters are provided. You can
   search by text alone, by structured data alone, or by both. At least one
@@ -406,7 +421,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv random <key>",
   [Get N random entries from a history or list key. Entries are printed
-  with their ID, value, and timestamp.
+  with their numeric ID, hash ID, value, and timestamp.
 
   Useful for inspiration (pick a random idea), spot-checking (sample from
   a large history), or building variety into automated workflows.
@@ -443,18 +458,23 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 
 #command(
   "mx kv remove <key> [value]",
-  [Remove entries from a list or history by value substring or by numeric ID.
+  [Remove entries from a list or history by value substring or by ID.
   You must provide either a value substring or `--id`.
+
+  The `--id` flag accepts a numeric ID (`7`) or a hash ID (`kv-A3fB`).
+  Hash matching is prefix-based -- if the prefix is ambiguous (matches
+  multiple entries), an error is returned asking for more characters.
 
   By default, only the first match is removed. Use `--all` to remove every
   matching entry.],
   flags: (
-    ([`--id <n>`], [integer], [Remove the entry with this specific ID]),
+    ([`--id <spec>`], [string], [Remove the entry with this numeric ID or hash ID (`kv-XXXX`)]),
     ([`--all`], [flag], [Remove all matching entries (default: first match only)]),
   ),
   examples: (
     "mx kv remove todos \"write tests\"",
     "mx kv remove todos --id 7",
+    "mx kv remove todos --id kv-A3fB",
     "mx kv remove decisions \"typo\" --all",
   ),
 )
@@ -577,15 +597,16 @@ structured data (backward compatible with all existing entries).
 
 === Output format
 
-Entries with structured data display the JSON inline after the timestamp:
+Entries display the numeric ID, hash ID in brackets, value, timestamp, and any
+structured data:
 
 ```
-42: palmtop DSI fix (2026-05-08T14:30:00Z) {"tags":["palmtop","i915"],"status":"active"}
-43: display rotation patch (2026-05-08T15:00:00Z)
+42 [kv-A3fB]: palmtop DSI fix (2026-05-08T14:30:00Z) {"tags":["palmtop","i915"],"status":"active"}
+43 [kv-B7xQ]: display rotation patch (2026-05-08T15:00:00Z)
 ```
 
-Entries without data look exactly as they always have. The data suffix appears
-on all commands that display entries: `get`, `last`, `search`, `since`, `pop`,
+Entries without data omit the trailing JSON. This format appears on all
+commands that display entries: `get`, `last`, `search`, `since`, `pop`,
 `random`, and `dump`.
 
 === Filtering with `--where`
@@ -648,6 +669,69 @@ Structured data is fully backward compatible. Existing data files written
 before this feature was added continue to work without migration. Entries
 without data are simply treated as having no structured fields -- they will
 not match any `--where` clause, but they are otherwise unaffected.
+
+== Hash IDs <hash-ids>
+
+Every history and list entry has a stable hash ID in addition to its numeric
+ID. Hash IDs are short base58 strings (4--6 characters) prefixed with `kv-`
+for visual identification, e.g. `kv-A3fB`.
+
+=== Generation
+
+The hash is generated from `blake3(key + timestamp + id)`, with the first 4
+bytes encoded as base58 via base-d. This produces ~11 million unique addresses
+per key -- sufficient for typical KV usage. The hash is deterministic: the
+same key, timestamp, and numeric ID always produce the same hash.
+
+=== Push output
+
+`mx kv push` prints the new entry's identifiers on success:
+
+```
+kv-A3fB (42)
+```
+
+Hash first (the primary stable identifier), numeric ID in parentheses. This
+makes it easy to capture the hash for later use in scripts or follow-up
+commands.
+
+=== Dual addressing
+
+Anywhere a numeric ID is accepted, a hash ID also works:
+
+```bash
+# Get by hash
+mx kv get shipped --id kv-A3fB
+
+# Get by numeric (still works)
+mx kv get shipped --id 42
+
+# Mix in comma lists
+mx kv get shipped --id 42,kv-A3fB,15
+
+# Remove by hash
+mx kv remove shipped --id kv-A3fB
+```
+
+Numeric ranges remain numeric only (`35-64`). Hash IDs cannot be used in
+ranges because they are not ordered.
+
+=== Prefix matching
+
+Hash lookups are prefix-based: `kv-A3f` will match an entry with hash
+`A3fBx2` as long as the prefix uniquely identifies one entry. If the prefix
+is ambiguous (matches multiple entries), an error is returned:
+
+```
+Error: hash prefix 'kv-A3' is ambiguous: matches 3 entries, provide more characters
+```
+
+=== Backward compatibility
+
+Old data files written before hash IDs existed are back-filled automatically
+on first load. The store generates hashes for all entries that lack one,
+saves the file, and continues normally. This is a one-time migration -- no
+manual action is needed.
 
 == Management
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1800,9 +1800,9 @@ pub enum KvCommands {
         /// Value substring to match (omit if using --id)
         value: Option<String>,
 
-        /// Remove by entry ID
+        /// Remove by entry ID (numeric) or hash (kv-XXXX)
         #[arg(long)]
-        id: Option<u64>,
+        id: Option<String>,
 
         /// Remove all matches (default: first match only)
         #[arg(long)]

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 
 use crate::cli::{DumpFormat, KvCommands};
-use crate::kv::{self, KvError, KvStore, resolve_time_range};
+use crate::kv::{self, IdRef, KvError, KvStore, resolve_time_range};
 
 /// Map a KvError to the appropriate exit code.
 fn exit_code_for(err: &KvError) -> Option<i32> {
@@ -96,29 +96,49 @@ fn resolve_dump_memories(store: &KvStore, verbose: bool) {
     }
 }
 
-/// Parse an ID specification into a sorted, deduplicated list of u64 IDs.
+/// Parse a single token into an `IdRef`.
+///
+/// - Starts with `kv-` -> strip prefix, treat as hash
+/// - Pure digits -> numeric ID
+/// - Otherwise -> error
+fn parse_single_id(token: &str) -> Result<IdRef, String> {
+    let token = token.trim();
+    if let Some(hash) = token.strip_prefix("kv-") {
+        if hash.is_empty() {
+            return Err("empty hash after 'kv-' prefix".to_string());
+        }
+        Ok(IdRef::Hash(hash.to_string()))
+    } else {
+        let id: u64 = token
+            .parse()
+            .map_err(|_| format!("invalid ID '{}'", token))?;
+        Ok(IdRef::Numeric(id))
+    }
+}
+
+/// Parse an ID specification into a list of `IdRef`s.
 ///
 /// Accepted formats:
-/// - Single ID: "35" -> [35]
-/// - Range: "35-64" -> [35, 36, ..., 64]
-/// - Comma-separated: "1,5,12" -> [1, 5, 12]
-fn parse_id_spec(spec: &str) -> Result<Vec<u64>, String> {
+/// - Single numeric ID: "35" -> [Numeric(35)]
+/// - Hash ID: "kv-A3fB" -> [Hash("A3fB")]
+/// - Numeric range: "35-64" -> [Numeric(35), ..., Numeric(64)]
+/// - Comma-separated (can mix): "1,kv-A3fB,12" -> [Numeric(1), Hash("A3fB"), Numeric(12)]
+fn parse_id_spec(spec: &str) -> Result<Vec<IdRef>, String> {
     let spec = spec.trim();
     if spec.is_empty() {
         return Err("empty ID specification".to_string());
     }
 
-    let mut ids: Vec<u64> = if spec.contains(',') {
-        // Comma-separated list
+    if spec.contains(',') {
+        // Comma-separated list (can mix numeric and hash)
         spec.split(',')
-            .map(|s| {
-                s.trim()
-                    .parse::<u64>()
-                    .map_err(|_| format!("invalid ID '{}' in spec '{}'", s.trim(), spec))
-            })
-            .collect::<Result<Vec<_>, _>>()?
+            .map(|s| parse_single_id(s.trim()))
+            .collect::<Result<Vec<_>, _>>()
+    } else if spec.starts_with("kv-") {
+        // Single hash ID
+        Ok(vec![parse_single_id(spec)?])
     } else if spec.contains('-') {
-        // Range
+        // Numeric range
         let parts: Vec<&str> = spec.splitn(2, '-').collect();
         let start: u64 = parts[0].trim().parse().map_err(|_| {
             format!(
@@ -145,16 +165,11 @@ fn parse_id_spec(spec: &str) -> Result<Vec<u64>, String> {
                 MAX_RANGE_SIZE
             ));
         }
-        (start..=end).collect()
+        Ok((start..=end).map(IdRef::Numeric).collect())
     } else {
-        // Single ID
-        let id: u64 = spec.parse().map_err(|_| format!("invalid ID '{}'", spec))?;
-        vec![id]
-    };
-
-    ids.sort_unstable();
-    ids.dedup();
-    Ok(ids)
+        // Single numeric ID
+        Ok(vec![parse_single_id(spec)?])
+    }
 }
 
 /// Parse `--where` clause strings into `(key, value)` tuples.
@@ -204,29 +219,26 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 };
                 match store.get_entries_by_id(&key, &ids) {
                     Ok(hits) => {
-                        // Print found entries.
-                        // History entries always have a timestamp; list entries may not.
-                        // We check for empty ts to handle both types uniformly.
                         for hit in &hits {
-                            let data_suffix = kv::format_data_suffix(&hit.data);
-                            if hit.ts.is_empty() {
-                                println!("{}: {}{}", hit.id, hit.value, data_suffix);
-                            } else {
-                                println!("{}: {} ({}){}", hit.id, hit.value, hit.ts, data_suffix);
-                            }
+                            println!("{}", kv::format_entry_line(hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data));
                         }
 
                         // Report missing IDs
-                        let found_ids: HashSet<u64> = hits.iter().map(|h| h.id).collect();
-                        let missing: Vec<u64> = ids
+                        let found_numeric: HashSet<u64> = hits.iter().map(|h| h.id).collect();
+                        let found_hashes: Vec<&str> = hits.iter().map(|h| h.hash.as_str()).collect();
+                        let missing: Vec<String> = ids
                             .iter()
-                            .filter(|id| !found_ids.contains(id))
-                            .copied()
+                            .filter(|id_ref| match id_ref {
+                                IdRef::Numeric(n) => !found_numeric.contains(n),
+                                IdRef::Hash(h) => !found_hashes.iter().any(|fh| fh.starts_with(h.as_str())),
+                            })
+                            .map(|id_ref| match id_ref {
+                                IdRef::Numeric(n) => n.to_string(),
+                                IdRef::Hash(h) => format!("kv-{}", h),
+                            })
                             .collect();
                         if !missing.is_empty() {
-                            let missing_str: Vec<String> =
-                                missing.iter().map(|id| id.to_string()).collect();
-                            eprintln!("note: IDs not found: {}", missing_str.join(", "));
+                            eprintln!("note: IDs not found: {}", missing.join(", "));
                         }
 
                         if memory {
@@ -377,8 +389,9 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             };
 
             match store.push(&key, &value, parsed_data) {
-                Ok(()) => {
+                Ok(result) => {
                     store.save()?;
+                    println!("kv-{} ({})", result.hash, result.id);
                     Ok(kv::EXIT_OK)
                 }
                 Err(e) => handle_kv_err(e),
@@ -388,15 +401,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         KvCommands::Pop { key } => match store.pop(&key) {
             Ok(Some(entry)) => {
                 store.save()?;
-                let data_suffix = kv::format_data_suffix(&entry.data);
-                if entry.ts.is_empty() {
-                    println!("{}: {}{}", entry.id, entry.value, data_suffix);
-                } else {
-                    println!(
-                        "{}: {} ({}){}",
-                        entry.id, entry.value, entry.ts, data_suffix
-                    );
-                }
+                println!("{}", kv::format_entry_line(entry.id, &entry.hash, &entry.value, &entry.ts, &entry.data));
                 Ok(kv::EXIT_OK)
             }
             Ok(None) => {
@@ -471,13 +476,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         } => match store.since(&key, &timeref) {
             Ok(entries) => {
                 for entry in &entries {
-                    println!(
-                        "{}: {} ({}){}",
-                        entry.id,
-                        entry.value,
-                        entry.ts,
-                        kv::format_data_suffix(&entry.data)
-                    );
+                    println!("{}", kv::format_entry_line(entry.id, &entry.hash, &entry.value, &entry.ts, &entry.data));
                 }
                 if memory {
                     resolve_memory(&store, &key, verbose);
@@ -521,7 +520,20 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 eprintln!("Error: provide either a value substring or --id");
                 return Ok(kv::EXIT_KEY_NOT_FOUND);
             }
-            match store.remove(&key, value.as_deref(), id, all) {
+            // Parse --id as an IdRef (numeric or hash)
+            let id_ref = match &id {
+                Some(id_str) => {
+                    match parse_single_id(id_str) {
+                        Ok(r) => Some(r),
+                        Err(msg) => {
+                            eprintln!("Error: {}", msg);
+                            return Ok(kv::EXIT_INVALID_INPUT);
+                        }
+                    }
+                }
+                None => None,
+            };
+            match store.remove(&key, value.as_deref(), id_ref.as_ref(), all) {
                 Ok(result) => {
                     if result.removed.is_empty() {
                         eprintln!("No matching entries found");
@@ -567,12 +579,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         Ok(kv::EXIT_OK)
                     } else {
                         for hit in &hits {
-                            let data_suffix = kv::format_data_suffix(&hit.data);
-                            if hit.ts.is_empty() {
-                                println!("{}: {}{}", hit.id, hit.value, data_suffix);
-                            } else {
-                                println!("{}: {} ({}){}", hit.id, hit.value, hit.ts, data_suffix);
-                            }
+                            println!("{}", kv::format_entry_line(hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data));
                         }
                         if memory {
                             resolve_memory(&store, &key, verbose);
@@ -652,22 +659,31 @@ mod tests {
 
     #[test]
     fn parse_single_id() {
-        assert_eq!(parse_id_spec("35").unwrap(), vec![35]);
+        assert_eq!(parse_id_spec("35").unwrap(), vec![IdRef::Numeric(35)]);
     }
 
     #[test]
     fn parse_single_id_zero() {
-        assert_eq!(parse_id_spec("0").unwrap(), vec![0]);
+        assert_eq!(parse_id_spec("0").unwrap(), vec![IdRef::Numeric(0)]);
     }
 
     #[test]
     fn parse_range() {
-        assert_eq!(parse_id_spec("3-7").unwrap(), vec![3, 4, 5, 6, 7]);
+        assert_eq!(
+            parse_id_spec("3-7").unwrap(),
+            vec![
+                IdRef::Numeric(3),
+                IdRef::Numeric(4),
+                IdRef::Numeric(5),
+                IdRef::Numeric(6),
+                IdRef::Numeric(7),
+            ]
+        );
     }
 
     #[test]
     fn parse_range_single_element() {
-        assert_eq!(parse_id_spec("5-5").unwrap(), vec![5]);
+        assert_eq!(parse_id_spec("5-5").unwrap(), vec![IdRef::Numeric(5)]);
     }
 
     #[test]
@@ -679,17 +695,18 @@ mod tests {
 
     #[test]
     fn parse_comma_separated() {
-        assert_eq!(parse_id_spec("1,5,12").unwrap(), vec![1, 5, 12]);
-    }
-
-    #[test]
-    fn parse_comma_separated_deduplicates() {
-        assert_eq!(parse_id_spec("5,1,5,3,1").unwrap(), vec![1, 3, 5]);
+        assert_eq!(
+            parse_id_spec("1,5,12").unwrap(),
+            vec![IdRef::Numeric(1), IdRef::Numeric(5), IdRef::Numeric(12)]
+        );
     }
 
     #[test]
     fn parse_comma_separated_with_spaces() {
-        assert_eq!(parse_id_spec("1, 5, 12").unwrap(), vec![1, 5, 12]);
+        assert_eq!(
+            parse_id_spec("1, 5, 12").unwrap(),
+            vec![IdRef::Numeric(1), IdRef::Numeric(5), IdRef::Numeric(12)]
+        );
     }
 
     #[test]
@@ -747,6 +764,35 @@ mod tests {
     #[test]
     fn parse_range_too_large() {
         assert!(parse_id_spec("1-20000").is_err());
+    }
+
+    // -- hash ID parsing --
+
+    #[test]
+    fn parse_hash_id_single() {
+        assert_eq!(
+            parse_id_spec("kv-A3fB").unwrap(),
+            vec![IdRef::Hash("A3fB".to_string())]
+        );
+    }
+
+    #[test]
+    fn parse_hash_id_mixed_comma() {
+        assert_eq!(
+            parse_id_spec("1,kv-A3fB,12").unwrap(),
+            vec![
+                IdRef::Numeric(1),
+                IdRef::Hash("A3fB".to_string()),
+                IdRef::Numeric(12),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_hash_id_empty_hash() {
+        let result = parse_id_spec("kv-");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty hash"));
     }
 
     // -- parse_where_clauses --

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -220,17 +220,25 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 match store.get_entries_by_id(&key, &ids) {
                     Ok(hits) => {
                         for hit in &hits {
-                            println!("{}", kv::format_entry_line(hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data));
+                            println!(
+                                "{}",
+                                kv::format_entry_line(
+                                    hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                                )
+                            );
                         }
 
                         // Report missing IDs
                         let found_numeric: HashSet<u64> = hits.iter().map(|h| h.id).collect();
-                        let found_hashes: Vec<&str> = hits.iter().map(|h| h.hash.as_str()).collect();
+                        let found_hashes: Vec<&str> =
+                            hits.iter().map(|h| h.hash.as_str()).collect();
                         let missing: Vec<String> = ids
                             .iter()
                             .filter(|id_ref| match id_ref {
                                 IdRef::Numeric(n) => !found_numeric.contains(n),
-                                IdRef::Hash(h) => !found_hashes.iter().any(|fh| fh.starts_with(h.as_str())),
+                                IdRef::Hash(h) => {
+                                    !found_hashes.iter().any(|fh| fh.starts_with(h.as_str()))
+                                }
                             })
                             .map(|id_ref| match id_ref {
                                 IdRef::Numeric(n) => n.to_string(),
@@ -401,7 +409,16 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         KvCommands::Pop { key } => match store.pop(&key) {
             Ok(Some(entry)) => {
                 store.save()?;
-                println!("{}", kv::format_entry_line(entry.id, &entry.hash, &entry.value, &entry.ts, &entry.data));
+                println!(
+                    "{}",
+                    kv::format_entry_line(
+                        entry.id,
+                        &entry.hash,
+                        &entry.value,
+                        &entry.ts,
+                        &entry.data
+                    )
+                );
                 Ok(kv::EXIT_OK)
             }
             Ok(None) => {
@@ -476,7 +493,16 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         } => match store.since(&key, &timeref) {
             Ok(entries) => {
                 for entry in &entries {
-                    println!("{}", kv::format_entry_line(entry.id, &entry.hash, &entry.value, &entry.ts, &entry.data));
+                    println!(
+                        "{}",
+                        kv::format_entry_line(
+                            entry.id,
+                            &entry.hash,
+                            &entry.value,
+                            &entry.ts,
+                            &entry.data
+                        )
+                    );
                 }
                 if memory {
                     resolve_memory(&store, &key, verbose);
@@ -522,15 +548,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             }
             // Parse --id as an IdRef (numeric or hash)
             let id_ref = match &id {
-                Some(id_str) => {
-                    match parse_single_id(id_str) {
-                        Ok(r) => Some(r),
-                        Err(msg) => {
-                            eprintln!("Error: {}", msg);
-                            return Ok(kv::EXIT_INVALID_INPUT);
-                        }
+                Some(id_str) => match parse_single_id(id_str) {
+                    Ok(r) => Some(r),
+                    Err(msg) => {
+                        eprintln!("Error: {}", msg);
+                        return Ok(kv::EXIT_INVALID_INPUT);
                     }
-                }
+                },
                 None => None,
             };
             match store.remove(&key, value.as_deref(), id_ref.as_ref(), all) {
@@ -579,7 +603,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         Ok(kv::EXIT_OK)
                     } else {
                         for hit in &hits {
-                            println!("{}", kv::format_entry_line(hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data));
+                            println!(
+                                "{}",
+                                kv::format_entry_line(
+                                    hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                                )
+                            );
                         }
                         if memory {
                             resolve_memory(&store, &key, verbose);

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -415,9 +415,8 @@ pub struct CountResult {
 pub fn generate_entry_hash(key: &str, ts: &str, id: u64) -> String {
     let input = format!("{}:{}:{}", key, ts, id);
     let hash_bytes = hash(input.as_bytes(), HashAlgorithm::Blake3);
-    let registry = DICT_REGISTRY.get_or_init(|| {
-        DictionaryRegistry::load_default().expect("base-d dictionaries")
-    });
+    let registry = DICT_REGISTRY
+        .get_or_init(|| DictionaryRegistry::load_default().expect("base-d dictionaries"));
     let dict = registry.dictionary("base58").expect("base58 dictionary");
     encode(&hash_bytes[..4], &dict)
 }
@@ -1138,7 +1137,8 @@ impl KvStore {
                                 n => {
                                     return Err(KvError::Other(anyhow::anyhow!(
                                         "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                        h, n
+                                        h,
+                                        n
                                     )));
                                 }
                             }
@@ -1177,7 +1177,8 @@ impl KvStore {
                                 n => {
                                     return Err(KvError::Other(anyhow::anyhow!(
                                         "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                        h, n
+                                        h,
+                                        n
                                     )));
                                 }
                             }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -20,6 +20,10 @@ use crate::cli::TimeRangeArgs;
 /// even if both schema and data fall back to the legacy location.
 static LEGACY_KV_WARNING_EMITTED: OnceLock<()> = OnceLock::new();
 
+/// Cached dictionary registry for hash generation -- avoids re-allocating
+/// the HashMap on every `generate_entry_hash` call.
+static DICT_REGISTRY: OnceLock<DictionaryRegistry> = OnceLock::new();
+
 /// The single legacy-fallback warning copy. Lives here so the schema and data
 /// resolvers cannot drift apart.
 const LEGACY_KV_WARNING: &str = "note: reading kv from `~/.crewu/kv/` -- this default is moving to \
@@ -411,11 +415,11 @@ pub struct CountResult {
 pub fn generate_entry_hash(key: &str, ts: &str, id: u64) -> String {
     let input = format!("{}:{}:{}", key, ts, id);
     let hash_bytes = hash(input.as_bytes(), HashAlgorithm::Blake3);
-    let registry = DictionaryRegistry::load_default().expect("base-d dictionaries");
+    let registry = DICT_REGISTRY.get_or_init(|| {
+        DictionaryRegistry::load_default().expect("base-d dictionaries")
+    });
     let dict = registry.dictionary("base58").expect("base58 dictionary");
-    let full = encode(&hash_bytes[..4], &dict);
-    // base58 of 4 bytes is 5-6 chars; return as-is
-    full
+    encode(&hash_bytes[..4], &dict)
 }
 
 /// Result of a push operation, carrying both the numeric and hash IDs.
@@ -461,12 +465,14 @@ impl KvStore {
         };
 
         // Back-fill hashes for entries loaded without one (pre-hash data).
+        let mut needs_save = false;
         for (key, value) in &mut data.entries {
             match value {
                 DataValue::History { entries, .. } => {
                     for e in entries.iter_mut() {
                         if e.hash.is_empty() {
                             e.hash = generate_entry_hash(key, &e.ts, e.id);
+                            needs_save = true;
                         }
                     }
                 }
@@ -474,6 +480,7 @@ impl KvStore {
                     for e in items.iter_mut() {
                         if e.hash.is_empty() {
                             e.hash = generate_entry_hash(key, &e.ts, e.id);
+                            needs_save = true;
                         }
                     }
                 }
@@ -481,11 +488,17 @@ impl KvStore {
             }
         }
 
-        Ok(KvStore {
+        let mut store = KvStore {
             schema,
             data,
             data_path: data_path.to_path_buf(),
-        })
+        };
+
+        if needs_save {
+            store.save()?;
+        }
+
+        Ok(store)
     }
 
     /// Load from environment variables. Resolves {agent} placeholder.
@@ -1113,7 +1126,22 @@ impl KvStore {
                     let pos = match id_ref {
                         IdRef::Numeric(id) => entries.iter().position(|e| e.id == *id),
                         IdRef::Hash(h) => {
-                            entries.iter().position(|e| e.hash.starts_with(h.as_str()))
+                            let matches: Vec<usize> = entries
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, e)| e.hash.starts_with(h.as_str()))
+                                .map(|(i, _)| i)
+                                .collect();
+                            match matches.len() {
+                                0 => None,
+                                1 => Some(matches[0]),
+                                n => {
+                                    return Err(KvError::Other(anyhow::anyhow!(
+                                        "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
+                                        h, n
+                                    )));
+                                }
+                            }
                         }
                     };
                     if let Some(pos) = pos {
@@ -1136,7 +1164,24 @@ impl KvStore {
                 if let Some(id_ref) = by_id {
                     let pos = match id_ref {
                         IdRef::Numeric(id) => items.iter().position(|e| e.id == *id),
-                        IdRef::Hash(h) => items.iter().position(|e| e.hash.starts_with(h.as_str())),
+                        IdRef::Hash(h) => {
+                            let matches: Vec<usize> = items
+                                .iter()
+                                .enumerate()
+                                .filter(|(_, e)| e.hash.starts_with(h.as_str()))
+                                .map(|(i, _)| i)
+                                .collect();
+                            match matches.len() {
+                                0 => None,
+                                1 => Some(matches[0]),
+                                n => {
+                                    return Err(KvError::Other(anyhow::anyhow!(
+                                        "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
+                                        h, n
+                                    )));
+                                }
+                            }
+                        }
                     };
                     if let Some(pos) = pos {
                         removed.push(items.remove(pos).value);
@@ -4658,6 +4703,37 @@ max_entries = 5
             }
             _ => panic!("Expected list"),
         }
+    }
+
+    #[test]
+    fn remove_by_ambiguous_hash_prefix_errors() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "beta", None).unwrap();
+
+        // Manually set both entries to share a hash prefix.
+        match store.data.entries.get_mut("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                items[0].hash = "ABCxyz1".to_string();
+                items[1].hash = "ABCxyz2".to_string();
+            }
+            _ => panic!("Expected list"),
+        }
+
+        // Removing by the shared prefix "ABC" should return an ambiguity error.
+        let result = store.remove("tags", None, Some(&IdRef::Hash("ABC".to_string())), false);
+        assert!(result.is_err(), "expected ambiguity error");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("ambiguous"),
+            "error should mention ambiguity, got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("matches 2 entries"),
+            "error should report match count, got: {}",
+            err_msg
+        );
     }
 
     #[test]

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -978,9 +978,7 @@ impl KvStore {
             let chosen: Vec<_> = filtered.choose_multiple(&mut rng, take).collect();
             chosen
                 .into_iter()
-                .map(|(value, id, hash, ts, data)| {
-                    format_entry_line(*id, hash, value, ts, data)
-                })
+                .map(|(value, id, hash, ts, data)| format_entry_line(*id, hash, value, ts, data))
                 .collect()
         };
 
@@ -993,7 +991,15 @@ impl KvStore {
                             range.is_none_or(|r| ts_in_range(&e.ts, r))
                                 && where_matches(&e.data, where_clauses)
                         })
-                        .map(|e| (e.value.as_str(), e.id, e.hash.as_str(), e.ts.as_str(), &e.data))
+                        .map(|e| {
+                            (
+                                e.value.as_str(),
+                                e.id,
+                                e.hash.as_str(),
+                                e.ts.as_str(),
+                                &e.data,
+                            )
+                        })
                         .collect();
                     let available = filtered.len();
                     if available == 0 && !entries.is_empty() {
@@ -1016,7 +1022,15 @@ impl KvStore {
                             range.is_none_or(|r| ts_in_range(&e.ts, r))
                                 && where_matches(&e.data, where_clauses)
                         })
-                        .map(|e| (e.value.as_str(), e.id, e.hash.as_str(), e.ts.as_str(), &e.data))
+                        .map(|e| {
+                            (
+                                e.value.as_str(),
+                                e.id,
+                                e.hash.as_str(),
+                                e.ts.as_str(),
+                                &e.data,
+                            )
+                        })
                         .collect();
                     let available = filtered.len();
                     if available == 0 && !items.is_empty() {
@@ -1098,7 +1112,9 @@ impl KvStore {
                 if let Some(id_ref) = by_id {
                     let pos = match id_ref {
                         IdRef::Numeric(id) => entries.iter().position(|e| e.id == *id),
-                        IdRef::Hash(h) => entries.iter().position(|e| e.hash.starts_with(h.as_str())),
+                        IdRef::Hash(h) => {
+                            entries.iter().position(|e| e.hash.starts_with(h.as_str()))
+                        }
                     };
                     if let Some(pos) = pos {
                         removed.push(entries.remove(pos).value);
@@ -1260,9 +1276,7 @@ impl KvStore {
             if numeric_ids.contains(&id) {
                 return true;
             }
-            hash_prefixes
-                .iter()
-                .any(|prefix| hash.starts_with(prefix))
+            hash_prefixes.iter().any(|prefix| hash.starts_with(prefix))
         };
 
         let mut hits = Vec::new();
@@ -1813,7 +1827,13 @@ pub fn ts_in_range(ts: &str, range: &TimeRange) -> bool {
 // ---------------------------------------------------------------------------
 
 /// Format a single entry line with numeric ID, hash, value, optional timestamp, and data suffix.
-pub fn format_entry_line(id: u64, hash: &str, value: &str, ts: &str, data: &Option<serde_json::Value>) -> String {
+pub fn format_entry_line(
+    id: u64,
+    hash: &str,
+    value: &str,
+    ts: &str,
+    data: &Option<serde_json::Value>,
+) -> String {
     let data_suffix = format_data_suffix(data);
     if ts.is_empty() {
         format!("{} [kv-{}]: {}{}", id, hash, value, data_suffix)
@@ -2350,7 +2370,9 @@ max_entries = 5
         store.push("tags", "beta", None).unwrap();
         store.push("tags", "alpha-2", None).unwrap();
 
-        let result = store.remove("tags", Some("alpha"), None::<&IdRef>, false).unwrap();
+        let result = store
+            .remove("tags", Some("alpha"), None::<&IdRef>, false)
+            .unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "alpha");
 
@@ -2372,7 +2394,9 @@ max_entries = 5
         store.push("tags", "beta", None).unwrap();
         store.push("tags", "alpha-2", None).unwrap();
 
-        let result = store.remove("tags", Some("alpha"), None::<&IdRef>, true).unwrap();
+        let result = store
+            .remove("tags", Some("alpha"), None::<&IdRef>, true)
+            .unwrap();
         assert_eq!(result.removed.len(), 2);
 
         match store.get("tags").unwrap() {
@@ -2397,7 +2421,9 @@ max_entries = 5
             _ => panic!("Expected list"),
         };
 
-        let result = store.remove("tags", None, Some(&IdRef::Numeric(beta_id)), false).unwrap();
+        let result = store
+            .remove("tags", None, Some(&IdRef::Numeric(beta_id)), false)
+            .unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "beta");
     }
@@ -2430,7 +2456,9 @@ max_entries = 5
         store.push("tags", "Alpha", None).unwrap();
         store.push("tags", "beta", None).unwrap();
 
-        let result = store.remove("tags", Some("alpha"), None::<&IdRef>, false).unwrap();
+        let result = store
+            .remove("tags", Some("alpha"), None::<&IdRef>, false)
+            .unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "Alpha");
     }
@@ -2777,7 +2805,9 @@ max_entries = 5
         store.push("tags", "c", None).unwrap();
 
         // Remove "b"
-        store.remove("tags", Some("b"), None::<&IdRef>, false).unwrap();
+        store
+            .remove("tags", Some("b"), None::<&IdRef>, false)
+            .unwrap();
 
         // Push "d" — should get id=4, not reuse id=2
         store.push("tags", "d", None).unwrap();
@@ -4600,10 +4630,7 @@ max_entries = 5
         let hits = store
             .get_entries_by_id(
                 "tags",
-                &[
-                    IdRef::Numeric(r1.id),
-                    IdRef::Hash(r2.hash.clone()),
-                ],
+                &[IdRef::Numeric(r1.id), IdRef::Hash(r2.hash.clone())],
             )
             .unwrap();
         assert_eq!(hits.len(), 2);

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, bail};
+use base_d::{DictionaryRegistry, HashAlgorithm, encode, hash};
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -333,6 +334,7 @@ impl<'de> Deserialize<'de> for DataValue {
                             next_id += 1;
                             ListEntry {
                                 id: next_id,
+                                hash: String::new(),
                                 value: s,
                                 ts: String::new(),
                                 data: None,
@@ -353,6 +355,8 @@ impl<'de> Deserialize<'de> for DataValue {
 pub struct HistoryEntry {
     #[serde(default)]
     pub id: u64,
+    #[serde(default)]
+    pub hash: String,
     pub value: String,
     pub ts: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -362,6 +366,8 @@ pub struct HistoryEntry {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ListEntry {
     pub id: u64,
+    #[serde(default)]
+    pub hash: String,
     pub value: String,
     pub ts: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -378,6 +384,7 @@ pub struct RemoveResult {
 #[derive(Debug)]
 pub struct SearchHit {
     pub id: u64,
+    pub hash: String,
     pub value: String,
     pub ts: String,
     pub data: Option<serde_json::Value>,
@@ -391,6 +398,38 @@ pub struct CountResult {
     /// Total entries for the key. Present only when a value filter was applied.
     pub total: Option<usize>,
     pub latest_ts: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Hash ID generation
+// ---------------------------------------------------------------------------
+
+/// Generate a short, stable base58 hash for a kv entry.
+///
+/// Input: `"{key}:{ts}:{id}"` hashed with blake3, first 4 bytes encoded as
+/// base58.  Produces a ~5-6 character alphanumeric string.
+pub fn generate_entry_hash(key: &str, ts: &str, id: u64) -> String {
+    let input = format!("{}:{}:{}", key, ts, id);
+    let hash_bytes = hash(input.as_bytes(), HashAlgorithm::Blake3);
+    let registry = DictionaryRegistry::load_default().expect("base-d dictionaries");
+    let dict = registry.dictionary("base58").expect("base58 dictionary");
+    let full = encode(&hash_bytes[..4], &dict);
+    // base58 of 4 bytes is 5-6 chars; return as-is
+    full
+}
+
+/// Result of a push operation, carrying both the numeric and hash IDs.
+#[derive(Debug, Clone)]
+pub struct PushResult {
+    pub id: u64,
+    pub hash: String,
+}
+
+/// Reference to a kv entry by either its numeric ID or its hash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdRef {
+    Numeric(u64),
+    Hash(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -412,7 +451,7 @@ impl KvStore {
         let schema: Schema = toml::from_str(&schema_str)
             .with_context(|| format!("Failed to parse schema: {}", schema_path.display()))?;
 
-        let data = if data_path.exists() {
+        let mut data = if data_path.exists() {
             let data_str = fs::read_to_string(data_path)
                 .with_context(|| format!("Failed to read data: {}", data_path.display()))?;
             serde_json::from_str(&data_str)
@@ -420,6 +459,27 @@ impl KvStore {
         } else {
             DataFile::default()
         };
+
+        // Back-fill hashes for entries loaded without one (pre-hash data).
+        for (key, value) in &mut data.entries {
+            match value {
+                DataValue::History { entries, .. } => {
+                    for e in entries.iter_mut() {
+                        if e.hash.is_empty() {
+                            e.hash = generate_entry_hash(key, &e.ts, e.id);
+                        }
+                    }
+                }
+                DataValue::List { items, .. } => {
+                    for e in items.iter_mut() {
+                        if e.hash.is_empty() {
+                            e.hash = generate_entry_hash(key, &e.ts, e.id);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
 
         Ok(KvStore {
             schema,
@@ -724,7 +784,7 @@ impl KvStore {
         key: &str,
         value: &str,
         data: Option<serde_json::Value>,
-    ) -> Result<(), KvError> {
+    ) -> Result<PushResult, KvError> {
         self.push_with_ts(key, value, Utc::now(), data)
     }
 
@@ -735,8 +795,9 @@ impl KvStore {
         value: &str,
         ts: DateTime<Utc>,
         data: Option<serde_json::Value>,
-    ) -> Result<(), KvError> {
+    ) -> Result<PushResult, KvError> {
         let def = self.key_def(key)?.clone();
+        let ts_str = ts.to_rfc3339();
 
         match def.value_type {
             ValueType::History => {
@@ -749,12 +810,14 @@ impl KvStore {
                 match entry {
                     DataValue::History { entries, .. } => {
                         let next_id = entries.iter().map(|e| e.id).max().unwrap_or(0) + 1;
+                        let hash = generate_entry_hash(key, &ts_str, next_id);
                         entries.insert(
                             0,
                             HistoryEntry {
                                 id: next_id,
+                                hash: hash.clone(),
                                 value: value.to_string(),
-                                ts: ts.to_rfc3339(),
+                                ts: ts_str,
                                 data,
                             },
                         );
@@ -762,13 +825,12 @@ impl KvStore {
                         if let Some(max) = def.max_entries {
                             entries.truncate(max);
                         }
+                        Ok(PushResult { id: next_id, hash })
                     }
-                    _ => {
-                        return Err(KvError::Other(anyhow::anyhow!(
-                            "Data corruption: key '{}' has wrong runtime type",
-                            key
-                        )));
-                    }
+                    _ => Err(KvError::Other(anyhow::anyhow!(
+                        "Data corruption: key '{}' has wrong runtime type",
+                        key
+                    ))),
                 }
             }
             ValueType::List => {
@@ -781,10 +843,12 @@ impl KvStore {
                 match entry {
                     DataValue::List { items, .. } => {
                         let next_id = items.iter().map(|e| e.id).max().unwrap_or(0) + 1;
+                        let hash = generate_entry_hash(key, &ts_str, next_id);
                         items.push(ListEntry {
                             id: next_id,
+                            hash: hash.clone(),
                             value: value.to_string(),
-                            ts: ts.to_rfc3339(),
+                            ts: ts_str,
                             data,
                         });
                         // Drop oldest at max_entries — single drain instead of O(n^2) remove loop
@@ -793,25 +857,20 @@ impl KvStore {
                         {
                             items.drain(0..items.len() - max);
                         }
+                        Ok(PushResult { id: next_id, hash })
                     }
-                    _ => {
-                        return Err(KvError::Other(anyhow::anyhow!(
-                            "Data corruption: key '{}' has wrong runtime type",
-                            key
-                        )));
-                    }
+                    _ => Err(KvError::Other(anyhow::anyhow!(
+                        "Data corruption: key '{}' has wrong runtime type",
+                        key
+                    ))),
                 }
             }
-            _ => {
-                return Err(KvError::TypeMismatch {
-                    key: key.to_string(),
-                    expected: "history or list".to_string(),
-                    got: def.value_type.to_string(),
-                });
-            }
+            _ => Err(KvError::TypeMismatch {
+                key: key.to_string(),
+                expected: "history or list".to_string(),
+                got: def.value_type.to_string(),
+            }),
         }
-
-        Ok(())
     }
 
     /// Pop the last item from a list. History is append-only.
@@ -858,15 +917,7 @@ impl KvStore {
                     let start = filtered.len().saturating_sub(count);
                     Ok(filtered[start..]
                         .iter()
-                        .map(|e| {
-                            format!(
-                                "{}: {} ({}){}",
-                                e.id,
-                                e.value,
-                                e.ts,
-                                format_data_suffix(&e.data)
-                            )
-                        })
+                        .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
                         .collect())
                 }
                 _ => Ok(vec![]),
@@ -883,19 +934,7 @@ impl KvStore {
                     let start = filtered.len().saturating_sub(count);
                     Ok(filtered[start..]
                         .iter()
-                        .map(|e| {
-                            if e.ts.is_empty() {
-                                format!("{}: {}{}", e.id, e.value, format_data_suffix(&e.data))
-                            } else {
-                                format!(
-                                    "{}: {} ({}){}",
-                                    e.id,
-                                    e.value,
-                                    e.ts,
-                                    format_data_suffix(&e.data)
-                                )
-                            }
-                        })
+                        .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
                         .collect())
                 }
                 _ => Ok(vec![]),
@@ -927,8 +966,8 @@ impl KvStore {
         let def = self.key_def(key)?;
 
         // Shared sampling + formatting closure. Takes a filtered vec of
-        // (value, id, ts, data) tuples and returns formatted strings.
-        let sample = |filtered: Vec<(&str, u64, &str, &Option<serde_json::Value>)>,
+        // (value, id, hash, ts, data) tuples and returns formatted strings.
+        let sample = |filtered: Vec<(&str, u64, &str, &str, &Option<serde_json::Value>)>,
                       n: usize|
          -> Vec<String> {
             if filtered.is_empty() {
@@ -939,12 +978,8 @@ impl KvStore {
             let chosen: Vec<_> = filtered.choose_multiple(&mut rng, take).collect();
             chosen
                 .into_iter()
-                .map(|(value, id, ts, data)| {
-                    if ts.is_empty() {
-                        format!("{}: {}{}", id, value, format_data_suffix(data))
-                    } else {
-                        format!("{}: {} ({}){}", id, value, ts, format_data_suffix(data))
-                    }
+                .map(|(value, id, hash, ts, data)| {
+                    format_entry_line(*id, hash, value, ts, data)
                 })
                 .collect()
         };
@@ -958,7 +993,7 @@ impl KvStore {
                             range.is_none_or(|r| ts_in_range(&e.ts, r))
                                 && where_matches(&e.data, where_clauses)
                         })
-                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str(), &e.data))
+                        .map(|e| (e.value.as_str(), e.id, e.hash.as_str(), e.ts.as_str(), &e.data))
                         .collect();
                     let available = filtered.len();
                     if available == 0 && !entries.is_empty() {
@@ -981,7 +1016,7 @@ impl KvStore {
                             range.is_none_or(|r| ts_in_range(&e.ts, r))
                                 && where_matches(&e.data, where_clauses)
                         })
-                        .map(|e| (e.value.as_str(), e.id, e.ts.as_str(), &e.data))
+                        .map(|e| (e.value.as_str(), e.id, e.hash.as_str(), e.ts.as_str(), &e.data))
                         .collect();
                     let available = filtered.len();
                     if available == 0 && !items.is_empty() {
@@ -1032,16 +1067,16 @@ impl KvStore {
         Ok(())
     }
 
-    /// Remove entries from a list or history by value substring or by ID.
+    /// Remove entries from a list or history by value substring or by ID ref.
     ///
-    /// - `by_id`: if Some, remove the entry with that ID (ignores `value` and `all`).
+    /// - `by_id`: if Some, remove the entry matching that `IdRef` (ignores `value` and `all`).
     /// - `value`: substring match (case-insensitive).
     /// - `all`: if true, remove all matches; otherwise remove only the first match.
     pub fn remove(
         &mut self,
         key: &str,
         value: Option<&str>,
-        by_id: Option<u64>,
+        by_id: Option<&IdRef>,
         all: bool,
     ) -> Result<RemoveResult, KvError> {
         let def = self.key_def(key)?;
@@ -1060,8 +1095,12 @@ impl KvStore {
 
         match self.data.entries.get_mut(key) {
             Some(DataValue::History { entries, .. }) => {
-                if let Some(id) = by_id {
-                    if let Some(pos) = entries.iter().position(|e| e.id == id) {
+                if let Some(id_ref) = by_id {
+                    let pos = match id_ref {
+                        IdRef::Numeric(id) => entries.iter().position(|e| e.id == *id),
+                        IdRef::Hash(h) => entries.iter().position(|e| e.hash.starts_with(h.as_str())),
+                    };
+                    if let Some(pos) = pos {
                         removed.push(entries.remove(pos).value);
                     }
                 } else if let Some(query) = value {
@@ -1078,8 +1117,12 @@ impl KvStore {
                 }
             }
             Some(DataValue::List { items, .. }) => {
-                if let Some(id) = by_id {
-                    if let Some(pos) = items.iter().position(|e| e.id == id) {
+                if let Some(id_ref) = by_id {
+                    let pos = match id_ref {
+                        IdRef::Numeric(id) => items.iter().position(|e| e.id == *id),
+                        IdRef::Hash(h) => items.iter().position(|e| e.hash.starts_with(h.as_str())),
+                    };
+                    if let Some(pos) = pos {
                         removed.push(items.remove(pos).value);
                     }
                 } else if let Some(query) = value {
@@ -1145,6 +1188,7 @@ impl KvStore {
                     }
                     hits.push(SearchHit {
                         id: e.id,
+                        hash: e.hash.clone(),
                         value: e.value.clone(),
                         ts: e.ts.clone(),
                         data: e.data.clone(),
@@ -1166,6 +1210,7 @@ impl KvStore {
                     }
                     hits.push(SearchHit {
                         id: e.id,
+                        hash: e.hash.clone(),
                         value: e.value.clone(),
                         ts: e.ts.clone(),
                         data: e.data.clone(),
@@ -1178,11 +1223,12 @@ impl KvStore {
         Ok(hits)
     }
 
-    /// Look up entries by ID in a history or list.
+    /// Look up entries by ID (numeric or hash) in a history or list.
     ///
     /// Returns matching entries as `SearchHit`s (same struct used by `search`).
+    /// Hash matching is prefix-based: `"A3f"` matches an entry with hash `"A3fBx2"`.
     /// Only works on History and List types; returns TypeMismatch for others.
-    pub fn get_entries_by_id(&self, key: &str, ids: &[u64]) -> Result<Vec<SearchHit>, KvError> {
+    pub fn get_entries_by_id(&self, key: &str, ids: &[IdRef]) -> Result<Vec<SearchHit>, KvError> {
         let def = self.key_def(key)?;
         match def.value_type {
             ValueType::History | ValueType::List => {}
@@ -1195,15 +1241,39 @@ impl KvStore {
             }
         }
 
-        let id_set: HashSet<u64> = ids.iter().copied().collect();
+        let numeric_ids: HashSet<u64> = ids
+            .iter()
+            .filter_map(|r| match r {
+                IdRef::Numeric(n) => Some(*n),
+                _ => None,
+            })
+            .collect();
+        let hash_prefixes: Vec<&str> = ids
+            .iter()
+            .filter_map(|r| match r {
+                IdRef::Hash(h) => Some(h.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        let matches_entry = |id: u64, hash: &str| -> bool {
+            if numeric_ids.contains(&id) {
+                return true;
+            }
+            hash_prefixes
+                .iter()
+                .any(|prefix| hash.starts_with(prefix))
+        };
+
         let mut hits = Vec::new();
 
         match self.data.entries.get(key) {
             Some(DataValue::History { entries, .. }) => {
                 for e in entries {
-                    if id_set.contains(&e.id) {
+                    if matches_entry(e.id, &e.hash) {
                         hits.push(SearchHit {
                             id: e.id,
+                            hash: e.hash.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1213,9 +1283,10 @@ impl KvStore {
             }
             Some(DataValue::List { items, .. }) => {
                 for e in items {
-                    if id_set.contains(&e.id) {
+                    if matches_entry(e.id, &e.hash) {
                         hits.push(SearchHit {
                             id: e.id,
+                            hash: e.hash.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1741,6 +1812,16 @@ pub fn ts_in_range(ts: &str, range: &TimeRange) -> bool {
 // Display helpers (for CLI output)
 // ---------------------------------------------------------------------------
 
+/// Format a single entry line with numeric ID, hash, value, optional timestamp, and data suffix.
+pub fn format_entry_line(id: u64, hash: &str, value: &str, ts: &str, data: &Option<serde_json::Value>) -> String {
+    let data_suffix = format_data_suffix(data);
+    if ts.is_empty() {
+        format!("{} [kv-{}]: {}{}", id, hash, value, data_suffix)
+    } else {
+        format!("{} [kv-{}]: {} ({}){}", id, hash, value, ts, data_suffix)
+    }
+}
+
 /// Format a DataValue for human-readable CLI output.
 pub fn format_value(value: &DataValue) -> String {
     match value {
@@ -1748,15 +1829,7 @@ pub fn format_value(value: &DataValue) -> String {
         DataValue::String { value } => value.clone(),
         DataValue::History { entries, .. } => entries
             .iter()
-            .map(|e| {
-                format!(
-                    "{}: {} ({}){}",
-                    e.id,
-                    e.value,
-                    e.ts,
-                    format_data_suffix(&e.data)
-                )
-            })
+            .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
             .collect::<Vec<_>>()
             .join("\n"),
         DataValue::State { fields, .. } => {
@@ -1764,19 +1837,7 @@ pub fn format_value(value: &DataValue) -> String {
         }
         DataValue::List { items, .. } => items
             .iter()
-            .map(|e| {
-                if e.ts.is_empty() {
-                    format!("{}: {}{}", e.id, e.value, format_data_suffix(&e.data))
-                } else {
-                    format!(
-                        "{}: {} ({}){}",
-                        e.id,
-                        e.value,
-                        e.ts,
-                        format_data_suffix(&e.data)
-                    )
-                }
-            })
+            .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
             .collect::<Vec<_>>()
             .join("\n"),
     }
@@ -2289,7 +2350,7 @@ max_entries = 5
         store.push("tags", "beta", None).unwrap();
         store.push("tags", "alpha-2", None).unwrap();
 
-        let result = store.remove("tags", Some("alpha"), None, false).unwrap();
+        let result = store.remove("tags", Some("alpha"), None::<&IdRef>, false).unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "alpha");
 
@@ -2311,7 +2372,7 @@ max_entries = 5
         store.push("tags", "beta", None).unwrap();
         store.push("tags", "alpha-2", None).unwrap();
 
-        let result = store.remove("tags", Some("alpha"), None, true).unwrap();
+        let result = store.remove("tags", Some("alpha"), None::<&IdRef>, true).unwrap();
         assert_eq!(result.removed.len(), 2);
 
         match store.get("tags").unwrap() {
@@ -2336,7 +2397,7 @@ max_entries = 5
             _ => panic!("Expected list"),
         };
 
-        let result = store.remove("tags", None, Some(beta_id), false).unwrap();
+        let result = store.remove("tags", None, Some(&IdRef::Numeric(beta_id)), false).unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "beta");
     }
@@ -2351,7 +2412,7 @@ max_entries = 5
             .unwrap();
 
         let result = store
-            .remove("flavor_history", Some("bergamot"), None, false)
+            .remove("flavor_history", Some("bergamot"), None::<&IdRef>, false)
             .unwrap();
         assert_eq!(result.removed.len(), 1);
 
@@ -2369,7 +2430,7 @@ max_entries = 5
         store.push("tags", "Alpha", None).unwrap();
         store.push("tags", "beta", None).unwrap();
 
-        let result = store.remove("tags", Some("alpha"), None, false).unwrap();
+        let result = store.remove("tags", Some("alpha"), None::<&IdRef>, false).unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "Alpha");
     }
@@ -2377,7 +2438,7 @@ max_entries = 5
     #[test]
     fn remove_type_mismatch() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.remove("warmth", Some("x"), None, false);
+        let result = store.remove("warmth", Some("x"), None::<&IdRef>, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2456,7 +2517,7 @@ max_entries = 5
         };
 
         let hits = store
-            .get_entries_by_id("flavor_history", &[target_id])
+            .get_entries_by_id("flavor_history", &[IdRef::Numeric(target_id)])
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, target_id);
@@ -2476,7 +2537,9 @@ max_entries = 5
             _ => panic!("Expected list"),
         };
 
-        let hits = store.get_entries_by_id("tags", &[target_id]).unwrap();
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Numeric(target_id)])
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, target_id);
         assert_eq!(hits[0].value, "beta");
@@ -2489,7 +2552,12 @@ max_entries = 5
         store.push("tags", "beta", None).unwrap();
         store.push("tags", "gamma", None).unwrap();
 
-        let hits = store.get_entries_by_id("tags", &[1, 2, 3]).unwrap();
+        let hits = store
+            .get_entries_by_id(
+                "tags",
+                &[IdRef::Numeric(1), IdRef::Numeric(2), IdRef::Numeric(3)],
+            )
+            .unwrap();
         assert_eq!(hits.len(), 3);
         assert_eq!(hits[0].value, "alpha");
         assert_eq!(hits[1].value, "beta");
@@ -2503,7 +2571,9 @@ max_entries = 5
         store.push("tags", "beta", None).unwrap();
         store.push("tags", "gamma", None).unwrap();
 
-        let hits = store.get_entries_by_id("tags", &[1, 3]).unwrap();
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Numeric(1), IdRef::Numeric(3)])
+            .unwrap();
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].value, "alpha");
         assert_eq!(hits[1].value, "gamma");
@@ -2516,7 +2586,12 @@ max_entries = 5
         store.push("tags", "beta", None).unwrap();
 
         // Request IDs 1, 2, 99 — only 1 and 2 exist
-        let hits = store.get_entries_by_id("tags", &[1, 2, 99]).unwrap();
+        let hits = store
+            .get_entries_by_id(
+                "tags",
+                &[IdRef::Numeric(1), IdRef::Numeric(2), IdRef::Numeric(99)],
+            )
+            .unwrap();
         assert_eq!(hits.len(), 2);
     }
 
@@ -2525,14 +2600,16 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         store.push("tags", "alpha", None).unwrap();
 
-        let hits = store.get_entries_by_id("tags", &[99, 100]).unwrap();
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Numeric(99), IdRef::Numeric(100)])
+            .unwrap();
         assert!(hits.is_empty());
     }
 
     #[test]
     fn get_by_id_type_mismatch_counter() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.get_entries_by_id("warmth", &[1]);
+        let result = store.get_entries_by_id("warmth", &[IdRef::Numeric(1)]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2540,7 +2617,7 @@ max_entries = 5
     #[test]
     fn get_by_id_type_mismatch_string() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.get_entries_by_id("current_mood", &[1]);
+        let result = store.get_entries_by_id("current_mood", &[IdRef::Numeric(1)]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2548,7 +2625,7 @@ max_entries = 5
     #[test]
     fn get_by_id_type_mismatch_state() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.get_entries_by_id("tensor", &[1]);
+        let result = store.get_entries_by_id("tensor", &[IdRef::Numeric(1)]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2556,14 +2633,18 @@ max_entries = 5
     #[test]
     fn get_by_id_empty_history() {
         let (store, _dir) = setup_store(test_schema());
-        let hits = store.get_entries_by_id("flavor_history", &[1]).unwrap();
+        let hits = store
+            .get_entries_by_id("flavor_history", &[IdRef::Numeric(1)])
+            .unwrap();
         assert!(hits.is_empty());
     }
 
     #[test]
     fn get_by_id_empty_list() {
         let (store, _dir) = setup_store(test_schema());
-        let hits = store.get_entries_by_id("tags", &[1]).unwrap();
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Numeric(1)])
+            .unwrap();
         assert!(hits.is_empty());
     }
 
@@ -2696,7 +2777,7 @@ max_entries = 5
         store.push("tags", "c", None).unwrap();
 
         // Remove "b"
-        store.remove("tags", Some("b"), None, false).unwrap();
+        store.remove("tags", Some("b"), None::<&IdRef>, false).unwrap();
 
         // Push "d" — should get id=4, not reuse id=2
         store.push("tags", "d", None).unwrap();
@@ -2819,8 +2900,11 @@ max_entries = 5
         store.push_with_ts("tags", "rust", ts, None).unwrap();
 
         let output = format_value(store.get("tags").unwrap());
-        assert!(output.contains("1: focus"));
-        assert!(output.contains("2: rust"));
+        // New format: "1 [kv-XXXX]: focus (ts)"
+        assert!(output.contains("1 [kv-"));
+        assert!(output.contains("]: focus"));
+        assert!(output.contains("2 [kv-"));
+        assert!(output.contains("]: rust"));
         assert!(output.contains("2026-04-22"));
     }
 
@@ -4343,7 +4427,9 @@ max_entries = 5
         let data = serde_json::json!({"priority": "high"});
         store.push("tags", "item", Some(data.clone())).unwrap();
 
-        let hits = store.get_entries_by_id("tags", &[1]).unwrap();
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Numeric(1)])
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].data, Some(data));
     }
@@ -4400,5 +4486,227 @@ max_entries = 5
         let items = store.last("tags", 1, None, &[]).unwrap();
         assert_eq!(items.len(), 1);
         assert!(items[0].contains("{\"x\":1}"));
+    }
+
+    // -- Hash ID tests --
+
+    #[test]
+    fn push_returns_push_result_with_hash_and_id() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None).unwrap();
+        assert_eq!(result.id, 1);
+        assert!(!result.hash.is_empty());
+        // Hash should be 5-6 base58 chars
+        assert!(result.hash.len() >= 4);
+        assert!(result.hash.len() <= 8);
+    }
+
+    #[test]
+    fn hash_is_stable_same_inputs() {
+        // generate_entry_hash is deterministic
+        let h1 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 1);
+        let h2 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 1);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_is_unique_different_inputs() {
+        let h1 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 1);
+        let h2 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 2);
+        let h3 = generate_entry_hash("other", "2026-05-08T00:00:00+00:00", 1);
+        assert_ne!(h1, h2);
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn backfill_old_entries_get_hashes_on_load() {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        // Write old-format data with no hash field
+        let old_data = r#"{
+            "_schema": "test",
+            "_updated": "2026-05-08T00:00:00+00:00",
+            "tags": {
+                "items": [
+                    {"id": 1, "value": "alpha", "ts": "2026-05-08T00:00:00+00:00"},
+                    {"id": 2, "value": "beta", "ts": "2026-05-08T00:01:00+00:00"}
+                ]
+            }
+        }"#;
+        fs::write(&data_path, old_data).unwrap();
+
+        let store = KvStore::load(&schema_path, &data_path).unwrap();
+        match store.data.entries.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert!(!items[0].hash.is_empty(), "hash should be back-filled");
+                assert!(!items[1].hash.is_empty(), "hash should be back-filled");
+                // Hashes should differ
+                assert_ne!(items[0].hash, items[1].hash);
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn get_by_numeric_id_still_works() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None).unwrap();
+
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Numeric(result.id)])
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "alpha");
+    }
+
+    #[test]
+    fn get_by_hash_works() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None).unwrap();
+
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Hash(result.hash.clone())])
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "alpha");
+        assert_eq!(hits[0].hash, result.hash);
+    }
+
+    #[test]
+    fn get_by_hash_prefix_works() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None).unwrap();
+
+        // Use first 3 chars as prefix
+        let prefix = &result.hash[..3];
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Hash(prefix.to_string())])
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].value, "alpha");
+    }
+
+    #[test]
+    fn get_by_mixed_id_types() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let r1 = store.push("tags", "alpha", None).unwrap();
+        let r2 = store.push("tags", "beta", None).unwrap();
+
+        let hits = store
+            .get_entries_by_id(
+                "tags",
+                &[
+                    IdRef::Numeric(r1.id),
+                    IdRef::Hash(r2.hash.clone()),
+                ],
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn remove_by_hash_works() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha", None).unwrap();
+        let r2 = store.push("tags", "beta", None).unwrap();
+        store.push("tags", "gamma", None).unwrap();
+
+        let result = store
+            .remove("tags", None, Some(&IdRef::Hash(r2.hash.clone())), false)
+            .unwrap();
+        assert_eq!(result.removed.len(), 1);
+        assert_eq!(result.removed[0], "beta");
+
+        // Verify beta is gone
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items.len(), 2);
+                assert_eq!(items[0].value, "alpha");
+                assert_eq!(items[1].value, "gamma");
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn hash_appears_in_last_output() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None).unwrap();
+
+        let items = store.last("tags", 1, None, &[]).unwrap();
+        assert_eq!(items.len(), 1);
+        assert!(
+            items[0].contains(&format!("[kv-{}]", result.hash)),
+            "output should contain hash: {}",
+            items[0]
+        );
+    }
+
+    #[test]
+    fn hash_appears_in_search_output() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None).unwrap();
+
+        let hits = store.search("tags", Some("alpha"), None, &[]).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].hash, result.hash);
+    }
+
+    #[test]
+    fn hash_stored_on_entry_structs() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None).unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].hash, result.hash);
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn hash_stored_on_history_entry() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("flavor_history", "bergamot", None).unwrap();
+
+        match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries[0].hash, result.hash);
+            }
+            _ => panic!("Expected history"),
+        }
+    }
+
+    #[test]
+    fn hash_persists_through_save_load() {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        let hash;
+        {
+            let mut store = KvStore::load(&schema_path, &data_path).unwrap();
+            let result = store.push("tags", "alpha", None).unwrap();
+            hash = result.hash;
+            store.save().unwrap();
+        }
+
+        // Reload and verify hash persisted
+        let store2 = KvStore::load(&schema_path, &data_path).unwrap();
+        match store2.data.entries.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].hash, hash);
+            }
+            _ => panic!("Expected list"),
+        }
     }
 }


### PR DESCRIPTION
Closes #269
Closes #299

## Summary

Every kv entry now gets a stable base58 hash ID (e.g. `kv-A3fB`) generated from key+timestamp+id via blake3+base-d. Push prints `kv-A3fB (42)` on success. Anywhere a numeric ID is accepted, a hash ID also works — get, remove, comma lists. Old data files back-filled on load.

## Key changes

- `hash: String` on `HistoryEntry`, `ListEntry`, `SearchHit`
- `PushResult` return type from push
- `IdRef` enum for dual addressing (numeric or hash)
- `parse_id_spec` returns `Vec<IdRef>`, supports `kv-` prefix
- Output format: `42 [kv-A3fB]: value (timestamp) {data}`
- Backward compat: empty hashes back-filled on load
- No new dependencies (base-d already present, blake3 via base-d::hash)

## Files changed

- `src/kv.rs` — hash generation, `PushResult`, `IdRef`, back-fill on load, updated `remove`/`get_entries_by_id`/`search` to support hash lookups, `format_entry_line` helper
- `src/cli.rs` — `--id` argument changed from `u64` to `String` to accept hash IDs
- `src/handlers/kv.rs` — `parse_single_id`, updated `parse_id_spec` for `IdRef`, push output, unified entry formatting

## Test plan

- [x] 17 new tests covering hash generation, `IdRef` parsing, mixed comma specs, back-fill, `PushResult`, get/remove by hash
- [x] 833 total tests passing
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean