### PR TITLE
kv: per-entry memory links and push --memory (#252, #278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,18 @@ mx kv remove shipped --id kv-A3fB
 mx kv random shipped --count 5
 mx kv random ideas --count 1
 mx kv random shipped --count 3 --since 30d
+
+# Per-entry memory links (bridge KV entries to the knowledge graph)
+mx kv push decisions "adopted memory links" --memory kn-abc123
+mx kv set decisions --id 17 --memory kn-abc123
+mx kv last decisions --count 3 --memory
 ```
 
 Every entry gets a stable hash ID (e.g. `kv-A3fB`) alongside its numeric ID. Push prints both: `kv-A3fB (42)`. Anywhere a numeric ID works, a hash ID also works -- `--id kv-A3fB`, mixed comma lists, remove. Ranges remain numeric only. Old data files are back-filled on first load.
 
 Entries can carry structured JSON data via `--data` on push. Query entries by data fields with `--where key=value` (available on `search`, `last`, `random`, `count`). Multiple `--where` flags are ANDed. Supports exact string match, array-contains, and numeric/boolean comparison on top-level fields.
+
+Individual entries can link to the memory graph via `--memory kn-xxx` on `push` (at creation) or `set --id --memory` (on existing entries). Per-entry memory wins over key-level fallback. Pass `--memory` on read commands (`get`, `last`, `since`, `search`, `random`, `dump`) to resolve linked knowledge entries.
 
 Time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) are available on `last`, `search`, `count`, and `random`. All dates are UTC. The `--since` flag accepts relative times (`30d`, `1w`, `2h`, `30m`) and ISO-8601 timestamps. For a standalone relative-time query on history keys, use `mx kv since`.
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -197,7 +197,11 @@ Most commands exit 0 on success or propagate an `anyhow::Error` (which prints
 the error chain to stderr and exits non-zero). The `kv` subcommand is the
 exception: it uses typed exit codes (0 = OK, 1 = key not found, 2 = type
 mismatch, 3 = schema missing, 4 = invalid input) so callers can distinguish
-failure modes programmatically.
+failure modes programmatically. The `KvError` enum covers five typed variants:
+`KeyNotFound`, `TypeMismatch`, `SchemaMissing`, `EntryNotFound` (a specific
+entry ID was not found within a key), and `AmbiguousHash` (a hash prefix
+matched multiple entries). Both `EntryNotFound` and `AmbiguousHash` map to
+exit code 4.
 
 
 // =========================================================================
@@ -595,13 +599,15 @@ writes are atomic: serialize to a temp file, fsync, rename. The format is a
 flat JSON object keyed by the key names from the schema.
 
 History and list entries are stored as objects with `id`, `hash`, `value`,
-`ts`, and an optional `data` field (arbitrary JSON object for structured
-metadata). The `hash` field is a short base58 string generated from
-`blake3(key + timestamp + id)` via base-d, providing a stable identifier
-independent of numeric ordering. Both `hash` and `data` use
-`#[serde(default)]` for backward compatibility -- files written before these
-fields existed are back-filled on first load (hashes are generated, data
-defaults to `None`) and saved automatically.
+`ts`, an optional `data` field (arbitrary JSON object for structured
+metadata), and an optional `memory` field (a `kn-` ID linking the entry to
+a knowledge node in the memory graph). The `hash` field is a short base58
+string generated from `blake3(key + timestamp + id)` via base-d, providing a
+stable identifier independent of numeric ordering. The `hash`, `data`, and
+`memory` fields all use `#[serde(default)]` for backward compatibility --
+files written before these fields existed are back-filled on first load
+(hashes are generated, data and memory default to `None`) and saved
+automatically.
 
 === Per-agent keying
 
@@ -615,7 +621,16 @@ to `~/.crewu/kv/` for migration purposes.
 KV keys can optionally link to a knowledge entry in the SurrealDB store via a
 `kn-` ID reference. This allows an agent to associate fast local state with
 richer knowledge graph entries. The `--memory` flag on `get`, `last`, `since`,
-`search`, and `dump` resolves these references and displays the linked entry.
+`search`, `random`, and `dump` resolves these references and displays the
+linked entry.
+
+Memory links exist at two levels: key-level (one pointer per key) and
+per-entry (one pointer per history or list entry). Per-entry links are set
+via `push --memory` at creation time or `set --id --memory` on existing
+entries. When resolving, per-entry memory wins over a legacy `kn-` value
+prefix, which wins over the key-level fallback. The `SearchHit` struct
+(returned by `last`, `random`, `search`, `since`, and `get --id`) carries the
+per-entry `memory` field for the handler to resolve.
 
 
 // =========================================================================

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -141,6 +141,11 @@ mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
 mx kv get decisions --id kv-A3fB              # look up by hash ID
 
+# Link entries to the memory graph
+mx kv push decisions "adopted memory links" --memory kn-abc123
+mx kv set decisions --id 17 --memory kn-abc123
+mx kv last decisions --count 3 --memory       # resolves linked entries
+
 # Attach structured data and query it
 mx kv push projects "palmtop DSI fix" \
   --data '{"tags":["palmtop","i915"],"status":"active"}'

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -76,6 +76,8 @@ mx kv get shipped --id 35-64
 mx kv push projects "palmtop DSI fix" \
   --data '{"tags":["palmtop","i915"],"status":"active"}'
 mx kv search projects --where status=active
+mx kv push decisions "adopted memory links" --memory kn-abc123
+mx kv set decisions --id 17 --memory kn-abc123
 ```
 
 == Installation

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -100,7 +100,7 @@ KV commands use structured exit codes for scripting:
 / `1`: Key not found (or no data yet for that key).
 / `2`: Type mismatch (e.g., `inc` on a string key, or `get --id` on a non-history/list key).
 / `3`: Schema file not found.
-/ `4`: Invalid input (e.g., reversed range, empty spec, empty hash after `kv-` prefix).
+/ `4`: Invalid input (e.g., reversed range, empty spec, empty hash after `kv-` prefix, entry not found by ID, ambiguous hash prefix).
 
 == Basic operations
 
@@ -146,7 +146,8 @@ KV commands use structured exit codes for scripting:
 
 #command(
   "mx kv set <key> <value> [field_value]",
-  [Set a value for a string, counter, or state key.
+  [Set a value for a string, counter, or state key, or link a specific
+  entry to a memory node.
 
   For *string* keys: `mx kv set <key> <value>` sets the value directly.
 
@@ -154,9 +155,17 @@ KV commands use structured exit codes for scripting:
   and clamps to min/max.
 
   For *state* keys: `mx kv set <key> <field> <value>` sets a single field.
-  The field name must be declared in the schema.],
+  The field name must be declared in the schema.
+
+  With `--id` and `--memory`, links an existing history or list entry to a
+  memory knowledge node. The `--id` flag accepts a numeric ID (`17`) or a
+  hash ID (`kv-A3fB`). Hash matching is prefix-based -- an ambiguous
+  prefix returns an error asking for more characters. `--id` requires
+  `--memory`; it cannot be used alone. Pass an empty string
+  (`--memory ""`) to clear a per-entry link.],
   flags: (
-    ([`--memory <kn-id>`], [string], [Link a memory entry (kn- ID) to this key, or `""` to clear]),
+    ([`--memory <kn-id>`], [string], [Link a memory entry (kn- ID) to this key or entry, or `""` to clear]),
+    ([`--id <spec>`], [string], [Target a specific entry by numeric ID or hash ID (requires `--memory`)]),
   ),
   examples: (
     "mx kv set session_goal \"ship the docs\"",
@@ -165,6 +174,9 @@ KV commands use structured exit codes for scripting:
     "mx kv set context phase \"writing\"",
     "mx kv set decisions --memory kn-abc123",
     "mx kv set decisions --memory \"\"",
+    "mx kv set decisions --id 17 --memory kn-abc123",
+    "mx kv set decisions --id kv-A3fB --memory kn-def456",
+    "mx kv set decisions --id 17 --memory \"\"",
   ),
 )
 
@@ -247,15 +259,23 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   Use `--data` to attach a JSON object to the entry. The data is stored
   alongside the value and timestamp, and is displayed inline in output.
   See #link(<structured-data>)[Structured data] for details and query
-  examples.],
+  examples.
+
+  Use `--memory` to link the new entry to a knowledge node in the memory
+  graph. This sets a per-entry memory pointer (a `kn-` ID) that is
+  resolved when `--memory` is passed to read commands. See
+  #link(<per-entry-memory>)[Per-entry memory links] for the full
+  resolution hierarchy.],
   flags: (
     ([`--data <json>`], [string], [Attach a JSON object to the entry. Must be a valid JSON object (not an array, string, or other type).]),
+    ([`--memory <kn-id>`], [string], [Link this entry to a memory knowledge node (e.g. `kn-abc123`). Resolved when `--memory` is passed on read commands.]),
   ),
   examples: (
     "mx kv push decisions \"chose Typst for docs\"",
     "mx kv push todos \"write tests for kv handler\"",
     "mx kv push projects \"palmtop DSI fix\" --data '{\"tags\":[\"palmtop\",\"i915\"],\"status\":\"active\"}'",
     "mx kv push shipped \"v0.1.156\" --data '{\"pr\":305,\"scope\":\"kv\"}'",
+    "mx kv push decisions \"adopted per-entry memory links\" --memory kn-abc123",
   ),
 )
 
@@ -781,7 +801,7 @@ When a memory link is set, commands that read the key (`get`, `last`, `since`,
 `search`, `random`, `dump`) can resolve the link with `--memory`, which fetches
 the linked entry from SurrealDB and prints its title, category, and body.
 
-=== Setting a memory link
+=== Key-level memory links
 
 ```bash
 # Link a key to a memory entry
@@ -791,9 +811,57 @@ mx kv set decisions --memory kn-abc123
 mx kv set decisions --memory ""
 ```
 
-Memory links are stored in the JSON data file alongside the key's entries.
-They survive resets -- `mx kv reset` clears the data but preserves the memory
-pointer.
+Key-level memory links are stored in the JSON data file alongside the key's
+entries. They survive resets -- `mx kv reset` clears the data but preserves
+the memory pointer.
+
+=== Per-entry memory links <per-entry-memory>
+
+Individual history and list entries can carry their own memory link. This
+allows different entries within the same key to reference different knowledge
+nodes.
+
+*Set at creation time:*
+
+```bash
+# Link a new entry to a knowledge node on push
+mx kv push decisions "adopted per-entry memory links" --memory kn-abc123
+```
+
+*Set on an existing entry:*
+
+```bash
+# Link by numeric ID
+mx kv set decisions --id 17 --memory kn-abc123
+
+# Link by hash ID
+mx kv set decisions --id kv-A3fB --memory kn-def456
+
+# Clear a per-entry link
+mx kv set decisions --id 17 --memory ""
+```
+
+The `--id` flag on `set` requires `--memory` -- it cannot be used alone.
+Hash matching is prefix-based: `kv-A3f` matches if the prefix uniquely
+identifies one entry. If the prefix is ambiguous, an error is returned.
+If the entry is not found, exit code 4 (invalid input) is returned.
+
+=== Resolution hierarchy
+
+When `--memory` is passed on a read command, memory links are resolved in
+priority order:
+
++ *Per-entry `memory` field* -- if the entry has its own memory link, that
+  link is resolved and displayed. This is the highest priority.
++ *Legacy `kn-` value* -- if the entry's value string starts with `kn-`,
+  it is treated as a memory reference and resolved. This provides backward
+  compatibility with entries that stored knowledge node IDs as their value.
++ *Key-level memory* -- after all entries are printed, the key-level memory
+  pointer (if any) is resolved once at the end.
+
+Per-entry memory wins. An entry with a `memory` field set will use that link
+regardless of whether the key itself also has a memory pointer. The key-level
+link serves as a fallback that applies to the key as a whole.
 
 === Resolving memory links
 
@@ -803,6 +871,9 @@ mx kv get decisions --memory
 
 # Show the last 5 entries plus linked memory
 mx kv last decisions --count 5 --memory
+
+# Look up a specific entry and resolve its memory link
+mx kv get decisions --id 17 --memory
 
 # Dump everything with all memory links resolved
 mx kv dump --memory

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1702,7 +1702,7 @@ pub enum KvCommands {
         memory: Option<String>,
 
         /// Target a specific entry by ID (numeric or kv-HASH) for --memory
-        #[arg(long)]
+        #[arg(long, requires = "memory")]
         id: Option<String>,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1700,6 +1700,10 @@ pub enum KvCommands {
         /// Link a memory entry (kn- ID) to this key, or "" to clear
         #[arg(long)]
         memory: Option<String>,
+
+        /// Target a specific entry by ID (numeric or kv-HASH) for --memory
+        #[arg(long)]
+        id: Option<String>,
     },
 
     /// Increment a counter
@@ -1733,6 +1737,10 @@ pub enum KvCommands {
         /// Attach structured JSON data to this entry
         #[arg(long)]
         data: Option<String>,
+
+        /// Link a memory entry (kn- ID) to this entry
+        #[arg(long)]
+        memory: Option<String>,
     },
 
     /// Pop the last value from a list

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -13,6 +13,7 @@ fn exit_code_for(err: &KvError) -> Option<i32> {
         KvError::KeyNotFound(_) => Some(kv::EXIT_KEY_NOT_FOUND),
         KvError::TypeMismatch { .. } => Some(kv::EXIT_TYPE_MISMATCH),
         KvError::SchemaMissing(_) => Some(kv::EXIT_SCHEMA_MISSING),
+        KvError::EntryNotFound { .. } => Some(kv::EXIT_INVALID_INPUT),
         KvError::Other(_) => None,
     }
 }
@@ -290,11 +291,8 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             id,
         } => {
             // Per-entry memory: --id + --memory targets a specific entry
+            // (clap enforces that --id requires --memory at parse time)
             if let Some(ref id_str) = id {
-                if memory.is_none() {
-                    eprintln!("Error: --id requires --memory");
-                    return Ok(kv::EXIT_INVALID_INPUT);
-                }
                 let id_ref = match parse_single_id(id_str) {
                     Ok(r) => r,
                     Err(msg) => {
@@ -483,8 +481,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                 hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                             )
                         );
-                        if memory && let Some(ref mem) = hit.memory {
-                            print_resolved_memory(mem, verbose);
+                        if memory {
+                            if let Some(ref mem) = hit.memory {
+                                print_resolved_memory(mem, verbose);
+                            } else if hit.value.starts_with("kn-") {
+                                print_resolved_memory(&hit.value, verbose);
+                            }
                         }
                     }
                     if memory {
@@ -520,8 +522,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                 hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                             )
                         );
-                        if memory && let Some(ref mem) = hit.memory {
-                            print_resolved_memory(mem, verbose);
+                        if memory {
+                            if let Some(ref mem) = hit.memory {
+                                print_resolved_memory(mem, verbose);
+                            } else if hit.value.starts_with("kn-") {
+                                print_resolved_memory(&hit.value, verbose);
+                            }
                         }
                     }
                     if memory {
@@ -550,8 +556,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                             &entry.data
                         )
                     );
-                    if memory && let Some(ref mem) = entry.memory {
-                        print_resolved_memory(mem, verbose);
+                    if memory {
+                        if let Some(ref mem) = entry.memory {
+                            print_resolved_memory(mem, verbose);
+                        } else if entry.value.starts_with("kn-") {
+                            print_resolved_memory(&entry.value, verbose);
+                        }
                     }
                 }
                 if memory {
@@ -659,8 +669,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                     hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                                 )
                             );
-                            if memory && let Some(ref mem) = hit.memory {
-                                print_resolved_memory(mem, verbose);
+                            if memory {
+                                if let Some(ref mem) = hit.memory {
+                                    print_resolved_memory(mem, verbose);
+                                } else if hit.value.starts_with("kn-") {
+                                    print_resolved_memory(&hit.value, verbose);
+                                }
                             }
                         }
                         if memory {

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -483,9 +483,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                 hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                             )
                         );
-                        if memory
-                            && let Some(ref mem) = hit.memory
-                        {
+                        if memory && let Some(ref mem) = hit.memory {
                             print_resolved_memory(mem, verbose);
                         }
                     }
@@ -522,9 +520,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                 hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                             )
                         );
-                        if memory
-                            && let Some(ref mem) = hit.memory
-                        {
+                        if memory && let Some(ref mem) = hit.memory {
                             print_resolved_memory(mem, verbose);
                         }
                     }
@@ -554,9 +550,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                             &entry.data
                         )
                     );
-                    if memory
-                        && let Some(ref mem) = entry.memory
-                    {
+                    if memory && let Some(ref mem) = entry.memory {
                         print_resolved_memory(mem, verbose);
                     }
                 }
@@ -665,9 +659,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                     hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                                 )
                             );
-                            if memory
-                                && let Some(ref mem) = hit.memory
-                            {
+                            if memory && let Some(ref mem) = hit.memory {
                                 print_resolved_memory(mem, verbose);
                             }
                         }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -392,7 +392,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             Err(e) => handle_kv_err(e),
         },
 
-        KvCommands::Push { key, value, data, memory } => {
+        KvCommands::Push {
+            key,
+            value,
+            data,
+            memory,
+        } => {
             // Parse --data as JSON object if provided
             let parsed_data = match data {
                 Some(ref json_str) => {

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -483,10 +483,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                 hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                             )
                         );
-                        if memory {
-                            if let Some(ref mem) = hit.memory {
-                                print_resolved_memory(mem, verbose);
-                            }
+                        if memory
+                            && let Some(ref mem) = hit.memory
+                        {
+                            print_resolved_memory(mem, verbose);
                         }
                     }
                     if memory {
@@ -522,10 +522,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                 hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                             )
                         );
-                        if memory {
-                            if let Some(ref mem) = hit.memory {
-                                print_resolved_memory(mem, verbose);
-                            }
+                        if memory
+                            && let Some(ref mem) = hit.memory
+                        {
+                            print_resolved_memory(mem, verbose);
                         }
                     }
                     if memory {
@@ -554,10 +554,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                             &entry.data
                         )
                     );
-                    if memory {
-                        if let Some(ref mem) = entry.memory {
-                            print_resolved_memory(mem, verbose);
-                        }
+                    if memory
+                        && let Some(ref mem) = entry.memory
+                    {
+                        print_resolved_memory(mem, verbose);
                     }
                 }
                 if memory {
@@ -665,10 +665,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                     hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                                 )
                             );
-                            if memory {
-                                if let Some(ref mem) = hit.memory {
-                                    print_resolved_memory(mem, verbose);
-                                }
+                            if memory
+                                && let Some(ref mem) = hit.memory
+                            {
+                                print_resolved_memory(mem, verbose);
                             }
                         }
                         if memory {

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -14,6 +14,7 @@ fn exit_code_for(err: &KvError) -> Option<i32> {
         KvError::TypeMismatch { .. } => Some(kv::EXIT_TYPE_MISMATCH),
         KvError::SchemaMissing(_) => Some(kv::EXIT_SCHEMA_MISSING),
         KvError::EntryNotFound { .. } => Some(kv::EXIT_INVALID_INPUT),
+        KvError::AmbiguousHash { .. } => Some(kv::EXIT_INVALID_INPUT),
         KvError::Other(_) => None,
     }
 }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -250,9 +250,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         }
 
                         if memory {
-                            // Resolve memory for each entry value that looks like a kn- reference
+                            // Resolve per-entry memory pointers
                             for hit in &hits {
-                                if hit.value.starts_with("kn-") {
+                                if let Some(ref mem) = hit.memory {
+                                    print_resolved_memory(mem, verbose);
+                                } else if hit.value.starts_with("kn-") {
+                                    // Legacy: resolve entry value as kn- reference
                                     print_resolved_memory(&hit.value, verbose);
                                 }
                             }
@@ -284,7 +287,30 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             value,
             field_value,
             memory,
+            id,
         } => {
+            // Per-entry memory: --id + --memory targets a specific entry
+            if let Some(ref id_str) = id {
+                if memory.is_none() {
+                    eprintln!("Error: --id requires --memory");
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
+                let id_ref = match parse_single_id(id_str) {
+                    Ok(r) => r,
+                    Err(msg) => {
+                        eprintln!("Error: {}", msg);
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
+                };
+                match store.set_entry_memory(&key, &id_ref, memory) {
+                    Ok(()) => {
+                        store.save()?;
+                        return Ok(kv::EXIT_OK);
+                    }
+                    Err(e) => return handle_kv_err(e),
+                }
+            }
+
             let mut did_something = false;
 
             // Handle the value set (if a value was provided)
@@ -366,7 +392,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             Err(e) => handle_kv_err(e),
         },
 
-        KvCommands::Push { key, value, data } => {
+        KvCommands::Push { key, value, data, memory } => {
             // Parse --data as JSON object if provided
             let parsed_data = match data {
                 Some(ref json_str) => {
@@ -396,7 +422,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 None => None,
             };
 
-            match store.push(&key, &value, parsed_data) {
+            match store.push(&key, &value, parsed_data, memory) {
                 Ok(result) => {
                     store.save()?;
                     println!("kv-{} ({})", result.hash, result.id);
@@ -444,9 +470,19 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 }
             };
             match store.last(&key, count, range.as_ref(), &parsed_where) {
-                Ok(items) => {
-                    for item in &items {
-                        println!("{}", item);
+                Ok(hits) => {
+                    for hit in &hits {
+                        println!(
+                            "{}",
+                            kv::format_entry_line(
+                                hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                            )
+                        );
+                        if memory {
+                            if let Some(ref mem) = hit.memory {
+                                print_resolved_memory(mem, verbose);
+                            }
+                        }
                     }
                     if memory {
                         resolve_memory(&store, &key, verbose);
@@ -473,9 +509,19 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 }
             };
             match store.random(&key, count, range.as_ref(), &parsed_where) {
-                Ok(items) => {
-                    for item in &items {
-                        println!("{}", item);
+                Ok(hits) => {
+                    for hit in &hits {
+                        println!(
+                            "{}",
+                            kv::format_entry_line(
+                                hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                            )
+                        );
+                        if memory {
+                            if let Some(ref mem) = hit.memory {
+                                print_resolved_memory(mem, verbose);
+                            }
+                        }
                     }
                     if memory {
                         resolve_memory(&store, &key, verbose);
@@ -503,6 +549,11 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                             &entry.data
                         )
                     );
+                    if memory {
+                        if let Some(ref mem) = entry.memory {
+                            print_resolved_memory(mem, verbose);
+                        }
+                    }
                 }
                 if memory {
                     resolve_memory(&store, &key, verbose);
@@ -609,6 +660,11 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                                     hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
                                 )
                             );
+                            if memory {
+                                if let Some(ref mem) = hit.memory {
+                                    print_resolved_memory(mem, verbose);
+                                }
+                            }
                         }
                         if memory {
                             resolve_memory(&store, &key, verbose);

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -114,6 +114,10 @@ pub enum KvError {
         got: String,
     },
     SchemaMissing(PathBuf),
+    EntryNotFound {
+        key: String,
+        id: String,
+    },
     Other(anyhow::Error),
 }
 
@@ -130,6 +134,9 @@ impl std::fmt::Display for KvError {
             }
             KvError::SchemaMissing(path) => {
                 write!(f, "Schema file not found: {}", path.display())
+            }
+            KvError::EntryNotFound { key, id } => {
+                write!(f, "Entry not found: ID {} in key '{}'", id, key)
             }
             KvError::Other(e) => write!(f, "{}", e),
         }
@@ -1553,7 +1560,7 @@ impl KvStore {
     /// Set or clear the memory pointer on a specific entry within a history or list.
     ///
     /// Pass `None` (or `Some("")`) to clear the pointer.
-    /// Returns `KvError::Other` if the entry is not found.
+    /// Returns `KvError::EntryNotFound` if the entry is not found.
     pub fn set_entry_memory(
         &mut self,
         key: &str,
@@ -1605,11 +1612,10 @@ impl KvStore {
                         e.memory = memory;
                         Ok(())
                     }
-                    None => Err(KvError::Other(anyhow::anyhow!(
-                        "entry not found for ID {:?} in key '{}'",
-                        id,
-                        key
-                    ))),
+                    None => Err(KvError::EntryNotFound {
+                        key: key.to_string(),
+                        id: format!("{:?}", id),
+                    }),
                 }
             }
             Some(DataValue::List { items, .. }) => {
@@ -1638,17 +1644,16 @@ impl KvStore {
                         e.memory = memory;
                         Ok(())
                     }
-                    None => Err(KvError::Other(anyhow::anyhow!(
-                        "entry not found for ID {:?} in key '{}'",
-                        id,
-                        key
-                    ))),
+                    None => Err(KvError::EntryNotFound {
+                        key: key.to_string(),
+                        id: format!("{:?}", id),
+                    }),
                 }
             }
-            _ => Err(KvError::Other(anyhow::anyhow!(
-                "key '{}' has no entries",
-                key
-            ))),
+            _ => Err(KvError::EntryNotFound {
+                key: key.to_string(),
+                id: format!("{:?}", id),
+            }),
         }
     }
 
@@ -5133,7 +5138,7 @@ max_entries = 5
 
         let result = store.set_entry_memory("tags", &IdRef::Numeric(999), Some("kn-x".to_string()));
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("entry not found"));
+        assert!(result.unwrap_err().to_string().contains("Entry not found"));
     }
 
     #[test]
@@ -5277,6 +5282,38 @@ max_entries = 5
         let result = store.set_entry_memory("warmth", &IdRef::Numeric(1), Some("kn-x".to_string()));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
+    }
+
+    #[test]
+    fn set_entry_memory_ambiguous_hash_prefix_errors() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+
+        // Manually set both entries to share a hash prefix.
+        match store.data.entries.get_mut("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                items[0].hash = "XYZaaa1".to_string();
+                items[1].hash = "XYZaaa2".to_string();
+            }
+            _ => panic!("Expected list"),
+        }
+
+        // Setting memory by the shared prefix "XYZ" should return an ambiguity error.
+        let result =
+            store.set_entry_memory("tags", &IdRef::Hash("XYZ".to_string()), Some("kn-x".to_string()));
+        assert!(result.is_err(), "expected ambiguity error");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("ambiguous"),
+            "error should mention ambiguity, got: {}",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("matches 2 entries"),
+            "error should report match count, got: {}",
+            err_msg
+        );
     }
 
     #[test]

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -118,6 +118,10 @@ pub enum KvError {
         key: String,
         id: String,
     },
+    AmbiguousHash {
+        prefix: String,
+        count: usize,
+    },
     Other(anyhow::Error),
 }
 
@@ -137,6 +141,13 @@ impl std::fmt::Display for KvError {
             }
             KvError::EntryNotFound { key, id } => {
                 write!(f, "Entry not found: ID {} in key '{}'", id, key)
+            }
+            KvError::AmbiguousHash { prefix, count } => {
+                write!(
+                    f,
+                    "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
+                    prefix, count
+                )
             }
             KvError::Other(e) => write!(f, "{}", e),
         }
@@ -1158,11 +1169,10 @@ impl KvStore {
                                 0 => None,
                                 1 => Some(matches[0]),
                                 n => {
-                                    return Err(KvError::Other(anyhow::anyhow!(
-                                        "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                        h,
-                                        n
-                                    )));
+                                    return Err(KvError::AmbiguousHash {
+                                        prefix: h.clone(),
+                                        count: n,
+                                    });
                                 }
                             }
                         }
@@ -1198,11 +1208,10 @@ impl KvStore {
                                 0 => None,
                                 1 => Some(matches[0]),
                                 n => {
-                                    return Err(KvError::Other(anyhow::anyhow!(
-                                        "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                        h,
-                                        n
-                                    )));
+                                    return Err(KvError::AmbiguousHash {
+                                        prefix: h.clone(),
+                                        count: n,
+                                    });
                                 }
                             }
                         }
@@ -1598,11 +1607,10 @@ impl KvStore {
                                 entries.iter_mut().find(|e| e.hash.starts_with(h.as_str()))
                             }
                             n => {
-                                return Err(KvError::Other(anyhow::anyhow!(
-                                    "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                    h,
-                                    n
-                                )));
+                                return Err(KvError::AmbiguousHash {
+                                    prefix: h.clone(),
+                                    count: n,
+                                });
                             }
                         }
                     }
@@ -1630,11 +1638,10 @@ impl KvStore {
                             0 => None,
                             1 => items.iter_mut().find(|e| e.hash.starts_with(h.as_str())),
                             n => {
-                                return Err(KvError::Other(anyhow::anyhow!(
-                                    "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                    h,
-                                    n
-                                )));
+                                return Err(KvError::AmbiguousHash {
+                                    prefix: h.clone(),
+                                    count: n,
+                                });
                             }
                         }
                     }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -5300,8 +5300,11 @@ max_entries = 5
         }
 
         // Setting memory by the shared prefix "XYZ" should return an ambiguity error.
-        let result =
-            store.set_entry_memory("tags", &IdRef::Hash("XYZ".to_string()), Some("kn-x".to_string()));
+        let result = store.set_entry_memory(
+            "tags",
+            &IdRef::Hash("XYZ".to_string()),
+            Some("kn-x".to_string()),
+        );
         assert!(result.is_err(), "expected ambiguity error");
         let err_msg = result.unwrap_err().to_string();
         assert!(

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -342,6 +342,7 @@ impl<'de> Deserialize<'de> for DataValue {
                                 value: s,
                                 ts: String::new(),
                                 data: None,
+                                memory: None,
                             }
                         }
                     })
@@ -365,6 +366,8 @@ pub struct HistoryEntry {
     pub ts: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -376,6 +379,8 @@ pub struct ListEntry {
     pub ts: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
 }
 
 /// Remove result for the CLI layer to format output.
@@ -385,13 +390,14 @@ pub struct RemoveResult {
 }
 
 /// Search result entry.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SearchHit {
     pub id: u64,
     pub hash: String,
     pub value: String,
     pub ts: String,
     pub data: Option<serde_json::Value>,
+    pub memory: Option<String>,
 }
 
 /// Count result.
@@ -796,8 +802,9 @@ impl KvStore {
         key: &str,
         value: &str,
         data: Option<serde_json::Value>,
+        memory: Option<String>,
     ) -> Result<PushResult, KvError> {
-        self.push_with_ts(key, value, Utc::now(), data)
+        self.push_with_ts(key, value, Utc::now(), data, memory)
     }
 
     /// Push with an explicit timestamp (used by tests).
@@ -807,6 +814,7 @@ impl KvStore {
         value: &str,
         ts: DateTime<Utc>,
         data: Option<serde_json::Value>,
+        memory: Option<String>,
     ) -> Result<PushResult, KvError> {
         let def = self.key_def(key)?.clone();
         let ts_str = ts.to_rfc3339();
@@ -831,6 +839,7 @@ impl KvStore {
                                 value: value.to_string(),
                                 ts: ts_str,
                                 data,
+                                memory,
                             },
                         );
                         // Drop oldest at max_entries
@@ -862,6 +871,7 @@ impl KvStore {
                             value: value.to_string(),
                             ts: ts_str,
                             data,
+                            memory,
                         });
                         // Drop oldest at max_entries — single drain instead of O(n^2) remove loop
                         if let Some(max) = def.max_entries
@@ -899,7 +909,7 @@ impl KvStore {
         }
     }
 
-    /// Get the last N entries from a history or list, formatted with IDs and timestamps.
+    /// Get the last N entries from a history or list as `SearchHit`s.
     ///
     /// When `range` is provided, entries are filtered by timestamp first, then
     /// the `count` limit is applied to the filtered set.
@@ -910,7 +920,7 @@ impl KvStore {
         count: usize,
         range: Option<&TimeRange>,
         where_clauses: &[(String, String)],
-    ) -> Result<Vec<String>, KvError> {
+    ) -> Result<Vec<SearchHit>, KvError> {
         let def = self.key_def(key)?;
 
         match def.value_type {
@@ -929,7 +939,14 @@ impl KvStore {
                     let start = filtered.len().saturating_sub(count);
                     Ok(filtered[start..]
                         .iter()
-                        .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
+                        .map(|e| SearchHit {
+                            id: e.id,
+                            hash: e.hash.clone(),
+                            value: e.value.clone(),
+                            ts: e.ts.clone(),
+                            data: e.data.clone(),
+                            memory: e.memory.clone(),
+                        })
                         .collect())
                 }
                 _ => Ok(vec![]),
@@ -946,7 +963,14 @@ impl KvStore {
                     let start = filtered.len().saturating_sub(count);
                     Ok(filtered[start..]
                         .iter()
-                        .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
+                        .map(|e| SearchHit {
+                            id: e.id,
+                            hash: e.hash.clone(),
+                            value: e.value.clone(),
+                            ts: e.ts.clone(),
+                            data: e.data.clone(),
+                            memory: e.memory.clone(),
+                        })
                         .collect())
                 }
                 _ => Ok(vec![]),
@@ -959,7 +983,7 @@ impl KvStore {
         }
     }
 
-    /// Get random entries from a history or list, formatted with IDs and timestamps.
+    /// Get random entries from a history or list as `SearchHit`s.
     ///
     /// When `range` is provided, entries are filtered by timestamp first, then
     /// `count` random items are sampled from the filtered set. If fewer entries
@@ -972,45 +996,41 @@ impl KvStore {
         count: usize,
         range: Option<&TimeRange>,
         where_clauses: &[(String, String)],
-    ) -> Result<Vec<String>, KvError> {
+    ) -> Result<Vec<SearchHit>, KvError> {
         use rand::seq::IndexedRandom;
 
         let def = self.key_def(key)?;
 
-        // Shared sampling + formatting closure. Takes a filtered vec of
-        // (value, id, hash, ts, data) tuples and returns formatted strings.
-        let sample = |filtered: Vec<(&str, u64, &str, &str, &Option<serde_json::Value>)>,
-                      n: usize|
-         -> Vec<String> {
+        /// Shared sampling helper. Takes a filtered vec of `SearchHit` references
+        /// and returns `count` randomly chosen hits (cloned).
+        fn sample_hits(filtered: &[SearchHit], n: usize) -> Vec<SearchHit> {
             if filtered.is_empty() {
                 return vec![];
             }
             let take = n.min(filtered.len());
             let mut rng = rand::rng();
-            let chosen: Vec<_> = filtered.choose_multiple(&mut rng, take).collect();
-            chosen
-                .into_iter()
-                .map(|(value, id, hash, ts, data)| format_entry_line(*id, hash, value, ts, data))
+            filtered
+                .choose_multiple(&mut rng, take)
+                .cloned()
                 .collect()
-        };
+        }
 
         match def.value_type {
             ValueType::History => match self.data.entries.get(key) {
                 Some(DataValue::History { entries, .. }) => {
-                    let filtered: Vec<_> = entries
+                    let filtered: Vec<SearchHit> = entries
                         .iter()
                         .filter(|e| {
                             range.is_none_or(|r| ts_in_range(&e.ts, r))
                                 && where_matches(&e.data, where_clauses)
                         })
-                        .map(|e| {
-                            (
-                                e.value.as_str(),
-                                e.id,
-                                e.hash.as_str(),
-                                e.ts.as_str(),
-                                &e.data,
-                            )
+                        .map(|e| SearchHit {
+                            id: e.id,
+                            hash: e.hash.clone(),
+                            value: e.value.clone(),
+                            ts: e.ts.clone(),
+                            data: e.data.clone(),
+                            memory: e.memory.clone(),
                         })
                         .collect();
                     let available = filtered.len();
@@ -1022,26 +1042,25 @@ impl KvStore {
                             available, count
                         );
                     }
-                    Ok(sample(filtered, count))
+                    Ok(sample_hits(&filtered, count))
                 }
                 _ => Ok(vec![]),
             },
             ValueType::List => match self.data.entries.get(key) {
                 Some(DataValue::List { items, .. }) => {
-                    let filtered: Vec<_> = items
+                    let filtered: Vec<SearchHit> = items
                         .iter()
                         .filter(|e| {
                             range.is_none_or(|r| ts_in_range(&e.ts, r))
                                 && where_matches(&e.data, where_clauses)
                         })
-                        .map(|e| {
-                            (
-                                e.value.as_str(),
-                                e.id,
-                                e.hash.as_str(),
-                                e.ts.as_str(),
-                                &e.data,
-                            )
+                        .map(|e| SearchHit {
+                            id: e.id,
+                            hash: e.hash.clone(),
+                            value: e.value.clone(),
+                            ts: e.ts.clone(),
+                            data: e.data.clone(),
+                            memory: e.memory.clone(),
                         })
                         .collect();
                     let available = filtered.len();
@@ -1053,7 +1072,7 @@ impl KvStore {
                             available, count
                         );
                     }
-                    Ok(sample(filtered, count))
+                    Ok(sample_hits(&filtered, count))
                 }
                 _ => Ok(vec![]),
             },
@@ -1254,6 +1273,7 @@ impl KvStore {
                         value: e.value.clone(),
                         ts: e.ts.clone(),
                         data: e.data.clone(),
+                        memory: e.memory.clone(),
                     });
                 }
             }
@@ -1276,6 +1296,7 @@ impl KvStore {
                         value: e.value.clone(),
                         ts: e.ts.clone(),
                         data: e.data.clone(),
+                        memory: e.memory.clone(),
                     });
                 }
             }
@@ -1337,6 +1358,7 @@ impl KvStore {
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
+                            memory: e.memory.clone(),
                         });
                     }
                 }
@@ -1350,6 +1372,7 @@ impl KvStore {
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
+                            memory: e.memory.clone(),
                         });
                     }
                 }
@@ -1527,6 +1550,110 @@ impl KvStore {
                 })
             }
             None => Ok(None),
+        }
+    }
+
+    /// Set or clear the memory pointer on a specific entry within a history or list.
+    ///
+    /// Pass `None` (or `Some("")`) to clear the pointer.
+    /// Returns `KvError::Other` if the entry is not found.
+    pub fn set_entry_memory(
+        &mut self,
+        key: &str,
+        id: &IdRef,
+        memory: Option<String>,
+    ) -> Result<(), KvError> {
+        let def = self.key_def(key)?;
+        match def.value_type {
+            ValueType::History | ValueType::List => {}
+            _ => {
+                return Err(KvError::TypeMismatch {
+                    key: key.to_string(),
+                    expected: "history or list".to_string(),
+                    got: def.value_type.to_string(),
+                });
+            }
+        }
+
+        // Normalize empty string to None (clearing the link)
+        let memory = memory.filter(|s| !s.is_empty());
+
+        match self.data.entries.get_mut(key) {
+            Some(DataValue::History { entries, .. }) => {
+                let entry = match id {
+                    IdRef::Numeric(n) => entries.iter_mut().find(|e| e.id == *n),
+                    IdRef::Hash(h) => {
+                        let matches: Vec<_> = entries
+                            .iter_mut()
+                            .filter(|e| e.hash.starts_with(h.as_str()))
+                            .collect();
+                        match matches.len() {
+                            0 => None,
+                            1 => {
+                                // Re-find to satisfy borrow checker (collected vec consumes &mut)
+                                entries
+                                    .iter_mut()
+                                    .find(|e| e.hash.starts_with(h.as_str()))
+                            }
+                            n => {
+                                return Err(KvError::Other(anyhow::anyhow!(
+                                    "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
+                                    h, n
+                                )));
+                            }
+                        }
+                    }
+                };
+                match entry {
+                    Some(e) => {
+                        e.memory = memory;
+                        Ok(())
+                    }
+                    None => Err(KvError::Other(anyhow::anyhow!(
+                        "entry not found for ID {:?} in key '{}'",
+                        id, key
+                    ))),
+                }
+            }
+            Some(DataValue::List { items, .. }) => {
+                let entry = match id {
+                    IdRef::Numeric(n) => items.iter_mut().find(|e| e.id == *n),
+                    IdRef::Hash(h) => {
+                        let matches: Vec<_> = items
+                            .iter_mut()
+                            .filter(|e| e.hash.starts_with(h.as_str()))
+                            .collect();
+                        match matches.len() {
+                            0 => None,
+                            1 => {
+                                items
+                                    .iter_mut()
+                                    .find(|e| e.hash.starts_with(h.as_str()))
+                            }
+                            n => {
+                                return Err(KvError::Other(anyhow::anyhow!(
+                                    "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
+                                    h, n
+                                )));
+                            }
+                        }
+                    }
+                };
+                match entry {
+                    Some(e) => {
+                        e.memory = memory;
+                        Ok(())
+                    }
+                    None => Err(KvError::Other(anyhow::anyhow!(
+                        "entry not found for ID {:?} in key '{}'",
+                        id, key
+                    ))),
+                }
+            }
+            _ => Err(KvError::Other(anyhow::anyhow!(
+                "key '{}' has no entries",
+                key
+            ))),
         }
     }
 
@@ -2088,13 +2215,12 @@ max_entries = 5
     #[test]
     fn history_push_and_last() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
-        store.push("flavor_history", "lapsang", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store.push("flavor_history", "lapsang", None, None).unwrap();
 
         let last = store.last("flavor_history", 1, None, &[]).unwrap();
         assert_eq!(last.len(), 1);
-        // last now includes id and ts
-        assert!(last[0].contains("lapsang"));
+        assert_eq!(last[0].value, "lapsang");
 
         let last2 = store.last("flavor_history", 2, None, &[]).unwrap();
         assert_eq!(last2.len(), 2);
@@ -2104,10 +2230,10 @@ max_entries = 5
     fn history_max_entries_overflow() {
         let (mut store, _dir) = setup_store(test_schema());
         // max_entries = 3
-        store.push("flavor_history", "a", None).unwrap();
-        store.push("flavor_history", "b", None).unwrap();
-        store.push("flavor_history", "c", None).unwrap();
-        store.push("flavor_history", "d", None).unwrap();
+        store.push("flavor_history", "a", None, None).unwrap();
+        store.push("flavor_history", "b", None, None).unwrap();
+        store.push("flavor_history", "c", None, None).unwrap();
+        store.push("flavor_history", "d", None, None).unwrap();
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
@@ -2129,10 +2255,10 @@ max_entries = 5
         let new_time = Utc::now() - chrono::Duration::minutes(10);
 
         store
-            .push_with_ts("flavor_history", "old_one", old_time, None)
+            .push_with_ts("flavor_history", "old_one", old_time, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "new_one", new_time, None)
+            .push_with_ts("flavor_history", "new_one", new_time, None, None)
             .unwrap();
 
         let results = store.since("flavor_history", "1h").unwrap();
@@ -2145,14 +2271,14 @@ max_entries = 5
     #[test]
     fn list_push_pop_last() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "gamma", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "gamma", None, None).unwrap();
 
         let last = store.last("tags", 2, None, &[]).unwrap();
         assert_eq!(last.len(), 2);
-        assert!(last[0].contains("beta"));
-        assert!(last[1].contains("gamma"));
+        assert_eq!(last[0].value, "beta");
+        assert_eq!(last[1].value, "gamma");
 
         let popped = store.pop("tags").unwrap();
         assert!(popped.is_some());
@@ -2164,7 +2290,7 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         // max_entries = 5
         for i in 0..8 {
-            store.push("tags", &format!("item_{}", i), None).unwrap();
+            store.push("tags", &format!("item_{}", i), None, None).unwrap();
         }
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2189,7 +2315,7 @@ max_entries = 5
     #[test]
     fn type_mismatch_push_on_counter() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("warmth", "value", None);
+        let result = store.push("warmth", "value", None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2235,7 +2361,7 @@ max_entries = 5
     #[test]
     fn reset_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "test", None).unwrap();
+        store.push("flavor_history", "test", None, None).unwrap();
         store.reset("flavor_history").unwrap();
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => assert!(entries.is_empty()),
@@ -2260,7 +2386,7 @@ max_entries = 5
         store.data.schema_id = "test".to_string();
         store.inc("warmth", 7).unwrap();
         store.set("current_mood", "happy", None).unwrap();
-        store.push("flavor_history", "earl grey", None).unwrap();
+        store.push("flavor_history", "earl grey", None, None).unwrap();
         store.save().unwrap();
 
         // Reload and verify
@@ -2287,8 +2413,8 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T10:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "focus", ts, None).unwrap();
-        store.push_with_ts("tags", "rust", ts, None).unwrap();
+        store.push_with_ts("tags", "focus", ts, None, None).unwrap();
+        store.push_with_ts("tags", "rust", ts, None, None).unwrap();
 
         let compact = store.dump_compact();
 
@@ -2315,7 +2441,7 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
         store
-            .push_with_ts("flavor_history", "bergamot", ts, None)
+            .push_with_ts("flavor_history", "bergamot", ts, None, None)
             .unwrap();
 
         let compact = store.dump_compact();
@@ -2412,9 +2538,9 @@ max_entries = 5
     #[test]
     fn remove_list_by_value_first_match() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "alpha-2", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "alpha-2", None, None).unwrap();
 
         let result = store
             .remove("tags", Some("alpha"), None::<&IdRef>, false)
@@ -2436,9 +2562,9 @@ max_entries = 5
     #[test]
     fn remove_list_by_value_all_matches() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "alpha-2", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "alpha-2", None, None).unwrap();
 
         let result = store
             .remove("tags", Some("alpha"), None::<&IdRef>, true)
@@ -2457,9 +2583,9 @@ max_entries = 5
     #[test]
     fn remove_list_by_id() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "gamma", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "gamma", None, None).unwrap();
 
         // Get the ID of "beta"
         let beta_id = match store.get("tags").unwrap() {
@@ -2477,10 +2603,10 @@ max_entries = 5
     #[test]
     fn remove_history_by_value() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
-        store.push("flavor_history", "lapsang", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store.push("flavor_history", "lapsang", None, None).unwrap();
         store
-            .push("flavor_history", "bergamot vanilla", None)
+            .push("flavor_history", "bergamot vanilla", None, None)
             .unwrap();
 
         let result = store
@@ -2499,8 +2625,8 @@ max_entries = 5
     #[test]
     fn remove_case_insensitive() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "Alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "Alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
 
         let result = store
             .remove("tags", Some("alpha"), None::<&IdRef>, false)
@@ -2522,9 +2648,9 @@ max_entries = 5
     #[test]
     fn search_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "rust-lang", None).unwrap();
-        store.push("tags", "focus", None).unwrap();
-        store.push("tags", "rust-tools", None).unwrap();
+        store.push("tags", "rust-lang", None, None).unwrap();
+        store.push("tags", "focus", None, None).unwrap();
+        store.push("tags", "rust-tools", None, None).unwrap();
 
         let hits = store.search("tags", Some("rust"), None, &[]).unwrap();
         assert_eq!(hits.len(), 2);
@@ -2535,10 +2661,10 @@ max_entries = 5
     #[test]
     fn search_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
-        store.push("flavor_history", "lapsang", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store.push("flavor_history", "lapsang", None, None).unwrap();
         store
-            .push("flavor_history", "bergamot vanilla", None)
+            .push("flavor_history", "bergamot vanilla", None, None)
             .unwrap();
 
         let hits = store
@@ -2550,9 +2676,9 @@ max_entries = 5
     #[test]
     fn search_case_insensitive() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "Rust", None).unwrap();
-        store.push("tags", "RUST-tools", None).unwrap();
-        store.push("tags", "python", None).unwrap();
+        store.push("tags", "Rust", None, None).unwrap();
+        store.push("tags", "RUST-tools", None, None).unwrap();
+        store.push("tags", "python", None, None).unwrap();
 
         let hits = store.search("tags", Some("rust"), None, &[]).unwrap();
         assert_eq!(hits.len(), 2);
@@ -2561,7 +2687,7 @@ max_entries = 5
     #[test]
     fn search_no_matches() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store.search("tags", Some("zzz"), None, &[]).unwrap();
         assert!(hits.is_empty());
@@ -2580,9 +2706,9 @@ max_entries = 5
     #[test]
     fn get_by_id_single_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
-        store.push("flavor_history", "lapsang", None).unwrap();
-        store.push("flavor_history", "earl grey", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store.push("flavor_history", "lapsang", None, None).unwrap();
+        store.push("flavor_history", "earl grey", None, None).unwrap();
 
         // Get the ID of the second entry
         let target_id = match store.get("flavor_history").unwrap() {
@@ -2601,9 +2727,9 @@ max_entries = 5
     #[test]
     fn get_by_id_single_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "gamma", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "gamma", None, None).unwrap();
 
         // Read the actual ID of the second entry from the store
         let target_id = match store.get("tags").unwrap() {
@@ -2622,9 +2748,9 @@ max_entries = 5
     #[test]
     fn get_by_id_range_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "gamma", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "gamma", None, None).unwrap();
 
         let hits = store
             .get_entries_by_id(
@@ -2641,9 +2767,9 @@ max_entries = 5
     #[test]
     fn get_by_id_multi_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "gamma", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "gamma", None, None).unwrap();
 
         let hits = store
             .get_entries_by_id("tags", &[IdRef::Numeric(1), IdRef::Numeric(3)])
@@ -2656,8 +2782,8 @@ max_entries = 5
     #[test]
     fn get_by_id_partial_match() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
 
         // Request IDs 1, 2, 99 — only 1 and 2 exist
         let hits = store
@@ -2672,7 +2798,7 @@ max_entries = 5
     #[test]
     fn get_by_id_all_not_found() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store
             .get_entries_by_id("tags", &[IdRef::Numeric(99), IdRef::Numeric(100)])
@@ -2727,9 +2853,9 @@ max_entries = 5
     #[test]
     fn count_list_total() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "a", None).unwrap();
-        store.push("tags", "b", None).unwrap();
-        store.push("tags", "c", None).unwrap();
+        store.push("tags", "a", None, None).unwrap();
+        store.push("tags", "b", None, None).unwrap();
+        store.push("tags", "c", None, None).unwrap();
 
         let result = store.count("tags", None, None, &[]).unwrap();
         assert_eq!(result.matched, 3);
@@ -2739,9 +2865,9 @@ max_entries = 5
     #[test]
     fn count_list_filtered() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "rust-lang", None).unwrap();
-        store.push("tags", "focus", None).unwrap();
-        store.push("tags", "rust-tools", None).unwrap();
+        store.push("tags", "rust-lang", None, None).unwrap();
+        store.push("tags", "focus", None, None).unwrap();
+        store.push("tags", "rust-tools", None, None).unwrap();
 
         let result = store.count("tags", Some("rust"), None, &[]).unwrap();
         assert_eq!(result.matched, 2);
@@ -2759,13 +2885,13 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot", ts1, None)
+            .push_with_ts("flavor_history", "bergamot", ts1, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "bergamot vanilla", ts2, None)
+            .push_with_ts("flavor_history", "bergamot vanilla", ts2, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "lapsang", ts1, None)
+            .push_with_ts("flavor_history", "lapsang", ts1, None, None)
             .unwrap();
 
         let result = store
@@ -2807,9 +2933,9 @@ max_entries = 5
     #[test]
     fn history_ids_auto_increment() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "a", None).unwrap();
-        store.push("flavor_history", "b", None).unwrap();
-        store.push("flavor_history", "c", None).unwrap();
+        store.push("flavor_history", "a", None, None).unwrap();
+        store.push("flavor_history", "b", None, None).unwrap();
+        store.push("flavor_history", "c", None, None).unwrap();
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
@@ -2829,9 +2955,9 @@ max_entries = 5
     #[test]
     fn list_ids_auto_increment() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "a", None).unwrap();
-        store.push("tags", "b", None).unwrap();
-        store.push("tags", "c", None).unwrap();
+        store.push("tags", "a", None, None).unwrap();
+        store.push("tags", "b", None, None).unwrap();
+        store.push("tags", "c", None, None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2846,9 +2972,9 @@ max_entries = 5
     #[test]
     fn list_ids_stable_after_remove() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "a", None).unwrap();
-        store.push("tags", "b", None).unwrap();
-        store.push("tags", "c", None).unwrap();
+        store.push("tags", "a", None, None).unwrap();
+        store.push("tags", "b", None, None).unwrap();
+        store.push("tags", "c", None, None).unwrap();
 
         // Remove "b"
         store
@@ -2856,7 +2982,7 @@ max_entries = 5
             .unwrap();
 
         // Push "d" — should get id=4, not reuse id=2
-        store.push("tags", "d", None).unwrap();
+        store.push("tags", "d", None, None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2952,7 +3078,7 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T10:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "focus", ts, None).unwrap();
+        store.push_with_ts("tags", "focus", ts, None, None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2972,8 +3098,8 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T10:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "focus", ts, None).unwrap();
-        store.push_with_ts("tags", "rust", ts, None).unwrap();
+        store.push_with_ts("tags", "focus", ts, None, None).unwrap();
+        store.push_with_ts("tags", "rust", ts, None, None).unwrap();
 
         let output = format_value(store.get("tags").unwrap());
         // New format: "1 [kv-XXXX]: focus (ts)"
@@ -2987,7 +3113,7 @@ max_entries = 5
     #[test]
     fn format_value_history_shows_ids() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
 
         let output = format_value(store.get("flavor_history").unwrap());
         // Should contain "N: bergamot (timestamp)"
@@ -3003,8 +3129,8 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T14:15:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "dsi-panel", ts, None).unwrap();
-        store.push_with_ts("tags", "anytype", ts, None).unwrap();
+        store.push_with_ts("tags", "dsi-panel", ts, None, None).unwrap();
+        store.push_with_ts("tags", "anytype", ts, None, None).unwrap();
 
         let compact = store.dump_compact();
         assert!(compact.contains("tags=[dsi-panel@14:15,anytype@14:15]"));
@@ -3017,7 +3143,7 @@ max_entries = 5
     #[test]
     fn set_get_memory_on_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
 
         // Initially no memory pointer
         assert_eq!(store.get_memory("flavor_history").unwrap(), None);
@@ -3041,7 +3167,7 @@ max_entries = 5
     #[test]
     fn set_get_memory_on_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
 
         store
             .set_memory("tags", Some("kn-def456".to_string()))
@@ -3088,7 +3214,7 @@ max_entries = 5
     #[test]
     fn clear_memory_with_empty_string() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
 
         // Set then clear
         store
@@ -3109,7 +3235,7 @@ max_entries = 5
     #[test]
     fn clear_memory_with_none() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
 
         store
             .set_memory("tags", Some("kn-abc123".to_string()))
@@ -3121,7 +3247,7 @@ max_entries = 5
     #[test]
     fn memory_not_serialized_when_none() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
         store.data.schema_id = "test".to_string();
         store.save().unwrap();
 
@@ -3223,7 +3349,7 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
         store
-            .push_with_ts("flavor_history", "bergamot", ts, None)
+            .push_with_ts("flavor_history", "bergamot", ts, None, None)
             .unwrap();
         store
             .set_memory("flavor_history", Some("kn-def456".to_string()))
@@ -3249,7 +3375,7 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
         store
-            .push_with_ts("flavor_history", "bergamot", ts, None)
+            .push_with_ts("flavor_history", "bergamot", ts, None, None)
             .unwrap();
         // No memory pointer set
 
@@ -3282,13 +3408,13 @@ max_entries = 5
     #[test]
     fn memory_survives_push() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
         store
             .set_memory("flavor_history", Some("kn-abc123".to_string()))
             .unwrap();
 
         // Push another entry
-        store.push("flavor_history", "lapsang", None).unwrap();
+        store.push("flavor_history", "lapsang", None, None).unwrap();
 
         // Memory pointer should still be set
         assert_eq!(
@@ -3300,7 +3426,7 @@ max_entries = 5
     #[test]
     fn memory_survives_reset() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None).unwrap();
+        store.push("flavor_history", "bergamot", None, None).unwrap();
         store
             .set_memory("flavor_history", Some("kn-abc123".to_string()))
             .unwrap();
@@ -3728,16 +3854,16 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "inside", ts_in, None)
+            .push_with_ts("flavor_history", "inside", ts_in, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "outside", ts_out, None)
+            .push_with_ts("flavor_history", "outside", ts_out, None, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         let results = store.last("flavor_history", 10, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].contains("inside"));
+        assert_eq!(results[0].value, "inside");
     }
 
     #[test]
@@ -3748,8 +3874,8 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("flavor_history", "a", ts, None).unwrap();
-        store.push_with_ts("flavor_history", "b", ts, None).unwrap();
+        store.push_with_ts("flavor_history", "a", ts, None, None).unwrap();
+        store.push_with_ts("flavor_history", "b", ts, None, None).unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         // Both entries match the range, but count=1 limits output
@@ -3768,9 +3894,9 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "rust-in", ts_in, None).unwrap();
+        store.push_with_ts("tags", "rust-in", ts_in, None, None).unwrap();
         store
-            .push_with_ts("tags", "rust-out", ts_out, None)
+            .push_with_ts("tags", "rust-out", ts_out, None, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
@@ -3792,22 +3918,22 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "inside", ts_in, None).unwrap();
-        store.push_with_ts("tags", "outside", ts_out, None).unwrap();
+        store.push_with_ts("tags", "inside", ts_in, None, None).unwrap();
+        store.push_with_ts("tags", "outside", ts_out, None, None).unwrap();
         store
-            .push_with_ts("tags", "also-inside", ts_in, None)
+            .push_with_ts("tags", "also-inside", ts_in, None, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         let results = store.last("tags", 10, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 2);
-        assert!(results[0].contains("inside"));
-        assert!(results[1].contains("also-inside"));
+        assert_eq!(results[0].value, "inside");
+        assert_eq!(results[1].value, "also-inside");
 
         // count limit applies after time filter
         let results = store.last("tags", 1, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].contains("also-inside"));
+        assert_eq!(results[0].value, "also-inside");
     }
 
     #[test]
@@ -3822,10 +3948,10 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot-in", ts_in, None)
+            .push_with_ts("flavor_history", "bergamot-in", ts_in, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "bergamot-out", ts_out, None)
+            .push_with_ts("flavor_history", "bergamot-out", ts_out, None, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
@@ -3848,13 +3974,13 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot", ts_in, None)
+            .push_with_ts("flavor_history", "bergamot", ts_in, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "lapsang", ts_in, None)
+            .push_with_ts("flavor_history", "lapsang", ts_in, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "bergamot earl", ts_out, None)
+            .push_with_ts("flavor_history", "bergamot earl", ts_out, None, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
@@ -3884,10 +4010,10 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "april", ts_apr, None)
+            .push_with_ts("flavor_history", "april", ts_apr, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "may", ts_may, None)
+            .push_with_ts("flavor_history", "may", ts_may, None, None)
             .unwrap();
 
         let range = parse_month("2026-04").unwrap();
@@ -3909,9 +4035,9 @@ max_entries = 5
     #[test]
     fn random_returns_requested_count() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
-        store.push("tags", "gamma", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "gamma", None, None).unwrap();
 
         let results = store.random("tags", 2, None, &[]).unwrap();
         assert_eq!(results.len(), 2);
@@ -3920,8 +4046,8 @@ max_entries = 5
     #[test]
     fn random_returns_all_when_count_exceeds_available() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
 
         let results = store.random("tags", 10, None, &[]).unwrap();
         assert_eq!(results.len(), 2);
@@ -3946,16 +4072,16 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "bergamot", ts, None)
+            .push_with_ts("flavor_history", "bergamot", ts, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "vanilla", ts, None)
+            .push_with_ts("flavor_history", "vanilla", ts, None, None)
             .unwrap();
 
         let results = store.random("flavor_history", 1, None, &[]).unwrap();
         assert_eq!(results.len(), 1);
-        // Result must contain one of the pushed values
-        assert!(results[0].contains("bergamot") || results[0].contains("vanilla"));
+        // Result must be one of the pushed values
+        assert!(results[0].value == "bergamot" || results[0].value == "vanilla");
     }
 
     #[test]
@@ -3969,13 +4095,13 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "inside", ts_in, None).unwrap();
-        store.push_with_ts("tags", "outside", ts_out, None).unwrap();
+        store.push_with_ts("tags", "inside", ts_in, None, None).unwrap();
+        store.push_with_ts("tags", "outside", ts_out, None, None).unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         let results = store.random("tags", 10, Some(&range), &[]).unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].contains("inside"));
+        assert_eq!(results[0].value, "inside");
     }
 
     #[test]
@@ -3990,10 +4116,10 @@ max_entries = 5
             .with_timezone(&Utc);
 
         store
-            .push_with_ts("flavor_history", "inside", ts_in, None)
+            .push_with_ts("flavor_history", "inside", ts_in, None, None)
             .unwrap();
         store
-            .push_with_ts("flavor_history", "outside", ts_out, None)
+            .push_with_ts("flavor_history", "outside", ts_out, None, None)
             .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
@@ -4001,7 +4127,7 @@ max_entries = 5
             .random("flavor_history", 10, Some(&range), &[])
             .unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].contains("inside"));
+        assert_eq!(results[0].value, "inside");
     }
 
     // -- --since resolver --
@@ -4043,7 +4169,7 @@ max_entries = 5
     fn push_with_data_stores_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"status": "active", "tags": ["rust", "kv"]});
-        store.push("tags", "my-item", Some(data.clone())).unwrap();
+        store.push("tags", "my-item", Some(data.clone()), None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -4058,7 +4184,7 @@ max_entries = 5
     #[test]
     fn push_without_data_stores_none() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "bare-item", None).unwrap();
+        store.push("tags", "bare-item", None, None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -4074,7 +4200,7 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"mood": "focused"});
         store
-            .push("flavor_history", "bergamot", Some(data.clone()))
+            .push("flavor_history", "bergamot", Some(data.clone()), None)
             .unwrap();
 
         match store.get("flavor_history").unwrap() {
@@ -4089,7 +4215,7 @@ max_entries = 5
     fn data_round_trip_through_save() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"priority": 1, "tags": ["a", "b"]});
-        store.push("tags", "item", Some(data.clone())).unwrap();
+        store.push("tags", "item", Some(data.clone()), None).unwrap();
         store.data.schema_id = "test".to_string();
         store.save().unwrap();
 
@@ -4260,6 +4386,7 @@ max_entries = 5
                 "tags",
                 "task-1",
                 Some(serde_json::json!({"status": "active"})),
+                None,
             )
             .unwrap();
         store
@@ -4267,6 +4394,7 @@ max_entries = 5
                 "tags",
                 "task-2",
                 Some(serde_json::json!({"status": "closed"})),
+                None,
             )
             .unwrap();
         store
@@ -4274,6 +4402,7 @@ max_entries = 5
                 "tags",
                 "task-3",
                 Some(serde_json::json!({"status": "active"})),
+                None,
             )
             .unwrap();
 
@@ -4292,6 +4421,7 @@ max_entries = 5
                 "tags",
                 "item-a",
                 Some(serde_json::json!({"labels": ["bug", "urgent"]})),
+                None,
             )
             .unwrap();
         store
@@ -4299,6 +4429,7 @@ max_entries = 5
                 "tags",
                 "item-b",
                 Some(serde_json::json!({"labels": ["feature"]})),
+                None,
             )
             .unwrap();
 
@@ -4311,12 +4442,13 @@ max_entries = 5
     #[test]
     fn search_with_where_excludes_entries_without_data() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "no-data", None).unwrap();
+        store.push("tags", "no-data", None, None).unwrap();
         store
             .push(
                 "tags",
                 "has-data",
                 Some(serde_json::json!({"status": "active"})),
+                None,
             )
             .unwrap();
 
@@ -4334,6 +4466,7 @@ max_entries = 5
                 "tags",
                 "rust-fix",
                 Some(serde_json::json!({"status": "active"})),
+                None,
             )
             .unwrap();
         store
@@ -4341,6 +4474,7 @@ max_entries = 5
                 "tags",
                 "rust-feature",
                 Some(serde_json::json!({"status": "closed"})),
+                None,
             )
             .unwrap();
         store
@@ -4348,6 +4482,7 @@ max_entries = 5
                 "tags",
                 "python-fix",
                 Some(serde_json::json!({"status": "active"})),
+                None,
             )
             .unwrap();
 
@@ -4362,10 +4497,10 @@ max_entries = 5
     fn search_with_only_where_no_query() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push("tags", "a", Some(serde_json::json!({"type": "bug"})))
+            .push("tags", "a", Some(serde_json::json!({"type": "bug"})), None)
             .unwrap();
         store
-            .push("tags", "b", Some(serde_json::json!({"type": "feature"})))
+            .push("tags", "b", Some(serde_json::json!({"type": "feature"})), None)
             .unwrap();
 
         let clauses = vec![("type".to_string(), "bug".to_string())];
@@ -4382,6 +4517,7 @@ max_entries = 5
                 "tags",
                 "match-both",
                 Some(serde_json::json!({"status": "active", "priority": "high"})),
+                None,
             )
             .unwrap();
         store
@@ -4389,6 +4525,7 @@ max_entries = 5
                 "tags",
                 "match-one",
                 Some(serde_json::json!({"status": "active", "priority": "low"})),
+                None,
             )
             .unwrap();
 
@@ -4407,20 +4544,20 @@ max_entries = 5
     fn last_with_where() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push("tags", "a", Some(serde_json::json!({"status": "active"})))
+            .push("tags", "a", Some(serde_json::json!({"status": "active"})), None)
             .unwrap();
         store
-            .push("tags", "b", Some(serde_json::json!({"status": "closed"})))
+            .push("tags", "b", Some(serde_json::json!({"status": "closed"})), None)
             .unwrap();
         store
-            .push("tags", "c", Some(serde_json::json!({"status": "active"})))
+            .push("tags", "c", Some(serde_json::json!({"status": "active"})), None)
             .unwrap();
 
         let clauses = vec![("status".to_string(), "active".to_string())];
         let items = store.last("tags", 10, None, &clauses).unwrap();
         assert_eq!(items.len(), 2);
-        assert!(items[0].contains("a"));
-        assert!(items[1].contains("c"));
+        assert_eq!(items[0].value, "a");
+        assert_eq!(items[1].value, "c");
     }
 
     // -- random with where_clauses --
@@ -4433,6 +4570,7 @@ max_entries = 5
                 "tags",
                 "active-1",
                 Some(serde_json::json!({"status": "active"})),
+                None,
             )
             .unwrap();
         store
@@ -4440,6 +4578,7 @@ max_entries = 5
                 "tags",
                 "closed-1",
                 Some(serde_json::json!({"status": "closed"})),
+                None,
             )
             .unwrap();
         store
@@ -4447,6 +4586,7 @@ max_entries = 5
                 "tags",
                 "active-2",
                 Some(serde_json::json!({"status": "active"})),
+                None,
             )
             .unwrap();
 
@@ -4456,9 +4596,9 @@ max_entries = 5
         // All returned items should contain "active-"
         for item in &items {
             assert!(
-                item.contains("active-"),
+                item.value.contains("active-"),
                 "Expected active item, got: {}",
-                item
+                item.value
             );
         }
     }
@@ -4469,13 +4609,13 @@ max_entries = 5
     fn count_with_where() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push("tags", "a", Some(serde_json::json!({"status": "active"})))
+            .push("tags", "a", Some(serde_json::json!({"status": "active"})), None)
             .unwrap();
         store
-            .push("tags", "b", Some(serde_json::json!({"status": "closed"})))
+            .push("tags", "b", Some(serde_json::json!({"status": "closed"})), None)
             .unwrap();
         store
-            .push("tags", "c", Some(serde_json::json!({"status": "active"})))
+            .push("tags", "c", Some(serde_json::json!({"status": "active"})), None)
             .unwrap();
 
         let clauses = vec![("status".to_string(), "active".to_string())];
@@ -4490,7 +4630,7 @@ max_entries = 5
     fn search_hits_carry_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"status": "active"});
-        store.push("tags", "item", Some(data.clone())).unwrap();
+        store.push("tags", "item", Some(data.clone()), None).unwrap();
 
         let hits = store.search("tags", Some("item"), None, &[]).unwrap();
         assert_eq!(hits.len(), 1);
@@ -4501,7 +4641,7 @@ max_entries = 5
     fn get_entries_by_id_carries_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"priority": "high"});
-        store.push("tags", "item", Some(data.clone())).unwrap();
+        store.push("tags", "item", Some(data.clone()), None).unwrap();
 
         let hits = store
             .get_entries_by_id("tags", &[IdRef::Numeric(1)])
@@ -4534,7 +4674,7 @@ max_entries = 5
     fn format_value_includes_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"k": "v"});
-        store.push("tags", "item", Some(data)).unwrap();
+        store.push("tags", "item", Some(data), None).unwrap();
 
         let formatted = format_value(store.get("tags").unwrap());
         assert!(formatted.contains("{\"k\":\"v\"}"));
@@ -4543,7 +4683,7 @@ max_entries = 5
     #[test]
     fn format_value_no_data_unchanged() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "plain-item", None).unwrap();
+        store.push("tags", "plain-item", None, None).unwrap();
 
         let formatted = format_value(store.get("tags").unwrap());
         assert!(formatted.contains("plain-item"));
@@ -4557,11 +4697,11 @@ max_entries = 5
     fn last_output_includes_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"x": 1});
-        store.push("tags", "item", Some(data)).unwrap();
+        store.push("tags", "item", Some(data), None).unwrap();
 
         let items = store.last("tags", 1, None, &[]).unwrap();
         assert_eq!(items.len(), 1);
-        assert!(items[0].contains("{\"x\":1}"));
+        assert_eq!(items[0].data, Some(serde_json::json!({"x": 1})));
     }
 
     // -- Hash ID tests --
@@ -4569,7 +4709,7 @@ max_entries = 5
     #[test]
     fn push_returns_push_result_with_hash_and_id() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("tags", "alpha", None).unwrap();
+        let result = store.push("tags", "alpha", None, None).unwrap();
         assert_eq!(result.id, 1);
         assert!(!result.hash.is_empty());
         // Hash should be 5-6 base58 chars
@@ -4631,7 +4771,7 @@ max_entries = 5
     #[test]
     fn get_by_numeric_id_still_works() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("tags", "alpha", None).unwrap();
+        let result = store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store
             .get_entries_by_id("tags", &[IdRef::Numeric(result.id)])
@@ -4643,7 +4783,7 @@ max_entries = 5
     #[test]
     fn get_by_hash_works() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("tags", "alpha", None).unwrap();
+        let result = store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store
             .get_entries_by_id("tags", &[IdRef::Hash(result.hash.clone())])
@@ -4656,7 +4796,7 @@ max_entries = 5
     #[test]
     fn get_by_hash_prefix_works() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("tags", "alpha", None).unwrap();
+        let result = store.push("tags", "alpha", None, None).unwrap();
 
         // Use first 3 chars as prefix
         let prefix = &result.hash[..3];
@@ -4670,8 +4810,8 @@ max_entries = 5
     #[test]
     fn get_by_mixed_id_types() {
         let (mut store, _dir) = setup_store(test_schema());
-        let r1 = store.push("tags", "alpha", None).unwrap();
-        let r2 = store.push("tags", "beta", None).unwrap();
+        let r1 = store.push("tags", "alpha", None, None).unwrap();
+        let r2 = store.push("tags", "beta", None, None).unwrap();
 
         let hits = store
             .get_entries_by_id(
@@ -4685,9 +4825,9 @@ max_entries = 5
     #[test]
     fn remove_by_hash_works() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        let r2 = store.push("tags", "beta", None).unwrap();
-        store.push("tags", "gamma", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        let r2 = store.push("tags", "beta", None, None).unwrap();
+        store.push("tags", "gamma", None, None).unwrap();
 
         let result = store
             .remove("tags", None, Some(&IdRef::Hash(r2.hash.clone())), false)
@@ -4709,8 +4849,8 @@ max_entries = 5
     #[test]
     fn remove_by_ambiguous_hash_prefix_errors() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("tags", "alpha", None).unwrap();
-        store.push("tags", "beta", None).unwrap();
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
 
         // Manually set both entries to share a hash prefix.
         match store.data.entries.get_mut("tags").unwrap() {
@@ -4740,21 +4880,17 @@ max_entries = 5
     #[test]
     fn hash_appears_in_last_output() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("tags", "alpha", None).unwrap();
+        let result = store.push("tags", "alpha", None, None).unwrap();
 
         let items = store.last("tags", 1, None, &[]).unwrap();
         assert_eq!(items.len(), 1);
-        assert!(
-            items[0].contains(&format!("[kv-{}]", result.hash)),
-            "output should contain hash: {}",
-            items[0]
-        );
+        assert_eq!(items[0].hash, result.hash);
     }
 
     #[test]
     fn hash_appears_in_search_output() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("tags", "alpha", None).unwrap();
+        let result = store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store.search("tags", Some("alpha"), None, &[]).unwrap();
         assert_eq!(hits.len(), 1);
@@ -4764,7 +4900,7 @@ max_entries = 5
     #[test]
     fn hash_stored_on_entry_structs() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("tags", "alpha", None).unwrap();
+        let result = store.push("tags", "alpha", None, None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -4777,7 +4913,7 @@ max_entries = 5
     #[test]
     fn hash_stored_on_history_entry() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("flavor_history", "bergamot", None).unwrap();
+        let result = store.push("flavor_history", "bergamot", None, None).unwrap();
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
@@ -4799,7 +4935,7 @@ max_entries = 5
         let hash;
         {
             let mut store = KvStore::load(&schema_path, &data_path).unwrap();
-            let result = store.push("tags", "alpha", None).unwrap();
+            let result = store.push("tags", "alpha", None, None).unwrap();
             hash = result.hash;
             store.save().unwrap();
         }
@@ -4809,6 +4945,273 @@ max_entries = 5
         match store2.data.entries.get("tags").unwrap() {
             DataValue::List { items, .. } => {
                 assert_eq!(items[0].hash, hash);
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    // -- Per-entry memory tests --
+
+    #[test]
+    fn push_with_memory_stores_on_entry() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push("tags", "linked-item", None, Some("kn-abc123".to_string()))
+            .unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].memory, Some("kn-abc123".to_string()));
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn push_without_memory_has_none() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "plain-item", None, None).unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert!(items[0].memory.is_none());
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn push_history_with_memory() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push(
+                "flavor_history",
+                "bergamot",
+                None,
+                Some("kn-hist123".to_string()),
+            )
+            .unwrap();
+
+        match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries[0].memory, Some("kn-hist123".to_string()));
+            }
+            _ => panic!("Expected history"),
+        }
+    }
+
+    #[test]
+    fn set_entry_memory_by_numeric_id() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None, None).unwrap();
+
+        store
+            .set_entry_memory("tags", &IdRef::Numeric(result.id), Some("kn-set1".to_string()))
+            .unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].memory, Some("kn-set1".to_string()));
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn set_entry_memory_by_hash() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("tags", "alpha", None, None).unwrap();
+
+        store
+            .set_entry_memory(
+                "tags",
+                &IdRef::Hash(result.hash.clone()),
+                Some("kn-hash1".to_string()),
+            )
+            .unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].memory, Some("kn-hash1".to_string()));
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn set_entry_memory_not_found_errors() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("tags", "alpha", None, None).unwrap();
+
+        let result =
+            store.set_entry_memory("tags", &IdRef::Numeric(999), Some("kn-x".to_string()));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("entry not found"));
+    }
+
+    #[test]
+    fn set_entry_memory_history_by_numeric_id() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.push("flavor_history", "bergamot", None, None).unwrap();
+
+        store
+            .set_entry_memory(
+                "flavor_history",
+                &IdRef::Numeric(result.id),
+                Some("kn-hist-set".to_string()),
+            )
+            .unwrap();
+
+        match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries[0].memory, Some("kn-hist-set".to_string()));
+            }
+            _ => panic!("Expected history"),
+        }
+    }
+
+    #[test]
+    fn per_entry_memory_in_search_hit() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push("tags", "linked", None, Some("kn-search1".to_string()))
+            .unwrap();
+        store.push("tags", "plain", None, None).unwrap();
+
+        let hits = store.search("tags", Some("linked"), None, &[]).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].memory, Some("kn-search1".to_string()));
+
+        let hits = store.search("tags", Some("plain"), None, &[]).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].memory.is_none());
+    }
+
+    #[test]
+    fn last_returns_search_hit_with_memory() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push("tags", "with-mem", None, Some("kn-last1".to_string()))
+            .unwrap();
+        store.push("tags", "without-mem", None, None).unwrap();
+
+        let hits = store.last("tags", 2, None, &[]).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].memory, Some("kn-last1".to_string()));
+        assert!(hits[1].memory.is_none());
+    }
+
+    #[test]
+    fn random_returns_search_hit_with_memory() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .push("tags", "only-item", None, Some("kn-rand1".to_string()))
+            .unwrap();
+
+        let hits = store.random("tags", 1, None, &[]).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].memory, Some("kn-rand1".to_string()));
+    }
+
+    #[test]
+    fn backward_compat_data_without_memory_field() {
+        // Simulate old data without memory field on entries
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        // Write data file without memory field on entries
+        let old_data = r#"{
+            "_schema": "test",
+            "_updated": "2026-01-01T00:00:00Z",
+            "tags": {
+                "items": [
+                    {"id": 1, "hash": "abc", "value": "old-item", "ts": "2026-01-01T00:00:00Z"}
+                ]
+            }
+        }"#;
+        fs::write(&data_path, old_data).unwrap();
+
+        let store = KvStore::load(&schema_path, &data_path).unwrap();
+        match store.data.entries.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].value, "old-item");
+                assert!(items[0].memory.is_none());
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn clear_entry_memory_with_empty_string() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store
+            .push("tags", "alpha", None, Some("kn-clear1".to_string()))
+            .unwrap();
+
+        // Set memory to empty string should clear it
+        store
+            .set_entry_memory("tags", &IdRef::Numeric(result.id), Some("".to_string()))
+            .unwrap();
+
+        match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert!(items[0].memory.is_none());
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn get_entries_by_id_carries_memory() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let r1 = store
+            .push("tags", "with-mem", None, Some("kn-byid1".to_string()))
+            .unwrap();
+        store.push("tags", "without", None, None).unwrap();
+
+        let hits = store
+            .get_entries_by_id("tags", &[IdRef::Numeric(r1.id)])
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].memory, Some("kn-byid1".to_string()));
+    }
+
+    #[test]
+    fn set_entry_memory_type_mismatch() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.inc("warmth", 1).unwrap();
+
+        let result =
+            store.set_entry_memory("warmth", &IdRef::Numeric(1), Some("kn-x".to_string()));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Type mismatch"));
+    }
+
+    #[test]
+    fn entry_memory_persists_through_save_reload() {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        let mut f = fs::File::create(&schema_path).unwrap();
+        f.write_all(test_schema().as_bytes()).unwrap();
+
+        {
+            let mut store = KvStore::load(&schema_path, &data_path).unwrap();
+            store
+                .push("tags", "persistent", None, Some("kn-persist".to_string()))
+                .unwrap();
+            store.save().unwrap();
+        }
+
+        let store2 = KvStore::load(&schema_path, &data_path).unwrap();
+        match store2.data.entries.get("tags").unwrap() {
+            DataValue::List { items, .. } => {
+                assert_eq!(items[0].memory, Some("kn-persist".to_string()));
             }
             _ => panic!("Expected list"),
         }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1009,10 +1009,7 @@ impl KvStore {
             }
             let take = n.min(filtered.len());
             let mut rng = rand::rng();
-            filtered
-                .choose_multiple(&mut rng, take)
-                .cloned()
-                .collect()
+            filtered.choose_multiple(&mut rng, take).cloned().collect()
         }
 
         match def.value_type {
@@ -1591,14 +1588,13 @@ impl KvStore {
                             0 => None,
                             1 => {
                                 // Re-find to satisfy borrow checker (collected vec consumes &mut)
-                                entries
-                                    .iter_mut()
-                                    .find(|e| e.hash.starts_with(h.as_str()))
+                                entries.iter_mut().find(|e| e.hash.starts_with(h.as_str()))
                             }
                             n => {
                                 return Err(KvError::Other(anyhow::anyhow!(
                                     "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                    h, n
+                                    h,
+                                    n
                                 )));
                             }
                         }
@@ -1611,7 +1607,8 @@ impl KvStore {
                     }
                     None => Err(KvError::Other(anyhow::anyhow!(
                         "entry not found for ID {:?} in key '{}'",
-                        id, key
+                        id,
+                        key
                     ))),
                 }
             }
@@ -1625,15 +1622,12 @@ impl KvStore {
                             .collect();
                         match matches.len() {
                             0 => None,
-                            1 => {
-                                items
-                                    .iter_mut()
-                                    .find(|e| e.hash.starts_with(h.as_str()))
-                            }
+                            1 => items.iter_mut().find(|e| e.hash.starts_with(h.as_str())),
                             n => {
                                 return Err(KvError::Other(anyhow::anyhow!(
                                     "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
-                                    h, n
+                                    h,
+                                    n
                                 )));
                             }
                         }
@@ -1646,7 +1640,8 @@ impl KvStore {
                     }
                     None => Err(KvError::Other(anyhow::anyhow!(
                         "entry not found for ID {:?} in key '{}'",
-                        id, key
+                        id,
+                        key
                     ))),
                 }
             }
@@ -2215,7 +2210,9 @@ max_entries = 5
     #[test]
     fn history_push_and_last() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
         store.push("flavor_history", "lapsang", None, None).unwrap();
 
         let last = store.last("flavor_history", 1, None, &[]).unwrap();
@@ -2290,7 +2287,9 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         // max_entries = 5
         for i in 0..8 {
-            store.push("tags", &format!("item_{}", i), None, None).unwrap();
+            store
+                .push("tags", &format!("item_{}", i), None, None)
+                .unwrap();
         }
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -2386,7 +2385,9 @@ max_entries = 5
         store.data.schema_id = "test".to_string();
         store.inc("warmth", 7).unwrap();
         store.set("current_mood", "happy", None).unwrap();
-        store.push("flavor_history", "earl grey", None, None).unwrap();
+        store
+            .push("flavor_history", "earl grey", None, None)
+            .unwrap();
         store.save().unwrap();
 
         // Reload and verify
@@ -2603,7 +2604,9 @@ max_entries = 5
     #[test]
     fn remove_history_by_value() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
         store.push("flavor_history", "lapsang", None, None).unwrap();
         store
             .push("flavor_history", "bergamot vanilla", None, None)
@@ -2661,7 +2664,9 @@ max_entries = 5
     #[test]
     fn search_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
         store.push("flavor_history", "lapsang", None, None).unwrap();
         store
             .push("flavor_history", "bergamot vanilla", None, None)
@@ -2706,9 +2711,13 @@ max_entries = 5
     #[test]
     fn get_by_id_single_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
         store.push("flavor_history", "lapsang", None, None).unwrap();
-        store.push("flavor_history", "earl grey", None, None).unwrap();
+        store
+            .push("flavor_history", "earl grey", None, None)
+            .unwrap();
 
         // Get the ID of the second entry
         let target_id = match store.get("flavor_history").unwrap() {
@@ -3113,7 +3122,9 @@ max_entries = 5
     #[test]
     fn format_value_history_shows_ids() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
 
         let output = format_value(store.get("flavor_history").unwrap());
         // Should contain "N: bergamot (timestamp)"
@@ -3129,8 +3140,12 @@ max_entries = 5
         let ts = DateTime::parse_from_rfc3339("2026-04-22T14:15:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        store.push_with_ts("tags", "dsi-panel", ts, None, None).unwrap();
-        store.push_with_ts("tags", "anytype", ts, None, None).unwrap();
+        store
+            .push_with_ts("tags", "dsi-panel", ts, None, None)
+            .unwrap();
+        store
+            .push_with_ts("tags", "anytype", ts, None, None)
+            .unwrap();
 
         let compact = store.dump_compact();
         assert!(compact.contains("tags=[dsi-panel@14:15,anytype@14:15]"));
@@ -3143,7 +3158,9 @@ max_entries = 5
     #[test]
     fn set_get_memory_on_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
 
         // Initially no memory pointer
         assert_eq!(store.get_memory("flavor_history").unwrap(), None);
@@ -3214,7 +3231,9 @@ max_entries = 5
     #[test]
     fn clear_memory_with_empty_string() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
 
         // Set then clear
         store
@@ -3247,7 +3266,9 @@ max_entries = 5
     #[test]
     fn memory_not_serialized_when_none() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
         store.data.schema_id = "test".to_string();
         store.save().unwrap();
 
@@ -3408,7 +3429,9 @@ max_entries = 5
     #[test]
     fn memory_survives_push() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
         store
             .set_memory("flavor_history", Some("kn-abc123".to_string()))
             .unwrap();
@@ -3426,7 +3449,9 @@ max_entries = 5
     #[test]
     fn memory_survives_reset() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "bergamot", None, None).unwrap();
+        store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
         store
             .set_memory("flavor_history", Some("kn-abc123".to_string()))
             .unwrap();
@@ -3874,8 +3899,12 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("flavor_history", "a", ts, None, None).unwrap();
-        store.push_with_ts("flavor_history", "b", ts, None, None).unwrap();
+        store
+            .push_with_ts("flavor_history", "a", ts, None, None)
+            .unwrap();
+        store
+            .push_with_ts("flavor_history", "b", ts, None, None)
+            .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         // Both entries match the range, but count=1 limits output
@@ -3894,7 +3923,9 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "rust-in", ts_in, None, None).unwrap();
+        store
+            .push_with_ts("tags", "rust-in", ts_in, None, None)
+            .unwrap();
         store
             .push_with_ts("tags", "rust-out", ts_out, None, None)
             .unwrap();
@@ -3918,8 +3949,12 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "inside", ts_in, None, None).unwrap();
-        store.push_with_ts("tags", "outside", ts_out, None, None).unwrap();
+        store
+            .push_with_ts("tags", "inside", ts_in, None, None)
+            .unwrap();
+        store
+            .push_with_ts("tags", "outside", ts_out, None, None)
+            .unwrap();
         store
             .push_with_ts("tags", "also-inside", ts_in, None, None)
             .unwrap();
@@ -4095,8 +4130,12 @@ max_entries = 5
             .unwrap()
             .with_timezone(&Utc);
 
-        store.push_with_ts("tags", "inside", ts_in, None, None).unwrap();
-        store.push_with_ts("tags", "outside", ts_out, None, None).unwrap();
+        store
+            .push_with_ts("tags", "inside", ts_in, None, None)
+            .unwrap();
+        store
+            .push_with_ts("tags", "outside", ts_out, None, None)
+            .unwrap();
 
         let range = parse_day("2026-04-25").unwrap();
         let results = store.random("tags", 10, Some(&range), &[]).unwrap();
@@ -4169,7 +4208,9 @@ max_entries = 5
     fn push_with_data_stores_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"status": "active", "tags": ["rust", "kv"]});
-        store.push("tags", "my-item", Some(data.clone()), None).unwrap();
+        store
+            .push("tags", "my-item", Some(data.clone()), None)
+            .unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
@@ -4215,7 +4256,9 @@ max_entries = 5
     fn data_round_trip_through_save() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"priority": 1, "tags": ["a", "b"]});
-        store.push("tags", "item", Some(data.clone()), None).unwrap();
+        store
+            .push("tags", "item", Some(data.clone()), None)
+            .unwrap();
         store.data.schema_id = "test".to_string();
         store.save().unwrap();
 
@@ -4500,7 +4543,12 @@ max_entries = 5
             .push("tags", "a", Some(serde_json::json!({"type": "bug"})), None)
             .unwrap();
         store
-            .push("tags", "b", Some(serde_json::json!({"type": "feature"})), None)
+            .push(
+                "tags",
+                "b",
+                Some(serde_json::json!({"type": "feature"})),
+                None,
+            )
             .unwrap();
 
         let clauses = vec![("type".to_string(), "bug".to_string())];
@@ -4544,13 +4592,28 @@ max_entries = 5
     fn last_with_where() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push("tags", "a", Some(serde_json::json!({"status": "active"})), None)
+            .push(
+                "tags",
+                "a",
+                Some(serde_json::json!({"status": "active"})),
+                None,
+            )
             .unwrap();
         store
-            .push("tags", "b", Some(serde_json::json!({"status": "closed"})), None)
+            .push(
+                "tags",
+                "b",
+                Some(serde_json::json!({"status": "closed"})),
+                None,
+            )
             .unwrap();
         store
-            .push("tags", "c", Some(serde_json::json!({"status": "active"})), None)
+            .push(
+                "tags",
+                "c",
+                Some(serde_json::json!({"status": "active"})),
+                None,
+            )
             .unwrap();
 
         let clauses = vec![("status".to_string(), "active".to_string())];
@@ -4609,13 +4672,28 @@ max_entries = 5
     fn count_with_where() {
         let (mut store, _dir) = setup_store(test_schema());
         store
-            .push("tags", "a", Some(serde_json::json!({"status": "active"})), None)
+            .push(
+                "tags",
+                "a",
+                Some(serde_json::json!({"status": "active"})),
+                None,
+            )
             .unwrap();
         store
-            .push("tags", "b", Some(serde_json::json!({"status": "closed"})), None)
+            .push(
+                "tags",
+                "b",
+                Some(serde_json::json!({"status": "closed"})),
+                None,
+            )
             .unwrap();
         store
-            .push("tags", "c", Some(serde_json::json!({"status": "active"})), None)
+            .push(
+                "tags",
+                "c",
+                Some(serde_json::json!({"status": "active"})),
+                None,
+            )
             .unwrap();
 
         let clauses = vec![("status".to_string(), "active".to_string())];
@@ -4630,7 +4708,9 @@ max_entries = 5
     fn search_hits_carry_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"status": "active"});
-        store.push("tags", "item", Some(data.clone()), None).unwrap();
+        store
+            .push("tags", "item", Some(data.clone()), None)
+            .unwrap();
 
         let hits = store.search("tags", Some("item"), None, &[]).unwrap();
         assert_eq!(hits.len(), 1);
@@ -4641,7 +4721,9 @@ max_entries = 5
     fn get_entries_by_id_carries_data() {
         let (mut store, _dir) = setup_store(test_schema());
         let data = serde_json::json!({"priority": "high"});
-        store.push("tags", "item", Some(data.clone()), None).unwrap();
+        store
+            .push("tags", "item", Some(data.clone()), None)
+            .unwrap();
 
         let hits = store
             .get_entries_by_id("tags", &[IdRef::Numeric(1)])
@@ -4913,7 +4995,9 @@ max_entries = 5
     #[test]
     fn hash_stored_on_history_entry() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("flavor_history", "bergamot", None, None).unwrap();
+        let result = store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
@@ -5006,7 +5090,11 @@ max_entries = 5
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         store
-            .set_entry_memory("tags", &IdRef::Numeric(result.id), Some("kn-set1".to_string()))
+            .set_entry_memory(
+                "tags",
+                &IdRef::Numeric(result.id),
+                Some("kn-set1".to_string()),
+            )
             .unwrap();
 
         match store.get("tags").unwrap() {
@@ -5043,8 +5131,7 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         store.push("tags", "alpha", None, None).unwrap();
 
-        let result =
-            store.set_entry_memory("tags", &IdRef::Numeric(999), Some("kn-x".to_string()));
+        let result = store.set_entry_memory("tags", &IdRef::Numeric(999), Some("kn-x".to_string()));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("entry not found"));
     }
@@ -5052,7 +5139,9 @@ max_entries = 5
     #[test]
     fn set_entry_memory_history_by_numeric_id() {
         let (mut store, _dir) = setup_store(test_schema());
-        let result = store.push("flavor_history", "bergamot", None, None).unwrap();
+        let result = store
+            .push("flavor_history", "bergamot", None, None)
+            .unwrap();
 
         store
             .set_entry_memory(
@@ -5185,8 +5274,7 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         store.inc("warmth", 1).unwrap();
 
-        let result =
-            store.set_entry_memory("warmth", &IdRef::Numeric(1), Some("kn-x".to_string()));
+        let result = store.set_entry_memory("warmth", &IdRef::Numeric(1), Some("kn-x".to_string()));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }


### PR DESCRIPTION
Closes #252
Closes #278

## Summary

Adds per-entry memory links to history/list entries. `push` can link at creation (`--memory kn-xxx`), `set` can link existing entries (`--id 17 --memory kn-xxx`). Per-entry memory wins over key-level fallback. Also refactors `last()` and `random()` from `Vec<String>` to `Vec<SearchHit>` for structured access.

## Key changes

- `memory: Option<String>` on `HistoryEntry`, `ListEntry`, `SearchHit`
- `push --memory kn-xxx` links at creation
- `set --id 17 --memory kn-xxx` links existing entry (by numeric ID or hash)
- `set_entry_memory()` method with `IdRef` support
- `last()` and `random()` refactored to return `Vec<SearchHit>`
- Per-entry resolution in all `--memory` display paths (entry wins, key fallback)

## Files changed

- `src/kv.rs` -- core engine: entry structs, push/set/last/random, new method
- `src/cli.rs` -- CLI arg wiring for `--memory` on push/set
- `src/handlers/kv.rs` -- handler integration for per-entry memory display

## Testing

- 15 new tests added
- 849 total passing
- Backward compat via `serde(default)`