### PR TITLE
kv: push --create auto-adds key to schema (#253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ mx kv inc builds
 mx kv push decisions "chose Typst for docs"    # prints: kv-A3fB (1)
 mx kv last decisions --count 5
 
+# Auto-create a key in the schema and push in one step
+mx kv push puns "the joke" --create history
+mx kv push ideas "wild thought" --create list --max-entries 500
+
 # Structured data on entries
 mx kv push projects "palmtop DSI fix" \
   --data '{"tags":["palmtop","i915"],"status":"active"}'

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -609,6 +609,17 @@ files written before these fields existed are back-filled on first load
 (hashes are generated, data and memory default to `None`) and saved
 automatically.
 
+=== Schema mutation
+
+The `KvStore` struct holds a `schema_path` field alongside the existing
+`data_path`. The `add_key_to_schema()` method validates the key name
+(alphanumeric, underscores, hyphens; max 128 chars; no dots), appends a
+`[keys.<name>]` block to the TOML file without reformatting existing
+content, and re-parses the file to update the in-memory `Schema`. This is
+exposed through `push --create <type>` at the CLI layer, where the handler
+calls `add_key_to_schema` before the normal push path. If the key already
+exists, the method is a no-op.
+
 === Per-agent keying
 
 The active agent is determined by the `MX_CURRENT_AGENT` environment variable.

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -141,6 +141,10 @@ mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
 mx kv get decisions --id kv-A3fB              # look up by hash ID
 
+# Auto-create a key in the schema and push in one step
+mx kv push puns "the joke" --create history
+mx kv push ideas "wild thought" --create list --max-entries 500
+
 # Link entries to the memory graph
 mx kv push decisions "adopted memory links" --memory kn-abc123
 mx kv set decisions --id 17 --memory kn-abc123

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -73,6 +73,7 @@ mx kv get session.goal
 mx kv push decisions "chose Typst over markdown"  # prints: kv-A3fB (1)
 mx kv get shipped --id kv-A3fB
 mx kv get shipped --id 35-64
+mx kv push puns "the joke" --create history        # auto-adds key to schema
 mx kv push projects "palmtop DSI fix" \
   --data '{"tags":["palmtop","i915"],"status":"active"}'
 mx kv search projects --where status=active

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -86,6 +86,14 @@ Schema fields:
 / `max_entries`: Optional. Maximum entries for history and list types. Oldest entries are dropped when exceeded. Omit to allow unbounded growth.
 / `fields`: Optional. List of valid field names for state types. Writes to unlisted fields are rejected.
 
+=== Auto-creating keys
+
+Keys can be added to the schema on the fly with `mx kv push --create`.
+When a key does not exist in the schema, `--create history` or
+`--create list` appends a new `[keys.<name>]` block to the TOML file
+and reloads the in-memory schema. This avoids manual schema editing for
+simple cases. See #link(<push>)[push] for details and validation rules.
+
 === Agent keying
 
 All KV operations require `MX_CURRENT_AGENT` to be set. Each agent gets its
@@ -234,7 +242,7 @@ entry lookup by ID via `get --id`. Both support structured data on entries
 (`--data` on push) and structured data filtering (`--where` on queries).
 Only lists support `pop`. Only history supports `since` (time-based queries).
 
-=== push
+=== push <push>
 
 #command(
   "mx kv push <key> <value>",
@@ -265,10 +273,27 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   graph. This sets a per-entry memory pointer (a `kn-` ID) that is
   resolved when `--memory` is passed to read commands. See
   #link(<per-entry-memory>)[Per-entry memory links] for the full
-  resolution hierarchy.],
+  resolution hierarchy.
+
+  Use `--create` to auto-add the key to the schema if it does not already
+  exist. Pass the type as the value: `--create history` or `--create list`.
+  Only `history` and `list` types are accepted (those are the types that
+  support `push`). If the key already exists in the schema, `--create` is
+  silently ignored -- this makes it safe to use unconditionally in scripts
+  without checking whether the key has been defined yet.
+
+  The optional `--max-entries` flag sets the entry cap for the new key.
+  It requires `--create` and has no effect if the key already exists.
+
+  Key names are validated on creation: alphanumeric characters, underscores,
+  and hyphens only, maximum 128 characters. Dots are rejected because they
+  conflict with TOML key quoting. The new key block is appended to the
+  schema file without reformatting existing content.],
   flags: (
     ([`--data <json>`], [string], [Attach a JSON object to the entry. Must be a valid JSON object (not an array, string, or other type).]),
     ([`--memory <kn-id>`], [string], [Link this entry to a memory knowledge node (e.g. `kn-abc123`). Resolved when `--memory` is passed on read commands.]),
+    ([`--create <type>`], [enum], [Auto-create the key in the schema if missing. Accepted types: `history`, `list`. Silently ignored if the key already exists.]),
+    ([`--max-entries <n>`], [integer], [Maximum entries for the new key (only valid with `--create`). Oldest entries are dropped when exceeded.]),
   ),
   examples: (
     "mx kv push decisions \"chose Typst for docs\"",
@@ -276,6 +301,8 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv push projects \"palmtop DSI fix\" --data '{\"tags\":[\"palmtop\",\"i915\"],\"status\":\"active\"}'",
     "mx kv push shipped \"v0.1.156\" --data '{\"pr\":305,\"scope\":\"kv\"}'",
     "mx kv push decisions \"adopted per-entry memory links\" --memory kn-abc123",
+    "mx kv push puns \"the joke\" --create history",
+    "mx kv push ideas \"wild thought\" --create list --max-entries 500",
   ),
 )
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1630,6 +1630,15 @@ pub enum ContentTypesCommands {
     },
 }
 
