### PR TITLE
feat: mx memory sweep-ghosts — ghost anchor repair tool

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1067,6 +1067,23 @@ pub enum MemoryCommands {
         format: String,
     },
 
+    /// Sweep ghost anchor references pointing to deleted nodes
+    ///
+    /// Scans all entries with non-empty anchor lists. For each anchor ID,
+    /// checks whether the target entry still exists. Ghost references (pointing
+    /// to deleted or missing entries) are removed from the source entry.
+    ///
+    /// Always run with --dry-run first to preview what will be changed.
+    SweepGhosts {
+        /// Report what would be cleaned without modifying anything
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Output as JSON (useful for programmatic processing)
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Reinforce a knowledge entry (increment resonance, update last_activated, increment activation_count)
     Reinforce {
         /// Entry ID to reinforce

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -2343,6 +2343,68 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 bail!("Entry '{}' not found", normalized_id);
             }
         }
+
+        MemoryCommands::SweepGhosts { dry_run, json } => {
+            let db = store::create_store_with_verbose(&config.db_path, verbose)?;
+
+            if dry_run {
+                eprintln!("sweep-ghosts: DRY RUN — no changes will be made");
+            }
+
+            let result = db.sweep_ghost_anchors(dry_run)?;
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            } else {
+                // Human-readable report
+                println!("Ghost anchor sweep{}", if dry_run { " (dry run)" } else { "" });
+                println!("  Entries scanned (with anchors): {}", result.entries_scanned);
+                println!("  Ghost references found:         {}", result.ghosts_found);
+                if dry_run {
+                    println!("  Ghost references to remove:     {} (dry run, no changes made)", result.ghosts_found);
+                } else {
+                    println!("  Ghost references removed:       {}", result.ghosts_removed);
+                }
+                println!("  Entries affected:               {}", result.affected_entries.len());
+
+                if !result.affected_entries.is_empty() {
+                    println!();
+                    println!("Affected entries:");
+                    for entry in &result.affected_entries {
+                        let ghost_count = entry.ghost_anchors.len();
+                        println!(
+                            "  {} ({}) — {} ghost anchor{}",
+                            entry.id,
+                            entry.title,
+                            ghost_count,
+                            if ghost_count == 1 { "" } else { "s" }
+                        );
+                        // Show individual ghost IDs — useful for verifying before real run
+                        if verbose {
+                            for ghost in &entry.ghost_anchors {
+                                println!("      ghost: {}", ghost);
+                            }
+                        }
+                    }
+                }
+
+                if dry_run && result.ghosts_found > 0 {
+                    println!();
+                    println!(
+                        "To apply: hearth mx memory sweep-ghosts (without --dry-run)"
+                    );
+                } else if !dry_run && result.ghosts_removed > 0 {
+                    println!();
+                    println!("Done. {} ghost reference{} removed.",
+                        result.ghosts_removed,
+                        if result.ghosts_removed == 1 { "" } else { "s" }
+                    );
+                } else if result.ghosts_found == 0 {
+                    println!();
+                    println!("Graph is clean. No ghost anchors found.");
+                }
+            }
+        }
     }
 
     Ok(())

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -2350,7 +2350,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             if dry_run {
                 eprintln!("sweep-ghosts: DRY RUN — no changes will be made");
             } else {
-                eprintln!("sweep-ghosts: WARNING — this will modify memory data. Use --dry-run to preview first.");
+                eprintln!(
+                    "sweep-ghosts: WARNING — this will modify memory data. Use --dry-run to preview first."
+                );
             }
 
             let result = db.sweep_ghost_anchors(dry_run)?;

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -2357,15 +2357,30 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
                 // Human-readable report
-                println!("Ghost anchor sweep{}", if dry_run { " (dry run)" } else { "" });
-                println!("  Entries scanned (with anchors): {}", result.entries_scanned);
+                println!(
+                    "Ghost anchor sweep{}",
+                    if dry_run { " (dry run)" } else { "" }
+                );
+                println!(
+                    "  Entries scanned (with anchors): {}",
+                    result.entries_scanned
+                );
                 println!("  Ghost references found:         {}", result.ghosts_found);
                 if dry_run {
-                    println!("  Ghost references to remove:     {} (dry run, no changes made)", result.ghosts_found);
+                    println!(
+                        "  Ghost references to remove:     {} (dry run, no changes made)",
+                        result.ghosts_found
+                    );
                 } else {
-                    println!("  Ghost references removed:       {}", result.ghosts_removed);
+                    println!(
+                        "  Ghost references removed:       {}",
+                        result.ghosts_removed
+                    );
                 }
-                println!("  Entries affected:               {}", result.affected_entries.len());
+                println!(
+                    "  Entries affected:               {}",
+                    result.affected_entries.len()
+                );
 
                 if !result.affected_entries.is_empty() {
                     println!();
@@ -2390,12 +2405,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 if dry_run && result.ghosts_found > 0 {
                     println!();
-                    println!(
-                        "To apply: hearth mx memory sweep-ghosts (without --dry-run)"
-                    );
+                    println!("To apply: hearth mx memory sweep-ghosts (without --dry-run)");
                 } else if !dry_run && result.ghosts_removed > 0 {
                     println!();
-                    println!("Done. {} ghost reference{} removed.",
+                    println!(
+                        "Done. {} ghost reference{} removed.",
                         result.ghosts_removed,
                         if result.ghosts_removed == 1 { "" } else { "s" }
                     );

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -2349,6 +2349,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             if dry_run {
                 eprintln!("sweep-ghosts: DRY RUN — no changes will be made");
+            } else {
+                eprintln!("sweep-ghosts: WARNING — this will modify memory data. Use --dry-run to preview first.");
             }
 
             let result = db.sweep_ghost_anchors(dry_run)?;

--- a/src/store.rs
+++ b/src/store.rs
@@ -426,11 +426,51 @@ pub trait KnowledgeStore {
     fn delete_wake_session(&self, session_id: &str) -> Result<()>;
 
     // =========================================================================
+    // GHOST EDGE REPAIR
+    // =========================================================================
+
+    /// Sweep anchor fields for references to deleted/missing entries.
+    ///
+    /// For each entry with non-empty anchors, checks each anchor ID for
+    /// existence. Ghost references (pointing to entries that no longer exist)
+    /// are either removed (dry_run=false) or reported without modification
+    /// (dry_run=true).
+    ///
+    /// Returns a summary of what was (or would be) cleaned.
+    fn sweep_ghost_anchors(&self, dry_run: bool) -> Result<GhostSweepResult>;
+
+    // =========================================================================
     // MIGRATION & INTROSPECTION
     // =========================================================================
 
     /// List tables (for migration status)
     fn list_tables(&self) -> Result<Vec<String>>;
+}
+
+/// Summary result from a ghost anchor sweep.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GhostSweepResult {
+    /// Total entries scanned (those with at least one anchor)
+    pub entries_scanned: usize,
+    /// Total ghost references found
+    pub ghosts_found: usize,
+    /// Total ghost references removed (0 when dry_run=true)
+    pub ghosts_removed: usize,
+    /// Entries that had at least one ghost anchor (id + count of ghosts)
+    pub affected_entries: Vec<GhostEntry>,
+    /// Whether this was a dry run
+    pub dry_run: bool,
+}
+
+/// One entry affected by the ghost sweep.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GhostEntry {
+    /// Entry ID (kn-prefixed)
+    pub id: String,
+    /// Entry title for context
+    pub title: String,
+    /// Ghost anchor IDs found in this entry
+    pub ghost_anchors: Vec<String>,
 }
 
 /// Factory function to create the SurrealDB store

--- a/src/store.rs
+++ b/src/store.rs
@@ -454,7 +454,10 @@ pub struct GhostSweepResult {
     pub entries_scanned: usize,
     /// Total ghost references found
     pub ghosts_found: usize,
-    /// Total ghost references removed (0 when dry_run=true)
+    /// Total ghost references removal was attempted for (0 when dry_run=true).
+    /// This counts attempted removals, not confirmed removals — if a database
+    /// update fails for a particular entry, the ghost count for that entry is
+    /// still included here but the anchors may not have been removed.
     pub ghosts_removed: usize,
     /// Entries that had at least one ghost anchor (id + count of ghosts)
     pub affected_entries: Vec<GhostEntry>,

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1575,10 +1575,7 @@ impl SurrealDatabase {
     ///   5. If dry_run=false, UPDATE each affected entry to remove ghosts.
     ///
     /// Returns a `GhostSweepResult` with full accounting.
-    pub fn sweep_ghost_anchors(
-        &self,
-        dry_run: bool,
-    ) -> Result<crate::store::GhostSweepResult> {
+    pub fn sweep_ghost_anchors(&self, dry_run: bool) -> Result<crate::store::GhostSweepResult> {
         Self::runtime().block_on(self.sweep_ghost_anchors_async(dry_run))
     }
 
@@ -1692,12 +1689,10 @@ impl SurrealDatabase {
             .collect();
 
         let mut exist_response = with_db!(self, db, {
-            db.query(
-                "SELECT meta::id(id) AS id FROM knowledge WHERE id IN $ids",
-            )
-            .bind(("ids", things))
-            .await
-            .context("Failed to check anchor target existence")
+            db.query("SELECT meta::id(id) AS id FROM knowledge WHERE id IN $ids")
+                .bind(("ids", things))
+                .await
+                .context("Failed to check anchor target existence")
         })?;
 
         let exist_raw: Vec<serde_json::Value> = exist_response

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1734,64 +1734,58 @@ impl SurrealDatabase {
 
         // ----------------------------------------------------------------
         // Phase 5: Remove ghost anchors (unless dry run).
-        // For each affected entry, compute the live anchor list and UPDATE.
+        //
+        // Instead of snapshotting the full anchor list and overwriting it,
+        // we subtract each ghost individually using array::complement inside
+        // the UPDATE. This eliminates the TOCTOU window: if another process
+        // adds a new anchor between Phases 1–4 and this write, that anchor
+        // is never in $ghost_id and therefore survives untouched.
+        //
+        // Per ghost anchor, we issue:
+        //   UPDATE knowledge
+        //   SET anchors = array::complement(anchors, [$ghost_id]),
+        //       updated_at = time::now()
+        //   WHERE meta::id(id) = $entry_id
+        //
+        // array::complement(a, b) returns every element of `a` not present
+        // in `b`, so wrapping the single ghost ID in an array removes exactly
+        // that value without touching anything else in the live array.
         // ----------------------------------------------------------------
         let mut ghosts_removed = 0usize;
 
         if !dry_run && !affected_entries.is_empty() {
-            // Build a lookup from id -> full anchor list for efficient access
-            let anchor_map: std::collections::HashMap<&str, &Vec<String>> = anchored_entries
-                .iter()
-                .map(|e| (e.id.as_str(), &e.anchors))
-                .collect();
-
             for ghost_entry in &affected_entries {
                 let bare_id = ghost_entry
                     .id
                     .strip_prefix("kn-")
                     .unwrap_or(&ghost_entry.id);
 
-                // Build the cleaned anchor list: keep only live anchors.
-                let original = match anchor_map.get(bare_id) {
-                    Some(a) => *a,
-                    None => continue,
-                };
+                for ghost_id in &ghost_entry.ghost_anchors {
+                    let mut update_response = with_db!(self, db, {
+                        db.query(
+                            "UPDATE knowledge
+                             SET anchors = array::complement(anchors, [$ghost_id]),
+                                 updated_at = time::now()
+                             WHERE meta::id(id) = $entry_id",
+                        )
+                        .bind(("entry_id", bare_id.to_string()))
+                        .bind(("ghost_id", ghost_id.clone()))
+                        .await
+                        .context("Failed to remove ghost anchor during sweep")
+                    })?;
 
-                let ghost_set: std::collections::HashSet<&str> = ghost_entry
-                    .ghost_anchors
-                    .iter()
-                    .map(|s| s.as_str())
-                    .collect();
+                    let errors = update_response.take_errors();
+                    if !errors.is_empty() {
+                        // Non-fatal: log the failure and continue sweeping.
+                        eprintln!(
+                            "sweep-ghosts: failed to remove anchor {} from {} — {:?}",
+                            ghost_id, ghost_entry.id, errors
+                        );
+                        continue;
+                    }
 
-                let live_anchors: Vec<String> = original
-                    .iter()
-                    .filter(|a| !ghost_set.contains(a.as_str()))
-                    .cloned()
-                    .collect();
-
-                // UPDATE the entry with the cleaned anchor list.
-                let mut update_response = with_db!(self, db, {
-                    db.query(
-                        "UPDATE knowledge SET anchors = $anchors, updated_at = time::now()
-                         WHERE meta::id(id) = $id",
-                    )
-                    .bind(("id", bare_id.to_string()))
-                    .bind(("anchors", live_anchors))
-                    .await
-                    .context("Failed to update anchors during ghost sweep")
-                })?;
-
-                let errors = update_response.take_errors();
-                if !errors.is_empty() {
-                    // Non-fatal: log the failure and continue sweeping.
-                    eprintln!(
-                        "sweep-ghosts: failed to update {} — {:?}",
-                        ghost_entry.id, errors
-                    );
-                    continue;
+                    ghosts_removed += 1;
                 }
-
-                ghosts_removed += ghost_entry.ghost_anchors.len();
             }
         }
 

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1558,4 +1558,254 @@ impl SurrealDatabase {
 
         Ok(())
     }
+
+    // =========================================================================
+    // GHOST ANCHOR SWEEP
+    // =========================================================================
+
+    /// Sweep anchor fields for references to deleted/missing entries.
+    ///
+    /// Strategy:
+    ///   1. Fetch all entries that have at least one anchor (no visibility
+    ///      filter — soren-vault has full access and we must repair ALL entries).
+    ///   2. Collect every unique anchor ID referenced across the graph.
+    ///   3. Batch-check which of those IDs actually exist in the knowledge table.
+    ///   4. For each entry, compute the set of ghost anchors (referenced but
+    ///      missing from the existence set).
+    ///   5. If dry_run=false, UPDATE each affected entry to remove ghosts.
+    ///
+    /// Returns a `GhostSweepResult` with full accounting.
+    pub fn sweep_ghost_anchors(
+        &self,
+        dry_run: bool,
+    ) -> Result<crate::store::GhostSweepResult> {
+        Self::runtime().block_on(self.sweep_ghost_anchors_async(dry_run))
+    }
+
+    async fn sweep_ghost_anchors_async(
+        &self,
+        dry_run: bool,
+    ) -> Result<crate::store::GhostSweepResult> {
+        // ----------------------------------------------------------------
+        // Phase 1: Fetch all entries with non-empty anchors.
+        // No visibility filter — this is a maintenance operation running as
+        // soren-vault. We need to repair all entries regardless of visibility.
+        // ----------------------------------------------------------------
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(id) AS id, title, anchors
+                 FROM knowledge
+                 WHERE array::len(anchors) > 0
+                 ORDER BY id",
+            )
+            .await
+            .context("Failed to query anchored entries for ghost sweep")
+        })?;
+
+        #[derive(serde::Deserialize)]
+        struct AnchoredRecord {
+            id: String,
+            title: String,
+            #[serde(default)]
+            anchors: Vec<serde_json::Value>,
+        }
+
+        let raw: Vec<serde_json::Value> = response
+            .take(0)
+            .context("Failed to parse anchored entries")?;
+
+        // Parse records, normalizing anchors to plain strings.
+        // Anchors are stored as plain strings in SurrealDB, but may come back
+        // as Thing objects ({ tb: "knowledge", id: "..." }) depending on how
+        // they were originally inserted. Handle both forms.
+        struct ParsedEntry {
+            id: String,
+            title: String,
+            anchors: Vec<String>,
+        }
+
+        let mut anchored_entries: Vec<ParsedEntry> = Vec::new();
+        for obj in raw {
+            let id = obj["id"].as_str().unwrap_or("").to_string();
+            let title = obj["title"].as_str().unwrap_or("").to_string();
+            if id.is_empty() {
+                continue;
+            }
+
+            let anchors_raw = obj["anchors"].as_array().cloned().unwrap_or_default();
+            let anchors: Vec<String> = anchors_raw
+                .into_iter()
+                .filter_map(|v| {
+                    // Plain string form: "kn-abc123" or "abc123"
+                    if let Some(s) = v.as_str() {
+                        return Some(s.to_string());
+                    }
+                    // Object form from Thing deserialization
+                    if let Some(obj) = v.as_object() {
+                        if let Some(id_val) = obj.get("id") {
+                            return id_val.as_str().map(|s| s.to_string());
+                        }
+                    }
+                    None
+                })
+                .collect();
+
+            if !anchors.is_empty() {
+                anchored_entries.push(ParsedEntry { id, title, anchors });
+            }
+        }
+
+        let entries_scanned = anchored_entries.len();
+
+        if entries_scanned == 0 {
+            return Ok(crate::store::GhostSweepResult {
+                entries_scanned: 0,
+                ghosts_found: 0,
+                ghosts_removed: 0,
+                affected_entries: vec![],
+                dry_run,
+            });
+        }
+
+        // ----------------------------------------------------------------
+        // Phase 2: Collect all unique anchor IDs referenced anywhere.
+        // ----------------------------------------------------------------
+        let mut all_referenced: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for entry in &anchored_entries {
+            for anchor in &entry.anchors {
+                // Normalize: strip "kn-" prefix for the existence check since
+                // the knowledge table's meta::id returns the bare suffix.
+                let bare = anchor.strip_prefix("kn-").unwrap_or(anchor).to_string();
+                all_referenced.insert(bare);
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Phase 3: Batch-check existence.
+        // Build Things for all referenced IDs and query which ones exist.
+        // ----------------------------------------------------------------
+        let referenced_vec: Vec<String> = all_referenced.into_iter().collect();
+        let things: Vec<Thing> = referenced_vec
+            .iter()
+            .map(|id| Thing::from(("knowledge", id.as_str())))
+            .collect();
+
+        let mut exist_response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(id) AS id FROM knowledge WHERE id IN $ids",
+            )
+            .bind(("ids", things))
+            .await
+            .context("Failed to check anchor target existence")
+        })?;
+
+        let exist_raw: Vec<serde_json::Value> = exist_response
+            .take(0)
+            .context("Failed to parse existence results")?;
+
+        // Build the live-ID set (bare IDs without "kn-" prefix).
+        let live_ids: std::collections::HashSet<String> = exist_raw
+            .into_iter()
+            .filter_map(|v| v["id"].as_str().map(|s| s.to_string()))
+            .collect();
+
+        // ----------------------------------------------------------------
+        // Phase 4: Find ghost anchors per entry.
+        // ----------------------------------------------------------------
+        let mut affected_entries: Vec<crate::store::GhostEntry> = Vec::new();
+        let mut total_ghosts = 0usize;
+
+        for entry in &anchored_entries {
+            let ghost_anchors: Vec<String> = entry
+                .anchors
+                .iter()
+                .filter(|anchor| {
+                    let bare = anchor.strip_prefix("kn-").unwrap_or(anchor);
+                    !live_ids.contains(bare)
+                })
+                .cloned()
+                .collect();
+
+            if !ghost_anchors.is_empty() {
+                total_ghosts += ghost_anchors.len();
+                affected_entries.push(crate::store::GhostEntry {
+                    id: format!("kn-{}", entry.id),
+                    title: entry.title.clone(),
+                    ghost_anchors,
+                });
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Phase 5: Remove ghost anchors (unless dry run).
+        // For each affected entry, compute the live anchor list and UPDATE.
+        // ----------------------------------------------------------------
+        let mut ghosts_removed = 0usize;
+
+        if !dry_run && !affected_entries.is_empty() {
+            // Build a lookup from id -> full anchor list for efficient access
+            let anchor_map: std::collections::HashMap<&str, &Vec<String>> = anchored_entries
+                .iter()
+                .map(|e| (e.id.as_str(), &e.anchors))
+                .collect();
+
+            for ghost_entry in &affected_entries {
+                let bare_id = ghost_entry
+                    .id
+                    .strip_prefix("kn-")
+                    .unwrap_or(&ghost_entry.id);
+
+                // Build the cleaned anchor list: keep only live anchors.
+                let original = match anchor_map.get(bare_id) {
+                    Some(a) => *a,
+                    None => continue,
+                };
+
+                let ghost_set: std::collections::HashSet<&str> = ghost_entry
+                    .ghost_anchors
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect();
+
+                let live_anchors: Vec<String> = original
+                    .iter()
+                    .filter(|a| !ghost_set.contains(a.as_str()))
+                    .cloned()
+                    .collect();
+
+                // UPDATE the entry with the cleaned anchor list.
+                let mut update_response = with_db!(self, db, {
+                    db.query(
+                        "UPDATE knowledge SET anchors = $anchors, updated_at = time::now()
+                         WHERE meta::id(id) = $id",
+                    )
+                    .bind(("id", bare_id.to_string()))
+                    .bind(("anchors", live_anchors))
+                    .await
+                    .context("Failed to update anchors during ghost sweep")
+                })?;
+
+                let errors = update_response.take_errors();
+                if !errors.is_empty() {
+                    // Non-fatal: log the failure and continue sweeping.
+                    eprintln!(
+                        "sweep-ghosts: failed to update {} — {:?}",
+                        ghost_entry.id, errors
+                    );
+                    continue;
+                }
+
+                ghosts_removed += ghost_entry.ghost_anchors.len();
+            }
+        }
+
+        Ok(crate::store::GhostSweepResult {
+            entries_scanned,
+            ghosts_found: total_ghosts,
+            ghosts_removed,
+            affected_entries,
+            dry_run,
+        })
+    }
 }

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -189,8 +189,7 @@ impl SurrealDatabase {
 
         // Layer 2: Recent blooms (last N days)
         // Exclude IDs already in core, use remaining quota
-        let core_ids: HashSet<String> =
-            core.iter().map(|e| e.id.clone()).collect();
+        let core_ids: HashSet<String> = core.iter().map(|e| e.id.clone()).collect();
 
         let all_recent = self.query_recent_blooms(ctx, remaining * 2, days).await?;
         let recent: Vec<_> = all_recent
@@ -1661,8 +1660,7 @@ impl SurrealDatabase {
         // ----------------------------------------------------------------
         // Phase 2: Collect all unique anchor IDs referenced anywhere.
         // ----------------------------------------------------------------
-        let mut all_referenced: HashSet<String> =
-            HashSet::new();
+        let mut all_referenced: HashSet<String> = HashSet::new();
         for entry in &anchored_entries {
             for anchor in &entry.anchors {
                 // Normalize: strip "kn-" prefix for the existence check since

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1638,10 +1638,10 @@ impl SurrealDatabase {
                         return Some(s.to_string());
                     }
                     // Object form from Thing deserialization
-                    if let Some(obj) = v.as_object() {
-                        if let Some(id_val) = obj.get("id") {
-                            return id_val.as_str().map(|s| s.to_string());
-                        }
+                    if let Some(obj) = v.as_object()
+                        && let Some(id_val) = obj.get("id")
+                    {
+                        return id_val.as_str().map(|s| s.to_string());
                     }
                     None
                 })

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::{Context, Result};
 use chrono::Utc;
 use surrealdb::sql::Thing;
@@ -187,7 +189,7 @@ impl SurrealDatabase {
 
         // Layer 2: Recent blooms (last N days)
         // Exclude IDs already in core, use remaining quota
-        let core_ids: std::collections::HashSet<String> =
+        let core_ids: HashSet<String> =
             core.iter().map(|e| e.id.clone()).collect();
 
         let all_recent = self.query_recent_blooms(ctx, remaining * 2, days).await?;
@@ -1599,14 +1601,6 @@ impl SurrealDatabase {
             .context("Failed to query anchored entries for ghost sweep")
         })?;
 
-        #[derive(serde::Deserialize)]
-        struct AnchoredRecord {
-            id: String,
-            title: String,
-            #[serde(default)]
-            anchors: Vec<serde_json::Value>,
-        }
-
         let raw: Vec<serde_json::Value> = response
             .take(0)
             .context("Failed to parse anchored entries")?;
@@ -1667,8 +1661,8 @@ impl SurrealDatabase {
         // ----------------------------------------------------------------
         // Phase 2: Collect all unique anchor IDs referenced anywhere.
         // ----------------------------------------------------------------
-        let mut all_referenced: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut all_referenced: HashSet<String> =
+            HashSet::new();
         for entry in &anchored_entries {
             for anchor in &entry.anchors {
                 // Normalize: strip "kn-" prefix for the existence check since
@@ -1700,27 +1694,20 @@ impl SurrealDatabase {
             .context("Failed to parse existence results")?;
 
         // Build the live-ID set (bare IDs without "kn-" prefix).
-        let live_ids: std::collections::HashSet<String> = exist_raw
+        let live_ids: HashSet<String> = exist_raw
             .into_iter()
             .filter_map(|v| v["id"].as_str().map(|s| s.to_string()))
             .collect();
 
         // ----------------------------------------------------------------
         // Phase 4: Find ghost anchors per entry.
+        // Uses the extracted `detect_ghosts` pure function for testability.
         // ----------------------------------------------------------------
         let mut affected_entries: Vec<crate::store::GhostEntry> = Vec::new();
         let mut total_ghosts = 0usize;
 
         for entry in &anchored_entries {
-            let ghost_anchors: Vec<String> = entry
-                .anchors
-                .iter()
-                .filter(|anchor| {
-                    let bare = anchor.strip_prefix("kn-").unwrap_or(anchor);
-                    !live_ids.contains(bare)
-                })
-                .cloned()
-                .collect();
+            let ghost_anchors = detect_ghosts(&entry.anchors, &live_ids);
 
             if !ghost_anchors.is_empty() {
                 total_ghosts += ghost_anchors.len();
@@ -1736,20 +1723,20 @@ impl SurrealDatabase {
         // Phase 5: Remove ghost anchors (unless dry run).
         //
         // Instead of snapshotting the full anchor list and overwriting it,
-        // we subtract each ghost individually using array::complement inside
-        // the UPDATE. This eliminates the TOCTOU window: if another process
-        // adds a new anchor between Phases 1–4 and this write, that anchor
-        // is never in $ghost_id and therefore survives untouched.
+        // we subtract ghosts using array::complement inside the UPDATE.
+        // This eliminates the TOCTOU window: if another process adds a new
+        // anchor between Phases 1-4 and this write, that anchor is never in
+        // $ghost_ids and therefore survives untouched.
         //
-        // Per ghost anchor, we issue:
+        // All ghosts for a single entry are batched into one query:
         //   UPDATE knowledge
-        //   SET anchors = array::complement(anchors, [$ghost_id]),
+        //   SET anchors = array::complement(anchors, $ghost_ids),
         //       updated_at = time::now()
         //   WHERE meta::id(id) = $entry_id
         //
         // array::complement(a, b) returns every element of `a` not present
-        // in `b`, so wrapping the single ghost ID in an array removes exactly
-        // that value without touching anything else in the live array.
+        // in `b`, so passing the full ghost vec removes exactly those values
+        // without touching anything else in the live array.
         // ----------------------------------------------------------------
         let mut ghosts_removed = 0usize;
 
@@ -1760,32 +1747,33 @@ impl SurrealDatabase {
                     .strip_prefix("kn-")
                     .unwrap_or(&ghost_entry.id);
 
-                for ghost_id in &ghost_entry.ghost_anchors {
-                    let mut update_response = with_db!(self, db, {
-                        db.query(
-                            "UPDATE knowledge
-                             SET anchors = array::complement(anchors, [$ghost_id]),
-                                 updated_at = time::now()
-                             WHERE meta::id(id) = $entry_id",
-                        )
-                        .bind(("entry_id", bare_id.to_string()))
-                        .bind(("ghost_id", ghost_id.clone()))
-                        .await
-                        .context("Failed to remove ghost anchor during sweep")
-                    })?;
+                let ghost_ids = ghost_entry.ghost_anchors.clone();
+                let ghost_count = ghost_ids.len();
 
-                    let errors = update_response.take_errors();
-                    if !errors.is_empty() {
-                        // Non-fatal: log the failure and continue sweeping.
-                        eprintln!(
-                            "sweep-ghosts: failed to remove anchor {} from {} — {:?}",
-                            ghost_id, ghost_entry.id, errors
-                        );
-                        continue;
-                    }
+                let mut update_response = with_db!(self, db, {
+                    db.query(
+                        "UPDATE knowledge
+                         SET anchors = array::complement(anchors, $ghost_ids),
+                             updated_at = time::now()
+                         WHERE meta::id(id) = $entry_id",
+                    )
+                    .bind(("entry_id", bare_id.to_string()))
+                    .bind(("ghost_ids", ghost_ids))
+                    .await
+                    .context("Failed to remove ghost anchors during sweep")
+                })?;
 
-                    ghosts_removed += 1;
+                let errors = update_response.take_errors();
+                if !errors.is_empty() {
+                    // Non-fatal: log the failure and continue sweeping.
+                    eprintln!(
+                        "sweep-ghosts: failed to remove {} ghost anchor(s) from {} — {:?}",
+                        ghost_count, ghost_entry.id, errors
+                    );
+                    continue;
                 }
+
+                ghosts_removed += ghost_count;
             }
         }
 
@@ -1797,4 +1785,27 @@ impl SurrealDatabase {
             dry_run,
         })
     }
+}
+
+// =========================================================================
+// GHOST DETECTION — Pure function for testability
+// =========================================================================
+
+/// Identify ghost anchors for a single entry.
+///
+/// An anchor is a "ghost" if its bare ID (with "kn-" prefix stripped) does not
+/// appear in `live_ids`. Returns the list of ghost anchor strings (preserving
+/// their original form, including any "kn-" prefix they may carry).
+///
+/// This is the core detection logic used by `sweep_ghost_anchors_async`, extracted
+/// as a pure function so it can be tested without a database connection.
+pub(crate) fn detect_ghosts(anchors: &[String], live_ids: &HashSet<String>) -> Vec<String> {
+    anchors
+        .iter()
+        .filter(|anchor| {
+            let bare = anchor.strip_prefix("kn-").unwrap_or(anchor);
+            !live_ids.contains(bare)
+        })
+        .cloned()
+        .collect()
 }

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::*;
 use crate::store::KnowledgeStore;
 
@@ -1301,4 +1303,210 @@ fn test_list_all_tags_empty_database() {
 
     let tags = db.list_all_tags(Some("pattern")).unwrap();
     assert!(tags.is_empty());
+}
+
+// =========================================================================
+// GHOST ANCHOR SWEEP TESTS
+// =========================================================================
+
+// ---- Pure function tests (no DB required) ----
+
+#[test]
+fn test_detect_ghosts_finds_missing_anchors() {
+    // Entry references anchors "aaa" and "bbb", but only "aaa" exists.
+    let live_ids: HashSet<String> = ["aaa"].iter().map(|s| s.to_string()).collect();
+    let anchors = vec!["aaa".to_string(), "bbb".to_string()];
+
+    let ghosts = queries::detect_ghosts(&anchors, &live_ids);
+    assert_eq!(ghosts, vec!["bbb"]);
+}
+
+#[test]
+fn test_detect_ghosts_no_false_positives() {
+    // All anchors exist — no ghosts should be reported.
+    let live_ids: HashSet<String> = ["aaa", "bbb", "ccc"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let anchors = vec!["aaa".to_string(), "bbb".to_string()];
+
+    let ghosts = queries::detect_ghosts(&anchors, &live_ids);
+    assert!(ghosts.is_empty(), "No ghosts should be detected when all anchors exist");
+}
+
+#[test]
+fn test_detect_ghosts_all_anchors_are_ghosts() {
+    // No referenced IDs exist — every anchor is a ghost.
+    let live_ids: HashSet<String> = HashSet::new();
+    let anchors = vec!["aaa".to_string(), "bbb".to_string(), "ccc".to_string()];
+
+    let ghosts = queries::detect_ghosts(&anchors, &live_ids);
+    assert_eq!(ghosts.len(), 3, "All anchors should be ghosts");
+    assert_eq!(ghosts, anchors);
+}
+
+#[test]
+fn test_detect_ghosts_handles_kn_prefix() {
+    // Anchors stored with "kn-" prefix should still be detected against
+    // bare IDs in the live set.
+    let live_ids: HashSet<String> = ["aaa"].iter().map(|s| s.to_string()).collect();
+    let anchors = vec!["kn-aaa".to_string(), "kn-bbb".to_string()];
+
+    let ghosts = queries::detect_ghosts(&anchors, &live_ids);
+    assert_eq!(ghosts, vec!["kn-bbb"], "kn-aaa maps to live 'aaa', kn-bbb is a ghost");
+}
+
+#[test]
+fn test_detect_ghosts_mixed_prefix_and_bare() {
+    // Mix of prefixed and bare anchors. Both forms should resolve correctly.
+    let live_ids: HashSet<String> = ["aaa", "bbb"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let anchors = vec![
+        "kn-aaa".to_string(),  // maps to live "aaa" — not a ghost
+        "bbb".to_string(),     // maps to live "bbb" — not a ghost
+        "ccc".to_string(),     // not in live set — ghost
+        "kn-ddd".to_string(),  // maps to bare "ddd", not in live set — ghost
+    ];
+
+    let ghosts = queries::detect_ghosts(&anchors, &live_ids);
+    assert_eq!(ghosts, vec!["ccc", "kn-ddd"]);
+}
+
+#[test]
+fn test_detect_ghosts_empty_anchors() {
+    // Entry with no anchors should produce no ghosts.
+    let live_ids: HashSet<String> = ["aaa"].iter().map(|s| s.to_string()).collect();
+    let anchors: Vec<String> = vec![];
+
+    let ghosts = queries::detect_ghosts(&anchors, &live_ids);
+    assert!(ghosts.is_empty());
+}
+
+// ---- Integration tests (in-memory SurrealDB) ----
+
+#[test]
+fn test_sweep_ghost_anchors_dry_run_does_not_modify() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Create two entries: "target" exists, "ghost" does not.
+    let mut entry_a = make_test_entry("kn-sweep-a", 5, 0.0);
+    entry_a.anchors = vec!["kn-sweep-target".to_string(), "kn-sweep-ghost".to_string()];
+    db.upsert_knowledge(&entry_a).unwrap();
+
+    let entry_target = make_test_entry("kn-sweep-target", 3, 0.0);
+    db.upsert_knowledge(&entry_target).unwrap();
+    // "kn-sweep-ghost" is intentionally NOT created.
+
+    // Dry run
+    let result = db.sweep_ghost_anchors(true).unwrap();
+
+    assert_eq!(result.ghosts_found, 1, "Should detect one ghost anchor");
+    assert_eq!(result.ghosts_removed, 0, "Dry run should not remove anything");
+    assert!(result.dry_run);
+    assert_eq!(result.affected_entries.len(), 1);
+    assert_eq!(result.affected_entries[0].ghost_anchors, vec!["kn-sweep-ghost"]);
+
+    // Verify anchors were NOT modified
+    let ctx = crate::store::AgentContext::public_only();
+    let unchanged = db.get("kn-sweep-a", &ctx).unwrap().unwrap();
+    assert_eq!(
+        unchanged.anchors.len(),
+        2,
+        "Dry run must not modify anchors"
+    );
+}
+
+#[test]
+fn test_sweep_ghost_anchors_removes_ghosts() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Create entry with one live and one ghost anchor.
+    let mut entry_a = make_test_entry("kn-sweep-rm-a", 5, 0.0);
+    entry_a.anchors = vec!["kn-sweep-rm-live".to_string(), "kn-sweep-rm-dead".to_string()];
+    db.upsert_knowledge(&entry_a).unwrap();
+
+    let live_entry = make_test_entry("kn-sweep-rm-live", 3, 0.0);
+    db.upsert_knowledge(&live_entry).unwrap();
+    // "kn-sweep-rm-dead" is intentionally NOT created.
+
+    // Real sweep
+    let result = db.sweep_ghost_anchors(false).unwrap();
+
+    assert_eq!(result.ghosts_found, 1);
+    assert_eq!(result.ghosts_removed, 1);
+    assert!(!result.dry_run);
+
+    // Verify the ghost anchor was actually removed
+    let ctx = crate::store::AgentContext::public_only();
+    let updated = db.get("kn-sweep-rm-a", &ctx).unwrap().unwrap();
+    assert_eq!(
+        updated.anchors.len(),
+        1,
+        "Ghost anchor should have been removed"
+    );
+    assert!(
+        updated.anchors.contains(&"kn-sweep-rm-live".to_string()),
+        "Live anchor should be preserved"
+    );
+}
+
+#[test]
+fn test_sweep_ghost_anchors_all_ghosts_on_entry() {
+    // Edge case: entry where ALL anchors are ghosts.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    let mut entry = make_test_entry("kn-sweep-all-ghost", 5, 0.0);
+    entry.anchors = vec!["kn-ghost-x".to_string(), "kn-ghost-y".to_string()];
+    db.upsert_knowledge(&entry).unwrap();
+    // Neither ghost-x nor ghost-y exist.
+
+    let result = db.sweep_ghost_anchors(false).unwrap();
+
+    assert_eq!(result.ghosts_found, 2, "Both anchors should be ghosts");
+    assert_eq!(result.ghosts_removed, 2);
+    assert_eq!(result.affected_entries.len(), 1);
+
+    // Verify all anchors were removed
+    let ctx = crate::store::AgentContext::public_only();
+    let updated = db.get("kn-sweep-all-ghost", &ctx).unwrap().unwrap();
+    assert!(
+        updated.anchors.is_empty(),
+        "All ghost anchors should be removed"
+    );
+}
+
+#[test]
+fn test_sweep_ghost_anchors_clean_graph() {
+    // When no ghosts exist, the sweep should report 0 found / 0 removed.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    let mut entry_a = make_test_entry("kn-clean-a", 5, 0.0);
+    entry_a.anchors = vec!["kn-clean-b".to_string()];
+    db.upsert_knowledge(&entry_a).unwrap();
+
+    let entry_b = make_test_entry("kn-clean-b", 3, 0.0);
+    db.upsert_knowledge(&entry_b).unwrap();
+
+    let result = db.sweep_ghost_anchors(true).unwrap();
+
+    assert_eq!(result.ghosts_found, 0, "Clean graph should have no ghosts");
+    assert_eq!(result.entries_scanned, 1, "One entry has anchors");
+    assert!(result.affected_entries.is_empty());
+}
+
+#[test]
+fn test_sweep_ghost_anchors_no_anchored_entries() {
+    // When no entries have anchors, the sweep should return immediately.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    let entry = make_test_entry("kn-no-anchors", 5, 0.0);
+    db.upsert_knowledge(&entry).unwrap();
+
+    let result = db.sweep_ghost_anchors(true).unwrap();
+
+    assert_eq!(result.entries_scanned, 0);
+    assert_eq!(result.ghosts_found, 0);
+    assert!(result.affected_entries.is_empty());
 }

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -1331,7 +1331,10 @@ fn test_detect_ghosts_no_false_positives() {
     let anchors = vec!["aaa".to_string(), "bbb".to_string()];
 
     let ghosts = queries::detect_ghosts(&anchors, &live_ids);
-    assert!(ghosts.is_empty(), "No ghosts should be detected when all anchors exist");
+    assert!(
+        ghosts.is_empty(),
+        "No ghosts should be detected when all anchors exist"
+    );
 }
 
 #[test]
@@ -1353,21 +1356,22 @@ fn test_detect_ghosts_handles_kn_prefix() {
     let anchors = vec!["kn-aaa".to_string(), "kn-bbb".to_string()];
 
     let ghosts = queries::detect_ghosts(&anchors, &live_ids);
-    assert_eq!(ghosts, vec!["kn-bbb"], "kn-aaa maps to live 'aaa', kn-bbb is a ghost");
+    assert_eq!(
+        ghosts,
+        vec!["kn-bbb"],
+        "kn-aaa maps to live 'aaa', kn-bbb is a ghost"
+    );
 }
 
 #[test]
 fn test_detect_ghosts_mixed_prefix_and_bare() {
     // Mix of prefixed and bare anchors. Both forms should resolve correctly.
-    let live_ids: HashSet<String> = ["aaa", "bbb"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let live_ids: HashSet<String> = ["aaa", "bbb"].iter().map(|s| s.to_string()).collect();
     let anchors = vec![
-        "kn-aaa".to_string(),  // maps to live "aaa" — not a ghost
-        "bbb".to_string(),     // maps to live "bbb" — not a ghost
-        "ccc".to_string(),     // not in live set — ghost
-        "kn-ddd".to_string(),  // maps to bare "ddd", not in live set — ghost
+        "kn-aaa".to_string(), // maps to live "aaa" — not a ghost
+        "bbb".to_string(),    // maps to live "bbb" — not a ghost
+        "ccc".to_string(),    // not in live set — ghost
+        "kn-ddd".to_string(), // maps to bare "ddd", not in live set — ghost
     ];
 
     let ghosts = queries::detect_ghosts(&anchors, &live_ids);
@@ -1403,10 +1407,16 @@ fn test_sweep_ghost_anchors_dry_run_does_not_modify() {
     let result = db.sweep_ghost_anchors(true).unwrap();
 
     assert_eq!(result.ghosts_found, 1, "Should detect one ghost anchor");
-    assert_eq!(result.ghosts_removed, 0, "Dry run should not remove anything");
+    assert_eq!(
+        result.ghosts_removed, 0,
+        "Dry run should not remove anything"
+    );
     assert!(result.dry_run);
     assert_eq!(result.affected_entries.len(), 1);
-    assert_eq!(result.affected_entries[0].ghost_anchors, vec!["kn-sweep-ghost"]);
+    assert_eq!(
+        result.affected_entries[0].ghost_anchors,
+        vec!["kn-sweep-ghost"]
+    );
 
     // Verify anchors were NOT modified
     let ctx = crate::store::AgentContext::public_only();
@@ -1424,7 +1434,10 @@ fn test_sweep_ghost_anchors_removes_ghosts() {
 
     // Create entry with one live and one ghost anchor.
     let mut entry_a = make_test_entry("kn-sweep-rm-a", 5, 0.0);
-    entry_a.anchors = vec!["kn-sweep-rm-live".to_string(), "kn-sweep-rm-dead".to_string()];
+    entry_a.anchors = vec![
+        "kn-sweep-rm-live".to_string(),
+        "kn-sweep-rm-dead".to_string(),
+    ];
     db.upsert_knowledge(&entry_a).unwrap();
 
     let live_entry = make_test_entry("kn-sweep-rm-live", 3, 0.0);

--- a/src/surreal_db/trait_impl.rs
+++ b/src/surreal_db/trait_impl.rs
@@ -327,4 +327,8 @@ impl KnowledgeStore for SurrealDatabase {
     fn delete_wake_session(&self, session_id: &str) -> Result<()> {
         self.delete_wake_session(session_id)
     }
+
+    fn sweep_ghost_anchors(&self, dry_run: bool) -> Result<crate::store::GhostSweepResult> {
+        self.sweep_ghost_anchors(dry_run)
+    }
 }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1555,7 +1555,10 @@ mod tests {
                 unreachable!()
             }
 
-            fn sweep_ghost_anchors(&self, _dry_run: bool) -> Result<crate::store::GhostSweepResult> {
+            fn sweep_ghost_anchors(
+                &self,
+                _dry_run: bool,
+            ) -> Result<crate::store::GhostSweepResult> {
                 unreachable!()
             }
         }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1554,6 +1554,10 @@ mod tests {
             fn list_tables(&self) -> Result<Vec<String>> {
                 unreachable!()
             }
+
+            fn sweep_ghost_anchors(&self, _dry_run: bool) -> Result<crate::store::GhostSweepResult> {
+                unreachable!()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- New `mx memory sweep-ghosts` subcommand that detects and removes broken anchor references
- Ghost anchors = entries referencing knowledge nodes that have been deleted
- Dry-run mode (--dry-run) reports what would be cleaned without modifying
- JSON output mode (--json) for scripting
- Verbose mode (-v) shows individual ghost IDs per entry

## Context
Memory graph health audit found 3,210 ghost references across 1,158 entries (~28% of anchored entries). These are dangling pointers left behind when entries were deleted but inbound references weren't pruned. The sweep tool detects and removes them.

## Test plan
- `hearth mx memory sweep-ghosts --dry-run` — verify detection without modification
- `hearth mx memory sweep-ghosts --dry-run --verbose` — inspect individual ghost IDs
- `hearth mx memory sweep-ghosts` — run actual cleanup
- Verify no false positives (live anchors preserved)