+/// Key type for `kv push --create`.
+#[derive(Clone, Debug, ValueEnum)]
+pub enum CreateType {
+    /// History (append-only, timestamped)
+    History,
+    /// List (push/pop, ordered)
+    List,
+}
+
 /// Output format for `kv dump`.
 #[derive(Clone, Debug, ValueEnum)]
 pub enum DumpFormat {
@@ -1744,7 +1753,7 @@ pub enum KvCommands {
 
         /// Auto-create key in schema if missing (type: history or list)
         #[arg(long, value_name = "TYPE")]
-        create: Option<String>,
+        create: Option<CreateType>,
 
         /// Maximum entries for the new key (only with --create)
         #[arg(long, requires = "create")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1741,6 +1741,14 @@ pub enum KvCommands {
         /// Link a memory entry (kn- ID) to this entry
         #[arg(long)]
         memory: Option<String>,
+
+        /// Auto-create key in schema if missing (type: history or list)
+        #[arg(long, value_name = "TYPE")]
+        create: Option<String>,
+
+        /// Maximum entries for the new key (only with --create)
+        #[arg(long, requires = "create")]
+        max_entries: Option<usize>,
     },
 
     /// Pop the last value from a list

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -396,7 +396,23 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             value,
             data,
             memory,
+            create,
+            max_entries,
         } => {
+            // Handle --create: auto-add key to schema if missing
+            if let Some(ref type_str) = create {
+                if type_str != "history" && type_str != "list" {
+                    eprintln!("Error: --create type must be 'history' or 'list'");
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
+                if store.schema.keys.get(&key).is_none() {
+                    if let Err(e) = store.add_key_to_schema(&key, type_str, max_entries) {
+                        return handle_kv_err(e);
+                    }
+                }
+                // If key already exists, silently ignore --create
+            }
+
             // Parse --data as JSON object if provided
             let parsed_data = match data {
                 Some(ref json_str) => {

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -405,10 +405,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                     eprintln!("Error: --create type must be 'history' or 'list'");
                     return Ok(kv::EXIT_INVALID_INPUT);
                 }
-                if store.schema.keys.get(&key).is_none() {
-                    if let Err(e) = store.add_key_to_schema(&key, type_str, max_entries) {
-                        return handle_kv_err(e);
-                    }
+                if !store.schema.keys.contains_key(&key)
+                    && let Err(e) = store.add_key_to_schema(&key, type_str, max_entries)
+                {
+                    return handle_kv_err(e);
                 }
                 // If key already exists, silently ignore --create
             }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 
-use crate::cli::{DumpFormat, KvCommands};
+use crate::cli::{CreateType, DumpFormat, KvCommands};
 use crate::kv::{self, IdRef, KvError, KvStore, resolve_time_range};
 
 /// Map a KvError to the appropriate exit code.
@@ -400,11 +400,11 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             max_entries,
         } => {
             // Handle --create: auto-add key to schema if missing
-            if let Some(ref type_str) = create {
-                if type_str != "history" && type_str != "list" {
-                    eprintln!("Error: --create type must be 'history' or 'list'");
-                    return Ok(kv::EXIT_INVALID_INPUT);
-                }
+            if let Some(ref create_type) = create {
+                let type_str = match create_type {
+                    CreateType::History => "history",
+                    CreateType::List => "list",
+                };
                 if !store.schema.keys.contains_key(&key)
                     && let Err(e) = store.add_key_to_schema(&key, type_str, max_entries)
                 {

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -5626,9 +5626,7 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         let max_name = "a".repeat(128);
 
-        store
-            .add_key_to_schema(&max_name, "history", None)
-            .unwrap();
+        store.add_key_to_schema(&max_name, "history", None).unwrap();
         assert!(store.schema.keys.contains_key(max_name.as_str()));
     }
 
@@ -5648,9 +5646,7 @@ max_entries = 5
         assert!(store.schema.keys.contains_key("existing"));
 
         // Add a new key -- should not corrupt the file
-        store
-            .add_key_to_schema("newkey", "list", None)
-            .unwrap();
+        store.add_key_to_schema("newkey", "list", None).unwrap();
 
         // Both keys should be present after re-parse
         assert!(store.schema.keys.contains_key("existing"));

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -5586,9 +5586,7 @@ max_entries = 5
         store.save().unwrap();
 
         // Now add a new key to schema
-        store
-            .add_key_to_schema("jokes", "list", None)
-            .unwrap();
+        store.add_key_to_schema("jokes", "list", None).unwrap();
 
         // Original keys should all still be present and correct
         assert_eq!(store.schema.keys["warmth"].value_type, ValueType::Counter);

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -467,6 +467,7 @@ pub struct KvStore {
     pub schema: Schema,
     pub data: DataFile,
     pub data_path: PathBuf,
+    pub schema_path: PathBuf,
 }
 
 impl KvStore {
@@ -515,6 +516,7 @@ impl KvStore {
             schema,
             data,
             data_path: data_path.to_path_buf(),
+            schema_path: schema_path.to_path_buf(),
         };
 
         if needs_save {
@@ -644,6 +646,107 @@ impl KvStore {
             });
         }
         Ok(def)
+    }
+
+    /// Validate a key name for schema insertion.
+    ///
+    /// Accepts alphanumeric characters, underscores, and hyphens.
+    /// Rejects names containing dots (TOML quoting issues), empty names,
+    /// and names with other special characters.
+    fn validate_key_name(key: &str) -> Result<(), KvError> {
+        if key.is_empty() {
+            return Err(KvError::Other(anyhow::anyhow!("key name cannot be empty")));
+        }
+        if key.contains('.') {
+            return Err(KvError::Other(anyhow::anyhow!(
+                "key name '{}' cannot contain dots -- they require TOML quoting and create confusion",
+                key
+            )));
+        }
+        if !key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            return Err(KvError::Other(anyhow::anyhow!(
+                "key name '{}' contains invalid characters -- only alphanumeric, underscores, and hyphens are allowed",
+                key
+            )));
+        }
+        Ok(())
+    }
+
+    /// Add a new key to the schema file and reload the in-memory schema.
+    ///
+    /// Appends a `[keys.<name>]` block to the TOML file (preserving existing
+    /// content exactly) and re-parses the file to update `self.schema`.
+    ///
+    /// Only `history` and `list` types are accepted -- those are the types
+    /// that support `push`.
+    pub fn add_key_to_schema(
+        &mut self,
+        key: &str,
+        value_type: &str,
+        max_entries: Option<usize>,
+    ) -> Result<(), KvError> {
+        // Validate type
+        if value_type != "history" && value_type != "list" {
+            return Err(KvError::Other(anyhow::anyhow!(
+                "--create type must be 'history' or 'list', got '{}'",
+                value_type
+            )));
+        }
+
+        // Validate key name
+        Self::validate_key_name(key)?;
+
+        // Double-check: don't overwrite existing keys
+        if self.schema.keys.contains_key(key) {
+            return Ok(());
+        }
+
+        // Build the TOML block to append
+        let mut block = format!("\n[keys.{}]\ntype = \"{}\"\n", key, value_type);
+        if let Some(max) = max_entries {
+            block.push_str(&format!("max_entries = {}\n", max));
+        }
+
+        // Append to the schema file
+        let mut f = fs::OpenOptions::new()
+            .append(true)
+            .open(&self.schema_path)
+            .map_err(|e| {
+                KvError::Other(anyhow::anyhow!(
+                    "failed to open schema file for append: {}: {}",
+                    self.schema_path.display(),
+                    e
+                ))
+            })?;
+        f.write_all(block.as_bytes()).map_err(|e| {
+            KvError::Other(anyhow::anyhow!(
+                "failed to write to schema file: {}: {}",
+                self.schema_path.display(),
+                e
+            ))
+        })?;
+
+        // Re-read and re-parse the schema to update in-memory state
+        let schema_str = fs::read_to_string(&self.schema_path).map_err(|e| {
+            KvError::Other(anyhow::anyhow!(
+                "failed to re-read schema file after append: {}: {}",
+                self.schema_path.display(),
+                e
+            ))
+        })?;
+        let schema: Schema = toml::from_str(&schema_str).map_err(|e| {
+            KvError::Other(anyhow::anyhow!(
+                "failed to re-parse schema file after append: {}: {}",
+                self.schema_path.display(),
+                e
+            ))
+        })?;
+        self.schema = schema;
+
+        Ok(())
     }
 
     /// Get the default DataValue for a key based on its schema definition.
@@ -5350,5 +5453,167 @@ max_entries = 5
             }
             _ => panic!("Expected list"),
         }
+    }
+
+    // -- add_key_to_schema --
+
+    #[test]
+    fn add_key_to_schema_history() {
+        let (mut store, _dir) = setup_store(test_schema());
+        assert!(store.schema.keys.get("puns").is_none());
+
+        store.add_key_to_schema("puns", "history", None).unwrap();
+
+        // Key should now exist in the in-memory schema
+        let def = store.schema.keys.get("puns").unwrap();
+        assert_eq!(def.value_type, ValueType::History);
+        assert_eq!(def.max_entries, None);
+
+        // Push should now work on the new key
+        store.push("puns", "the joke", None, None).unwrap();
+        let last = store.last("puns", 1, None, &[]).unwrap();
+        assert_eq!(last.len(), 1);
+        assert_eq!(last[0].value, "the joke");
+    }
+
+    #[test]
+    fn add_key_to_schema_list() {
+        let (mut store, _dir) = setup_store(test_schema());
+        assert!(store.schema.keys.get("items").is_none());
+
+        store.add_key_to_schema("items", "list", None).unwrap();
+
+        let def = store.schema.keys.get("items").unwrap();
+        assert_eq!(def.value_type, ValueType::List);
+
+        store.push("items", "apple", None, None).unwrap();
+        let last = store.last("items", 1, None, &[]).unwrap();
+        assert_eq!(last[0].value, "apple");
+    }
+
+    #[test]
+    fn add_key_to_schema_with_max_entries() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        store
+            .add_key_to_schema("puns", "history", Some(500))
+            .unwrap();
+
+        let def = store.schema.keys.get("puns").unwrap();
+        assert_eq!(def.value_type, ValueType::History);
+        assert_eq!(def.max_entries, Some(500));
+    }
+
+    #[test]
+    fn add_key_to_schema_existing_key_is_noop() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        // "tags" already exists as a list in the test schema
+        assert!(store.schema.keys.get("tags").is_some());
+        let original_type = store.schema.keys["tags"].value_type;
+
+        // Should succeed silently without changing anything
+        store.add_key_to_schema("tags", "history", None).unwrap();
+
+        // Type should be unchanged
+        assert_eq!(store.schema.keys["tags"].value_type, original_type);
+    }
+
+    #[test]
+    fn add_key_to_schema_invalid_type_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let err = store
+            .add_key_to_schema("stuff", "counter", None)
+            .unwrap_err();
+        assert!(err.to_string().contains("'history' or 'list'"));
+    }
+
+    #[test]
+    fn add_key_to_schema_dotted_name_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let err = store
+            .add_key_to_schema("my.key", "history", None)
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot contain dots"));
+    }
+
+    #[test]
+    fn add_key_to_schema_special_chars_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let err = store
+            .add_key_to_schema("my key!", "history", None)
+            .unwrap_err();
+        assert!(err.to_string().contains("invalid characters"));
+    }
+
+    #[test]
+    fn add_key_to_schema_empty_name_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let err = store.add_key_to_schema("", "history", None).unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn add_key_to_schema_reparsed_correctly() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let original_key_count = store.schema.keys.len();
+
+        store
+            .add_key_to_schema("new_key", "history", Some(50))
+            .unwrap();
+
+        // Should have exactly one more key
+        assert_eq!(store.schema.keys.len(), original_key_count + 1);
+
+        // Reload from disk to verify file was written correctly
+        let store2 = KvStore::load(&store.schema_path, &store.data_path).unwrap();
+        assert_eq!(store2.schema.keys.len(), original_key_count + 1);
+        let def = store2.schema.keys.get("new_key").unwrap();
+        assert_eq!(def.value_type, ValueType::History);
+        assert_eq!(def.max_entries, Some(50));
+    }
+
+    #[test]
+    fn add_key_to_schema_preserves_existing_content() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        // Push some data to an existing key first
+        store.push("tags", "hello", None, None).unwrap();
+        store.save().unwrap();
+
+        // Now add a new key to schema
+        store
+            .add_key_to_schema("jokes", "list", None)
+            .unwrap();
+
+        // Original keys should all still be present and correct
+        assert_eq!(store.schema.keys["warmth"].value_type, ValueType::Counter);
+        assert_eq!(
+            store.schema.keys["flavor_history"].value_type,
+            ValueType::History
+        );
+        assert_eq!(store.schema.keys["tags"].value_type, ValueType::List);
+        assert_eq!(store.schema.keys["tensor"].value_type, ValueType::State);
+        assert_eq!(
+            store.schema.keys["current_mood"].value_type,
+            ValueType::String
+        );
+
+        // New key should be there too
+        assert_eq!(store.schema.keys["jokes"].value_type, ValueType::List);
+    }
+
+    #[test]
+    fn add_key_hyphen_and_underscore_accepted() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        store
+            .add_key_to_schema("my-key_v2", "history", None)
+            .unwrap();
+        assert!(store.schema.keys.get("my-key_v2").is_some());
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -5460,7 +5460,7 @@ max_entries = 5
     #[test]
     fn add_key_to_schema_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        assert!(store.schema.keys.get("puns").is_none());
+        assert!(!store.schema.keys.contains_key("puns"));
 
         store.add_key_to_schema("puns", "history", None).unwrap();
 
@@ -5479,7 +5479,7 @@ max_entries = 5
     #[test]
     fn add_key_to_schema_list() {
         let (mut store, _dir) = setup_store(test_schema());
-        assert!(store.schema.keys.get("items").is_none());
+        assert!(!store.schema.keys.contains_key("items"));
 
         store.add_key_to_schema("items", "list", None).unwrap();
 
@@ -5509,7 +5509,7 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
 
         // "tags" already exists as a list in the test schema
-        assert!(store.schema.keys.get("tags").is_some());
+        assert!(store.schema.keys.contains_key("tags"));
         let original_type = store.schema.keys["tags"].value_type;
 
         // Should succeed silently without changing anything
@@ -5612,6 +5612,6 @@ max_entries = 5
         store
             .add_key_to_schema("my-key_v2", "history", None)
             .unwrap();
-        assert!(store.schema.keys.get("my-key_v2").is_some());
+        assert!(store.schema.keys.contains_key("my-key_v2"));
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -657,6 +657,12 @@ impl KvStore {
         if key.is_empty() {
             return Err(KvError::Other(anyhow::anyhow!("key name cannot be empty")));
         }
+        if key.len() > 128 {
+            return Err(KvError::Other(anyhow::anyhow!(
+                "key name too long ({} chars, max 128)",
+                key.len()
+            )));
+        }
         if key.contains('.') {
             return Err(KvError::Other(anyhow::anyhow!(
                 "key name '{}' cannot contain dots -- they require TOML quoting and create confusion",
@@ -688,14 +694,6 @@ impl KvStore {
         value_type: &str,
         max_entries: Option<usize>,
     ) -> Result<(), KvError> {
-        // Validate type
-        if value_type != "history" && value_type != "list" {
-            return Err(KvError::Other(anyhow::anyhow!(
-                "--create type must be 'history' or 'list', got '{}'",
-                value_type
-            )));
-        }
-
         // Validate key name
         Self::validate_key_name(key)?;
 
@@ -728,6 +726,7 @@ impl KvStore {
                 e
             ))
         })?;
+        drop(f);
 
         // Re-read and re-parse the schema to update in-memory state
         let schema_str = fs::read_to_string(&self.schema_path).map_err(|e| {
@@ -5519,15 +5518,9 @@ max_entries = 5
         assert_eq!(store.schema.keys["tags"].value_type, original_type);
     }
 
-    #[test]
-    fn add_key_to_schema_invalid_type_rejected() {
-        let (mut store, _dir) = setup_store(test_schema());
-
-        let err = store
-            .add_key_to_schema("stuff", "counter", None)
-            .unwrap_err();
-        assert!(err.to_string().contains("'history' or 'list'"));
-    }
+    // Type validation for --create is now enforced by clap's ValueEnum
+    // (CreateType), so there is no add_key_to_schema_invalid_type_rejected
+    // test -- invalid types cannot reach add_key_to_schema.
 
     #[test]
     fn add_key_to_schema_dotted_name_rejected() {
@@ -5613,5 +5606,61 @@ max_entries = 5
             .add_key_to_schema("my-key_v2", "history", None)
             .unwrap();
         assert!(store.schema.keys.contains_key("my-key_v2"));
+    }
+
+    #[test]
+    fn add_key_to_schema_name_too_long_rejected() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let long_name = "a".repeat(129);
+
+        let err = store
+            .add_key_to_schema(&long_name, "history", None)
+            .unwrap_err();
+        assert!(err.to_string().contains("key name too long"));
+        assert!(err.to_string().contains("129 chars"));
+        assert!(err.to_string().contains("max 128"));
+    }
+
+    #[test]
+    fn add_key_to_schema_max_length_accepted() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let max_name = "a".repeat(128);
+
+        store
+            .add_key_to_schema(&max_name, "history", None)
+            .unwrap();
+        assert!(store.schema.keys.contains_key(max_name.as_str()));
+    }
+
+    #[test]
+    fn add_key_to_schema_without_trailing_newline() {
+        // S2: Schema file without trailing newline should still produce valid TOML
+        // after add_key_to_schema appends a new key block.
+        let schema_no_newline = "[keys.existing]\ntype = \"history\"";
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("test.schema.toml");
+        let data_path = dir.path().join("test.data.json");
+
+        // Write schema WITHOUT trailing newline
+        fs::write(&schema_path, schema_no_newline).unwrap();
+
+        let mut store = KvStore::load(&schema_path, &data_path).unwrap();
+        assert!(store.schema.keys.contains_key("existing"));
+
+        // Add a new key -- should not corrupt the file
+        store
+            .add_key_to_schema("newkey", "list", None)
+            .unwrap();
+
+        // Both keys should be present after re-parse
+        assert!(store.schema.keys.contains_key("existing"));
+        assert!(store.schema.keys.contains_key("newkey"));
+        assert_eq!(store.schema.keys["existing"].value_type, ValueType::History);
+        assert_eq!(store.schema.keys["newkey"].value_type, ValueType::List);
+
+        // Verify file on disk is valid TOML by reloading
+        let store2 = KvStore::load(&schema_path, &data_path).unwrap();
+        assert!(store2.schema.keys.contains_key("existing"));
+        assert!(store2.schema.keys.contains_key("newkey"));
     }
 }


### PR DESCRIPTION
Closes #253

## Summary

`mx kv push <key> <value> --create <type>` auto-adds the key to the schema TOML if missing, then pushes. Supports `--max-entries`. Silently ignores `--create` if key already exists. Validates key names (no dots, special chars). Appends to TOML without reformatting.

## Files changed

- `src/cli.rs`
- `src/kv.rs`
- `src/handlers/kv.rs`

## Tests

- 11 new tests, 861 total passing

## Usage

```bash
mx kv push puns "the joke" --create history --max-entries 500
```