### PR TITLE
kv: rename numeric id to index, hash becomes id (#310)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ mx kv count shipped --day 2026-05-07
 # Time range composes with --count (filter first, then limit)
 mx kv last shipped --month 2026-04 --count 5
 
-# Entry lookup by numeric ID or hash ID
+# Entry lookup by numeric index or entry ID
 mx kv get shipped --id 35
 mx kv get shipped --id kv-A3fB
 mx kv get shipped --id 35-64
 mx kv get shipped --id 1,kv-A3fB,12
 
-# Remove by hash ID
+# Remove by entry ID
 mx kv remove shipped --id kv-A3fB
 
 # Random sampling from history/list keys
@@ -172,7 +172,7 @@ mx kv set decisions --id 17 --memory kn-abc123
 mx kv last decisions --count 3 --memory
 ```
 
-Every entry gets a stable hash ID (e.g. `kv-A3fB`) alongside its numeric ID. Push prints both: `kv-A3fB (42)`. Anywhere a numeric ID works, a hash ID also works -- `--id kv-A3fB`, mixed comma lists, remove. Ranges remain numeric only. Old data files are back-filled on first load.
+Every entry gets a stable entry ID (e.g. `kv-A3fB`) alongside its numeric index. Push prints both: `kv-A3fB (42)`. Anywhere a numeric index works, an entry ID also works -- `--id kv-A3fB`, mixed comma lists, remove. Ranges remain numeric only. Old data files are back-filled on first load.
 
 Entries can carry structured JSON data via `--data` on push. Query entries by data fields with `--where key=value` (available on `search`, `last`, `random`, `count`). Multiple `--where` flags are ANDed. Supports exact string match, array-contains, and numeric/boolean comparison on top-level fields.
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -199,8 +199,8 @@ exception: it uses typed exit codes (0 = OK, 1 = key not found, 2 = type
 mismatch, 3 = schema missing, 4 = invalid input) so callers can distinguish
 failure modes programmatically. The `KvError` enum covers five typed variants:
 `KeyNotFound`, `TypeMismatch`, `SchemaMissing`, `EntryNotFound` (a specific
-entry ID was not found within a key), and `AmbiguousHash` (a hash prefix
-matched multiple entries). Both `EntryNotFound` and `AmbiguousHash` map to
+entry ID was not found within a key), and `AmbiguousId` (an ID prefix
+matched multiple entries). Both `EntryNotFound` and `AmbiguousId` map to
 exit code 4.
 
 
@@ -587,8 +587,8 @@ Supported types:
   table.header([*Type*], [*Behavior*]),
   [`counter`], [Integer with optional `min`/`max` bounds. Supports `inc`, `dec`, `set`, `get`],
   [`string`], [Simple string value. Supports `set`, `get`],
-  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. Each entry gets a numeric ID and a stable base58 hash ID (`kv-` prefix). Entries can carry optional structured JSON data (`--data` on push, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
-  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. Each entry gets a numeric ID and a stable base58 hash ID. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
+  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. Each entry gets a numeric index and a stable base58 entry ID (`kv-` prefix). Entries can carry optional structured JSON data (`--data` on push, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
+  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. Each entry gets a numeric index and a stable base58 entry ID. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
   [`state`], [Named fields (like a struct). Supports `set <key> <field> <value>`, `get`],
 )
 
@@ -598,16 +598,21 @@ The data file at `$MX_HOME/kv/data/{agent}.json` holds current values. All
 writes are atomic: serialize to a temp file, fsync, rename. The format is a
 flat JSON object keyed by the key names from the schema.
 
-History and list entries are stored as objects with `id`, `hash`, `value`,
-`ts`, an optional `data` field (arbitrary JSON object for structured
-metadata), and an optional `memory` field (a `kn-` ID linking the entry to
-a knowledge node in the memory graph). The `hash` field is a short base58
-string generated from `blake3(key + timestamp + id)` via base-d, providing a
-stable identifier independent of numeric ordering. The `hash`, `data`, and
-`memory` fields all use `#[serde(default)]` for backward compatibility --
-files written before these fields existed are back-filled on first load
-(hashes are generated, data and memory default to `None`) and saved
-automatically.
+History and list entries are stored as objects with `id` (stable entry ID,
+serialized from the `id` field), `hash` (legacy on-disk name for the entry ID,
+read via `serde(rename)`), `value`, `ts`, an optional `data` field (arbitrary
+JSON object for structured metadata), and an optional `memory` field (a `kn-`
+ID linking the entry to a knowledge node in the memory graph). In the Rust
+structs, the numeric sequence number is the `index` field (serialized as `id`
+on disk) and the stable base58 identifier is the `id` field (serialized as
+`hash` on disk). The on-disk names are preserved via `serde(rename)` for
+backward compatibility -- no data migration is needed. The entry ID is a short
+base58 string generated from `blake3(key + timestamp + index)` via base-d,
+providing a stable identifier independent of numeric ordering. The `id`
+(entry ID), `data`, and `memory` fields all use `#[serde(default)]` for
+backward compatibility -- files written before these fields existed are
+back-filled on first load (IDs are generated, data and memory default to
+`None`) and saved automatically.
 
 === Schema mutation
 

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -139,7 +139,7 @@ mx kv push decisions "chose Typst for docs"  # prints: kv-A3fB (1)
 mx kv last decisions --count 5
 mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
-mx kv get decisions --id kv-A3fB              # look up by hash ID
+mx kv get decisions --id kv-A3fB              # look up by entry ID
 
 # Auto-create a key in the schema and push in one step
 mx kv push puns "the joke" --create history

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -22,8 +22,8 @@ Every key has a type declared in the schema. Five types are supported:
 
 / string: A single text value. Has an optional `default`.
 / counter: An integer with optional `min`, `max`, and `default`. Clamped on every write.
-/ history: A timestamped append-only log. Newest entries first. Has an optional `max_entries` cap that drops the oldest entries on overflow. Each entry gets a numeric ID and a stable hash ID. Entries can carry optional structured JSON data.
-/ list: An ordered collection with timestamps. Supports push and pop. Also has an optional `max_entries` cap. Each entry gets a numeric ID and a stable hash ID. Entries can carry optional structured JSON data.
+/ history: A timestamped append-only log. Newest entries first. Has an optional `max_entries` cap that drops the oldest entries on overflow. Each entry gets a numeric index and a stable ID. Entries can carry optional structured JSON data.
+/ list: An ordered collection with timestamps. Supports push and pop. Also has an optional `max_entries` cap. Each entry gets a numeric index and a stable ID. Entries can carry optional structured JSON data.
 / state: A structured record with named fields. Fields are declared in the schema and validated on write.
 
 === Schema files
@@ -108,7 +108,7 @@ KV commands use structured exit codes for scripting:
 / `1`: Key not found (or no data yet for that key).
 / `2`: Type mismatch (e.g., `inc` on a string key, or `get --id` on a non-history/list key).
 / `3`: Schema file not found.
-/ `4`: Invalid input (e.g., reversed range, empty spec, empty hash after `kv-` prefix, entry not found by ID, ambiguous hash prefix).
+/ `4`: Invalid input (e.g., reversed range, empty spec, empty ID after `kv-` prefix, entry not found by ID, ambiguous ID prefix).
 
 == Basic operations
 
@@ -117,16 +117,16 @@ KV commands use structured exit codes for scripting:
   [Get the current value of a key, or look up specific entries by ID.
 
   Without `--id`, prints the full current value: raw text for strings and
-  counters, all entries with IDs and timestamps for history and list types,
+  counters, all entries with indexes and timestamps for history and list types,
   and fields as JSON for state types.
 
   With `--id`, retrieves specific entries from a history or list by numeric
-  ID or hash ID. Four ID formats are supported:
+  index or entry ID. Four formats are supported:
 
-  / Single numeric ID: `--id 35` -- returns exactly one entry.
-  / Single hash ID: `--id kv-A3fB` -- returns the entry matching that hash. Hash matching is prefix-based: `kv-A3f` will match if the prefix is unambiguous.
-  / Numeric range: `--id 35-64` -- returns all entries with numeric IDs 35 through 64 inclusive. Maximum range size is 10,000 entries. Ranges are numeric only.
-  / Comma-separated: `--id 1,kv-A3fB,12` -- returns the listed entries. Numeric and hash IDs can be mixed freely in comma lists.
+  / Single numeric index: `--id 35` -- returns exactly one entry.
+  / Single entry ID: `--id kv-A3fB` -- returns the entry matching that ID. ID matching is prefix-based: `kv-A3f` will match if the prefix is unambiguous.
+  / Numeric range: `--id 35-64` -- returns all entries with indexes 35 through 64 inclusive. Maximum range size is 10,000 entries. Ranges are numeric only.
+  / Comma-separated: `--id 1,kv-A3fB,12` -- returns the listed entries. Numeric indexes and entry IDs can be mixed freely in comma lists.
 
   If any requested IDs are not found, a note listing the missing IDs is
   printed to stderr. The found entries are still printed to stdout.
@@ -136,7 +136,7 @@ KV commands use structured exit codes for scripting:
   Parse failures (reversed ranges, empty specs) return exit code 4
   (invalid input).],
   flags: (
-    ([`--id <spec>`], [string], [Entry ID: numeric (`35`), hash (`kv-A3fB`), range (`35-64`), or comma-separated (`1,kv-A3fB,12`)]),
+    ([`--id <spec>`], [string], [Entry identifier: numeric index (`35`), entry ID (`kv-A3fB`), range (`35-64`), or comma-separated (`1,kv-A3fB,12`)]),
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
   ),
   examples: (
@@ -166,14 +166,14 @@ KV commands use structured exit codes for scripting:
   The field name must be declared in the schema.
 
   With `--id` and `--memory`, links an existing history or list entry to a
-  memory knowledge node. The `--id` flag accepts a numeric ID (`17`) or a
-  hash ID (`kv-A3fB`). Hash matching is prefix-based -- an ambiguous
+  memory knowledge node. The `--id` flag accepts a numeric index (`17`) or an
+  entry ID (`kv-A3fB`). ID matching is prefix-based -- an ambiguous
   prefix returns an error asking for more characters. `--id` requires
   `--memory`; it cannot be used alone. Pass an empty string
   (`--memory ""`) to clear a per-entry link.],
   flags: (
     ([`--memory <kn-id>`], [string], [Link a memory entry (kn- ID) to this key or entry, or `""` to clear]),
-    ([`--id <spec>`], [string], [Target a specific entry by numeric ID or hash ID (requires `--memory`)]),
+    ([`--id <spec>`], [string], [Target a specific entry by numeric index or entry ID (requires `--memory`)]),
   ),
   examples: (
     "mx kv set session_goal \"ship the docs\"",
@@ -232,9 +232,9 @@ History and list types both store timestamped entries with auto-assigned IDs.
 The difference is semantic: history is append-only (newest first, no pop),
 while lists support push/pop and maintain insertion order.
 
-Every entry gets two identifiers: a numeric ID (sequential, per-key) and a
-hash ID (a stable base58 string prefixed with `kv-`, e.g. `kv-A3fB`). Both
-can be used anywhere an ID is accepted. See #link(<hash-ids>)[Hash IDs] for
+Every entry gets two identifiers: a numeric index (sequential, per-key) and a
+stable entry ID (a base58 string prefixed with `kv-`, e.g. `kv-A3fB`). Both
+can be used anywhere an ID is accepted. See #link(<entry-ids>)[Entry IDs] for
 details.
 
 Both types support `push`, `last`, `search`, `count`, `random`, `remove`, and
@@ -247,7 +247,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv push <key> <value>",
   [Push a value onto a history or list key. The entry is automatically
-  timestamped and assigned both a numeric ID and a hash ID.
+  timestamped and assigned both a numeric index and a stable entry ID.
 
   On success, prints the new entry's identifiers:
 
@@ -255,7 +255,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   kv-A3fB (42)
   ```
 
-  Hash first (the primary stable identifier), numeric ID in parentheses.
+  Entry ID first (the primary stable identifier), numeric index in parentheses.
 
   For *history* keys, new entries are inserted at the front (newest first).
   If the key has a `max_entries` schema constraint, the oldest entries are
@@ -311,7 +311,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv pop <key>",
   [Pop the last item from a list key. Prints the removed entry with its
-  numeric ID, hash ID, value, and timestamp. Returns silently if the list
+  numeric index, entry ID, value, and timestamp. Returns silently if the list
   is empty.
 
   Only works on list types. History keys are append-only and do not support
@@ -326,7 +326,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv last <key>",
   [Get the last N entries from a history or list key. Entries are printed
-  with their numeric ID, hash ID, value, and timestamp.
+  with their numeric index, entry ID, value, and timestamp.
 
   For history keys, "last" means the most recent (entries are stored newest
   first). For list keys, "last" means the tail of the list.
@@ -371,7 +371,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   - Relative: `30m` (minutes), `1h` (hours), `7d` (days), `2w` (weeks)
   - Absolute: ISO-8601 format (e.g., `2025-01-15T10:00:00Z`)
 
-  Entries are printed with their numeric ID, hash ID, value, and timestamp.],
+  Entries are printed with their numeric index, entry ID, value, and timestamp.],
   flags: (
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
   ),
@@ -389,7 +389,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   "mx kv search <key> [query]",
   [Search entries in a list or history by case-insensitive substring match
   and/or structured data filters. Prints matching entries with their numeric
-  ID, hash ID, value, timestamp, and any attached data.
+  index, entry ID, value, timestamp, and any attached data.
 
   The text query is optional when `--where` filters are provided. You can
   search by text alone, by structured data alone, or by both. At least one
@@ -468,7 +468,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
 #command(
   "mx kv random <key>",
   [Get N random entries from a history or list key. Entries are printed
-  with their numeric ID, hash ID, value, and timestamp.
+  with their numeric index, entry ID, value, and timestamp.
 
   Useful for inspiration (pick a random idea), spot-checking (sample from
   a large history), or building variety into automated workflows.
@@ -508,14 +508,14 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   [Remove entries from a list or history by value substring or by ID.
   You must provide either a value substring or `--id`.
 
-  The `--id` flag accepts a numeric ID (`7`) or a hash ID (`kv-A3fB`).
-  Hash matching is prefix-based -- if the prefix is ambiguous (matches
+  The `--id` flag accepts a numeric index (`7`) or an entry ID (`kv-A3fB`).
+  ID matching is prefix-based -- if the prefix is ambiguous (matches
   multiple entries), an error is returned asking for more characters.
 
   By default, only the first match is removed. Use `--all` to remove every
   matching entry.],
   flags: (
-    ([`--id <spec>`], [string], [Remove the entry with this numeric ID or hash ID (`kv-XXXX`)]),
+    ([`--id <spec>`], [string], [Remove the entry with this numeric index or entry ID (`kv-XXXX`)]),
     ([`--all`], [flag], [Remove all matching entries (default: first match only)]),
   ),
   examples: (
@@ -644,8 +644,8 @@ structured data (backward compatible with all existing entries).
 
 === Output format
 
-Entries display the numeric ID, hash ID in brackets, value, timestamp, and any
-structured data:
+Entries display the numeric index, entry ID in brackets, value, timestamp, and
+any structured data:
 
 ```
 42 [kv-A3fB]: palmtop DSI fix (2026-05-08T14:30:00Z) {"tags":["palmtop","i915"],"status":"active"}
@@ -717,18 +717,18 @@ before this feature was added continue to work without migration. Entries
 without data are simply treated as having no structured fields -- they will
 not match any `--where` clause, but they are otherwise unaffected.
 
-== Hash IDs <hash-ids>
+== Entry IDs <entry-ids>
 
-Every history and list entry has a stable hash ID in addition to its numeric
-ID. Hash IDs are short base58 strings (4--6 characters) prefixed with `kv-`
+Every history and list entry has a stable entry ID in addition to its numeric
+index. Entry IDs are short base58 strings (4--6 characters) prefixed with `kv-`
 for visual identification, e.g. `kv-A3fB`.
 
 === Generation
 
-The hash is generated from `blake3(key + timestamp + id)`, with the first 4
+The ID is generated from `blake3(key + timestamp + index)`, with the first 4
 bytes encoded as base58 via base-d. This produces ~11 million unique addresses
-per key -- sufficient for typical KV usage. The hash is deterministic: the
-same key, timestamp, and numeric ID always produce the same hash.
+per key -- sufficient for typical KV usage. The ID is deterministic: the
+same key, timestamp, and numeric index always produce the same ID.
 
 === Push output
 
@@ -738,45 +738,45 @@ same key, timestamp, and numeric ID always produce the same hash.
 kv-A3fB (42)
 ```
 
-Hash first (the primary stable identifier), numeric ID in parentheses. This
-makes it easy to capture the hash for later use in scripts or follow-up
+Entry ID first (the primary stable identifier), numeric index in parentheses.
+This makes it easy to capture the ID for later use in scripts or follow-up
 commands.
 
 === Dual addressing
 
-Anywhere a numeric ID is accepted, a hash ID also works:
+Anywhere a numeric index is accepted, an entry ID also works:
 
 ```bash
-# Get by hash
+# Get by entry ID
 mx kv get shipped --id kv-A3fB
 
-# Get by numeric (still works)
+# Get by numeric index (still works)
 mx kv get shipped --id 42
 
 # Mix in comma lists
 mx kv get shipped --id 42,kv-A3fB,15
 
-# Remove by hash
+# Remove by entry ID
 mx kv remove shipped --id kv-A3fB
 ```
 
-Numeric ranges remain numeric only (`35-64`). Hash IDs cannot be used in
+Numeric ranges remain numeric only (`35-64`). Entry IDs cannot be used in
 ranges because they are not ordered.
 
 === Prefix matching
 
-Hash lookups are prefix-based: `kv-A3f` will match an entry with hash
+ID lookups are prefix-based: `kv-A3f` will match an entry with ID
 `A3fBx2` as long as the prefix uniquely identifies one entry. If the prefix
 is ambiguous (matches multiple entries), an error is returned:
 
 ```
-Error: hash prefix 'kv-A3' is ambiguous: matches 3 entries, provide more characters
+Error: ID prefix 'kv-A3' is ambiguous: matches 3 entries, provide more characters
 ```
 
 === Backward compatibility
 
-Old data files written before hash IDs existed are back-filled automatically
-on first load. The store generates hashes for all entries that lack one,
+Old data files written before entry IDs existed are back-filled automatically
+on first load. The store generates IDs for all entries that lack one,
 saves the file, and continues normally. This is a one-time migration -- no
 manual action is needed.
 
@@ -858,10 +858,10 @@ mx kv push decisions "adopted per-entry memory links" --memory kn-abc123
 *Set on an existing entry:*
 
 ```bash
-# Link by numeric ID
+# Link by numeric index
 mx kv set decisions --id 17 --memory kn-abc123
 
-# Link by hash ID
+# Link by entry ID
 mx kv set decisions --id kv-A3fB --memory kn-def456
 
 # Clear a per-entry link
@@ -869,7 +869,7 @@ mx kv set decisions --id 17 --memory ""
 ```
 
 The `--id` flag on `set` requires `--memory` -- it cannot be used alone.
-Hash matching is prefix-based: `kv-A3f` matches if the prefix uniquely
+ID matching is prefix-based: `kv-A3f` matches if the prefix uniquely
 identifies one entry. If the prefix is ambiguous, an error is returned.
 If the entry is not found, exit code 4 (invalid input) is returned.
 

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -231,10 +231,8 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         }
 
                         // Report missing IDs
-                        let found_indexes: HashSet<u64> =
-                            hits.iter().map(|h| h.index).collect();
-                        let found_ids: Vec<&str> =
-                            hits.iter().map(|h| h.id.as_str()).collect();
+                        let found_indexes: HashSet<u64> = hits.iter().map(|h| h.index).collect();
+                        let found_ids: Vec<&str> = hits.iter().map(|h| h.id.as_str()).collect();
                         let missing: Vec<String> = ids
                             .iter()
                             .filter(|id_ref| match id_ref {

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -100,8 +100,8 @@ fn resolve_dump_memories(store: &KvStore, verbose: bool) {
 
 /// Parse a single token into an `IdRef`.
 ///
-/// - Starts with `kv-` -> strip prefix, treat as hash
-/// - Pure digits -> numeric ID
+/// - Starts with `kv-` -> strip prefix, treat as stable ID (`IdRef::Id`)
+/// - Pure digits -> numeric index (`IdRef::Index`)
 /// - Otherwise -> error
 fn parse_single_id(token: &str) -> Result<IdRef, String> {
     let token = token.trim();
@@ -109,22 +109,22 @@ fn parse_single_id(token: &str) -> Result<IdRef, String> {
         if hash.is_empty() {
             return Err("empty hash after 'kv-' prefix".to_string());
         }
-        Ok(IdRef::Hash(hash.to_string()))
+        Ok(IdRef::Id(hash.to_string()))
     } else {
-        let id: u64 = token
+        let idx: u64 = token
             .parse()
             .map_err(|_| format!("invalid ID '{}'", token))?;
-        Ok(IdRef::Numeric(id))
+        Ok(IdRef::Index(idx))
     }
 }
 
 /// Parse an ID specification into a list of `IdRef`s.
 ///
 /// Accepted formats:
-/// - Single numeric ID: "35" -> [Numeric(35)]
-/// - Hash ID: "kv-A3fB" -> [Hash("A3fB")]
-/// - Numeric range: "35-64" -> [Numeric(35), ..., Numeric(64)]
-/// - Comma-separated (can mix): "1,kv-A3fB,12" -> [Numeric(1), Hash("A3fB"), Numeric(12)]
+/// - Single numeric index: "35" -> [Index(35)]
+/// - Stable ID: "kv-A3fB" -> [Id("A3fB")]
+/// - Numeric range: "35-64" -> [Index(35), ..., Index(64)]
+/// - Comma-separated (can mix): "1,kv-A3fB,12" -> [Index(1), Id("A3fB"), Index(12)]
 fn parse_id_spec(spec: &str) -> Result<Vec<IdRef>, String> {
     let spec = spec.trim();
     if spec.is_empty() {
@@ -132,12 +132,12 @@ fn parse_id_spec(spec: &str) -> Result<Vec<IdRef>, String> {
     }
 
     if spec.contains(',') {
-        // Comma-separated list (can mix numeric and hash)
+        // Comma-separated list (can mix numeric index and stable ID)
         spec.split(',')
             .map(|s| parse_single_id(s.trim()))
             .collect::<Result<Vec<_>, _>>()
     } else if spec.starts_with("kv-") {
-        // Single hash ID
+        // Single stable ID
         Ok(vec![parse_single_id(spec)?])
     } else if spec.contains('-') {
         // Numeric range
@@ -167,7 +167,7 @@ fn parse_id_spec(spec: &str) -> Result<Vec<IdRef>, String> {
                 MAX_RANGE_SIZE
             ));
         }
-        Ok((start..=end).map(IdRef::Numeric).collect())
+        Ok((start..=end).map(IdRef::Index).collect())
     } else {
         // Single numeric ID
         Ok(vec![parse_single_id(spec)?])
@@ -225,26 +225,27 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                             println!(
                                 "{}",
                                 kv::format_entry_line(
-                                    hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                                    hit.index, &hit.id, &hit.value, &hit.ts, &hit.data
                                 )
                             );
                         }
 
                         // Report missing IDs
-                        let found_numeric: HashSet<u64> = hits.iter().map(|h| h.id).collect();
-                        let found_hashes: Vec<&str> =
-                            hits.iter().map(|h| h.hash.as_str()).collect();
+                        let found_indexes: HashSet<u64> =
+                            hits.iter().map(|h| h.index).collect();
+                        let found_ids: Vec<&str> =
+                            hits.iter().map(|h| h.id.as_str()).collect();
                         let missing: Vec<String> = ids
                             .iter()
                             .filter(|id_ref| match id_ref {
-                                IdRef::Numeric(n) => !found_numeric.contains(n),
-                                IdRef::Hash(h) => {
-                                    !found_hashes.iter().any(|fh| fh.starts_with(h.as_str()))
+                                IdRef::Index(n) => !found_indexes.contains(n),
+                                IdRef::Id(h) => {
+                                    !found_ids.iter().any(|fid| fid.starts_with(h.as_str()))
                                 }
                             })
                             .map(|id_ref| match id_ref {
-                                IdRef::Numeric(n) => n.to_string(),
-                                IdRef::Hash(h) => format!("kv-{}", h),
+                                IdRef::Index(n) => n.to_string(),
+                                IdRef::Id(h) => format!("kv-{}", h),
                             })
                             .collect();
                         if !missing.is_empty() {
@@ -445,7 +446,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             match store.push(&key, &value, parsed_data, memory) {
                 Ok(result) => {
                     store.save()?;
-                    println!("kv-{} ({})", result.hash, result.id);
+                    println!("kv-{} ({})", result.id, result.index);
                     Ok(kv::EXIT_OK)
                 }
                 Err(e) => handle_kv_err(e),
@@ -458,8 +459,8 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 println!(
                     "{}",
                     kv::format_entry_line(
-                        entry.id,
-                        &entry.hash,
+                        entry.index,
+                        &entry.id,
                         &entry.value,
                         &entry.ts,
                         &entry.data
@@ -495,7 +496,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         println!(
                             "{}",
                             kv::format_entry_line(
-                                hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                                hit.index, &hit.id, &hit.value, &hit.ts, &hit.data
                             )
                         );
                         if memory {
@@ -536,7 +537,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         println!(
                             "{}",
                             kv::format_entry_line(
-                                hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                                hit.index, &hit.id, &hit.value, &hit.ts, &hit.data
                             )
                         );
                         if memory {
@@ -566,8 +567,8 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                     println!(
                         "{}",
                         kv::format_entry_line(
-                            entry.id,
-                            &entry.hash,
+                            entry.index,
+                            &entry.id,
                             &entry.value,
                             &entry.ts,
                             &entry.data
@@ -623,7 +624,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 eprintln!("Error: provide either a value substring or --id");
                 return Ok(kv::EXIT_KEY_NOT_FOUND);
             }
-            // Parse --id as an IdRef (numeric or hash)
+            // Parse --id as an IdRef (numeric index or stable ID)
             let id_ref = match &id {
                 Some(id_str) => match parse_single_id(id_str) {
                     Ok(r) => Some(r),
@@ -683,7 +684,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                             println!(
                                 "{}",
                                 kv::format_entry_line(
-                                    hit.id, &hit.hash, &hit.value, &hit.ts, &hit.data
+                                    hit.index, &hit.id, &hit.value, &hit.ts, &hit.data
                                 )
                             );
                             if memory {
@@ -772,12 +773,12 @@ mod tests {
 
     #[test]
     fn parse_single_id() {
-        assert_eq!(parse_id_spec("35").unwrap(), vec![IdRef::Numeric(35)]);
+        assert_eq!(parse_id_spec("35").unwrap(), vec![IdRef::Index(35)]);
     }
 
     #[test]
     fn parse_single_id_zero() {
-        assert_eq!(parse_id_spec("0").unwrap(), vec![IdRef::Numeric(0)]);
+        assert_eq!(parse_id_spec("0").unwrap(), vec![IdRef::Index(0)]);
     }
 
     #[test]
@@ -785,18 +786,18 @@ mod tests {
         assert_eq!(
             parse_id_spec("3-7").unwrap(),
             vec![
-                IdRef::Numeric(3),
-                IdRef::Numeric(4),
-                IdRef::Numeric(5),
-                IdRef::Numeric(6),
-                IdRef::Numeric(7),
+                IdRef::Index(3),
+                IdRef::Index(4),
+                IdRef::Index(5),
+                IdRef::Index(6),
+                IdRef::Index(7),
             ]
         );
     }
 
     #[test]
     fn parse_range_single_element() {
-        assert_eq!(parse_id_spec("5-5").unwrap(), vec![IdRef::Numeric(5)]);
+        assert_eq!(parse_id_spec("5-5").unwrap(), vec![IdRef::Index(5)]);
     }
 
     #[test]
@@ -810,7 +811,7 @@ mod tests {
     fn parse_comma_separated() {
         assert_eq!(
             parse_id_spec("1,5,12").unwrap(),
-            vec![IdRef::Numeric(1), IdRef::Numeric(5), IdRef::Numeric(12)]
+            vec![IdRef::Index(1), IdRef::Index(5), IdRef::Index(12)]
         );
     }
 
@@ -818,7 +819,7 @@ mod tests {
     fn parse_comma_separated_with_spaces() {
         assert_eq!(
             parse_id_spec("1, 5, 12").unwrap(),
-            vec![IdRef::Numeric(1), IdRef::Numeric(5), IdRef::Numeric(12)]
+            vec![IdRef::Index(1), IdRef::Index(5), IdRef::Index(12)]
         );
     }
 
@@ -885,7 +886,7 @@ mod tests {
     fn parse_hash_id_single() {
         assert_eq!(
             parse_id_spec("kv-A3fB").unwrap(),
-            vec![IdRef::Hash("A3fB".to_string())]
+            vec![IdRef::Id("A3fB".to_string())]
         );
     }
 
@@ -894,9 +895,9 @@ mod tests {
         assert_eq!(
             parse_id_spec("1,kv-A3fB,12").unwrap(),
             vec![
-                IdRef::Numeric(1),
-                IdRef::Hash("A3fB".to_string()),
-                IdRef::Numeric(12),
+                IdRef::Index(1),
+                IdRef::Id("A3fB".to_string()),
+                IdRef::Index(12),
             ]
         );
     }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -14,7 +14,7 @@ fn exit_code_for(err: &KvError) -> Option<i32> {
         KvError::TypeMismatch { .. } => Some(kv::EXIT_TYPE_MISMATCH),
         KvError::SchemaMissing(_) => Some(kv::EXIT_SCHEMA_MISSING),
         KvError::EntryNotFound { .. } => Some(kv::EXIT_INVALID_INPUT),
-        KvError::AmbiguousHash { .. } => Some(kv::EXIT_INVALID_INPUT),
+        KvError::AmbiguousId { .. } => Some(kv::EXIT_INVALID_INPUT),
         KvError::Other(_) => None,
     }
 }
@@ -105,11 +105,11 @@ fn resolve_dump_memories(store: &KvStore, verbose: bool) {
 /// - Otherwise -> error
 fn parse_single_id(token: &str) -> Result<IdRef, String> {
     let token = token.trim();
-    if let Some(hash) = token.strip_prefix("kv-") {
-        if hash.is_empty() {
-            return Err("empty hash after 'kv-' prefix".to_string());
+    if let Some(id_str) = token.strip_prefix("kv-") {
+        if id_str.is_empty() {
+            return Err("empty ID after 'kv-' prefix".to_string());
         }
-        Ok(IdRef::Id(hash.to_string()))
+        Ok(IdRef::Id(id_str.to_string()))
     } else {
         let idx: u64 = token
             .parse()
@@ -169,7 +169,7 @@ fn parse_id_spec(spec: &str) -> Result<Vec<IdRef>, String> {
         }
         Ok((start..=end).map(IdRef::Index).collect())
     } else {
-        // Single numeric ID
+        // Single numeric index
         Ok(vec![parse_single_id(spec)?])
     }
 }
@@ -878,10 +878,10 @@ mod tests {
         assert!(parse_id_spec("1-20000").is_err());
     }
 
-    // -- hash ID parsing --
+    // -- ID parsing --
 
     #[test]
-    fn parse_hash_id_single() {
+    fn parse_id_single() {
         assert_eq!(
             parse_id_spec("kv-A3fB").unwrap(),
             vec![IdRef::Id("A3fB".to_string())]
@@ -889,7 +889,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_hash_id_mixed_comma() {
+    fn parse_id_mixed_comma() {
         assert_eq!(
             parse_id_spec("1,kv-A3fB,12").unwrap(),
             vec![
@@ -901,10 +901,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_hash_id_empty_hash() {
+    fn parse_id_empty() {
         let result = parse_id_spec("kv-");
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("empty hash"));
+        assert!(result.unwrap_err().contains("empty ID"));
     }
 
     // -- parse_where_clauses --

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -20,8 +20,8 @@ use crate::cli::TimeRangeArgs;
 /// even if both schema and data fall back to the legacy location.
 static LEGACY_KV_WARNING_EMITTED: OnceLock<()> = OnceLock::new();
 
-/// Cached dictionary registry for hash generation -- avoids re-allocating
-/// the HashMap on every `generate_entry_hash` call.
+/// Cached dictionary registry for ID generation -- avoids re-allocating
+/// the HashMap on every `generate_entry_id` call.
 static DICT_REGISTRY: OnceLock<DictionaryRegistry> = OnceLock::new();
 
 /// The single legacy-fallback warning copy. Lives here so the schema and data
@@ -326,14 +326,14 @@ impl<'de> Deserialize<'de> for DataValue {
             DataValueDe::Counter { value } => DataValue::Counter { value },
             DataValueDe::String { value } => DataValue::String { value },
             DataValueDe::History { entries, memory } => {
-                // Back-fill IDs for history entries loaded with id=0 (old data)
-                let mut max_id = entries.iter().map(|e| e.id).max().unwrap_or(0);
+                // Back-fill indexes for history entries loaded with index=0 (old data)
+                let mut max_idx = entries.iter().map(|e| e.index).max().unwrap_or(0);
                 let entries = entries
                     .into_iter()
                     .map(|mut e| {
-                        if e.id == 0 {
-                            max_id += 1;
-                            e.id = max_id;
+                        if e.index == 0 {
+                            max_idx += 1;
+                            e.index = max_idx;
                         }
                         e
                     })
@@ -342,21 +342,21 @@ impl<'de> Deserialize<'de> for DataValue {
             }
             DataValueDe::State { fields, memory } => DataValue::State { fields, memory },
             DataValueDe::List { items, memory } => {
-                let mut next_id = 0u64;
+                let mut next_idx = 0u64;
                 let entries: Vec<ListEntry> = items
                     .into_iter()
                     .map(|item| match item {
                         RawListItem::Entry(e) => {
-                            if e.id >= next_id {
-                                next_id = e.id + 1;
+                            if e.index >= next_idx {
+                                next_idx = e.index + 1;
                             }
                             e
                         }
                         RawListItem::Bare(s) => {
-                            next_id += 1;
+                            next_idx += 1;
                             ListEntry {
-                                id: next_id,
-                                hash: String::new(),
+                                index: next_idx,
+                                id: String::new(),
                                 value: s,
                                 ts: String::new(),
                                 data: None,
@@ -376,10 +376,10 @@ impl<'de> Deserialize<'de> for DataValue {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HistoryEntry {
-    #[serde(default)]
-    pub id: u64,
-    #[serde(default)]
-    pub hash: String,
+    #[serde(default, rename = "id")]
+    pub index: u64,
+    #[serde(default, rename = "hash")]
+    pub id: String,
     pub value: String,
     pub ts: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -390,9 +390,10 @@ pub struct HistoryEntry {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ListEntry {
-    pub id: u64,
-    #[serde(default)]
-    pub hash: String,
+    #[serde(rename = "id")]
+    pub index: u64,
+    #[serde(default, rename = "hash")]
+    pub id: String,
     pub value: String,
     pub ts: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -410,8 +411,8 @@ pub struct RemoveResult {
 /// Search result entry.
 #[derive(Debug, Clone)]
 pub struct SearchHit {
-    pub id: u64,
-    pub hash: String,
+    pub index: u64,
+    pub id: String,
     pub value: String,
     pub ts: String,
     pub data: Option<serde_json::Value>,
@@ -432,12 +433,12 @@ pub struct CountResult {
 // Hash ID generation
 // ---------------------------------------------------------------------------
 
-/// Generate a short, stable base58 hash for a kv entry.
+/// Generate a short, stable base58 ID for a kv entry.
 ///
-/// Input: `"{key}:{ts}:{id}"` hashed with blake3, first 4 bytes encoded as
+/// Input: `"{key}:{ts}:{index}"` hashed with blake3, first 4 bytes encoded as
 /// base58.  Produces a ~5-6 character alphanumeric string.
-pub fn generate_entry_hash(key: &str, ts: &str, id: u64) -> String {
-    let input = format!("{}:{}:{}", key, ts, id);
+pub fn generate_entry_id(key: &str, ts: &str, index: u64) -> String {
+    let input = format!("{}:{}:{}", key, ts, index);
     let hash_bytes = hash(input.as_bytes(), HashAlgorithm::Blake3);
     let registry = DICT_REGISTRY
         .get_or_init(|| DictionaryRegistry::load_default().expect("base-d dictionaries"));
@@ -445,18 +446,18 @@ pub fn generate_entry_hash(key: &str, ts: &str, id: u64) -> String {
     encode(&hash_bytes[..4], &dict)
 }
 
-/// Result of a push operation, carrying both the numeric and hash IDs.
+/// Result of a push operation, carrying both the index and the stable ID.
 #[derive(Debug, Clone)]
 pub struct PushResult {
-    pub id: u64,
-    pub hash: String,
+    pub index: u64,
+    pub id: String,
 }
 
-/// Reference to a kv entry by either its numeric ID or its hash.
+/// Reference to a kv entry by either its numeric index or its stable ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdRef {
-    Numeric(u64),
-    Hash(String),
+    Index(u64),
+    Id(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -488,22 +489,22 @@ impl KvStore {
             DataFile::default()
         };
 
-        // Back-fill hashes for entries loaded without one (pre-hash data).
+        // Back-fill IDs for entries loaded without one (pre-ID data).
         let mut needs_save = false;
         for (key, value) in &mut data.entries {
             match value {
                 DataValue::History { entries, .. } => {
                     for e in entries.iter_mut() {
-                        if e.hash.is_empty() {
-                            e.hash = generate_entry_hash(key, &e.ts, e.id);
+                        if e.id.is_empty() {
+                            e.id = generate_entry_id(key, &e.ts, e.index);
                             needs_save = true;
                         }
                     }
                 }
                 DataValue::List { items, .. } => {
                     for e in items.iter_mut() {
-                        if e.hash.is_empty() {
-                            e.hash = generate_entry_hash(key, &e.ts, e.id);
+                        if e.id.is_empty() {
+                            e.id = generate_entry_id(key, &e.ts, e.index);
                             needs_save = true;
                         }
                     }
@@ -949,13 +950,13 @@ impl KvStore {
 
                 match entry {
                     DataValue::History { entries, .. } => {
-                        let next_id = entries.iter().map(|e| e.id).max().unwrap_or(0) + 1;
-                        let hash = generate_entry_hash(key, &ts_str, next_id);
+                        let next_idx = entries.iter().map(|e| e.index).max().unwrap_or(0) + 1;
+                        let id = generate_entry_id(key, &ts_str, next_idx);
                         entries.insert(
                             0,
                             HistoryEntry {
-                                id: next_id,
-                                hash: hash.clone(),
+                                index: next_idx,
+                                id: id.clone(),
                                 value: value.to_string(),
                                 ts: ts_str,
                                 data,
@@ -966,7 +967,7 @@ impl KvStore {
                         if let Some(max) = def.max_entries {
                             entries.truncate(max);
                         }
-                        Ok(PushResult { id: next_id, hash })
+                        Ok(PushResult { index: next_idx, id })
                     }
                     _ => Err(KvError::Other(anyhow::anyhow!(
                         "Data corruption: key '{}' has wrong runtime type",
@@ -983,11 +984,11 @@ impl KvStore {
 
                 match entry {
                     DataValue::List { items, .. } => {
-                        let next_id = items.iter().map(|e| e.id).max().unwrap_or(0) + 1;
-                        let hash = generate_entry_hash(key, &ts_str, next_id);
+                        let next_idx = items.iter().map(|e| e.index).max().unwrap_or(0) + 1;
+                        let id = generate_entry_id(key, &ts_str, next_idx);
                         items.push(ListEntry {
-                            id: next_id,
-                            hash: hash.clone(),
+                            index: next_idx,
+                            id: id.clone(),
                             value: value.to_string(),
                             ts: ts_str,
                             data,
@@ -999,7 +1000,7 @@ impl KvStore {
                         {
                             items.drain(0..items.len() - max);
                         }
-                        Ok(PushResult { id: next_id, hash })
+                        Ok(PushResult { index: next_idx, id })
                     }
                     _ => Err(KvError::Other(anyhow::anyhow!(
                         "Data corruption: key '{}' has wrong runtime type",
@@ -1060,8 +1061,8 @@ impl KvStore {
                     Ok(filtered[start..]
                         .iter()
                         .map(|e| SearchHit {
-                            id: e.id,
-                            hash: e.hash.clone(),
+                            index: e.index,
+                            id: e.id.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1084,8 +1085,8 @@ impl KvStore {
                     Ok(filtered[start..]
                         .iter()
                         .map(|e| SearchHit {
-                            id: e.id,
-                            hash: e.hash.clone(),
+                            index: e.index,
+                            id: e.id.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1142,8 +1143,8 @@ impl KvStore {
                                 && where_matches(&e.data, where_clauses)
                         })
                         .map(|e| SearchHit {
-                            id: e.id,
-                            hash: e.hash.clone(),
+                            index: e.index,
+                            id: e.id.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1172,8 +1173,8 @@ impl KvStore {
                                 && where_matches(&e.data, where_clauses)
                         })
                         .map(|e| SearchHit {
-                            id: e.id,
-                            hash: e.hash.clone(),
+                            index: e.index,
+                            id: e.id.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1259,12 +1260,12 @@ impl KvStore {
             Some(DataValue::History { entries, .. }) => {
                 if let Some(id_ref) = by_id {
                     let pos = match id_ref {
-                        IdRef::Numeric(id) => entries.iter().position(|e| e.id == *id),
-                        IdRef::Hash(h) => {
+                        IdRef::Index(idx) => entries.iter().position(|e| e.index == *idx),
+                        IdRef::Id(h) => {
                             let matches: Vec<usize> = entries
                                 .iter()
                                 .enumerate()
-                                .filter(|(_, e)| e.hash.starts_with(h.as_str()))
+                                .filter(|(_, e)| e.id.starts_with(h.as_str()))
                                 .map(|(i, _)| i)
                                 .collect();
                             match matches.len() {
@@ -1298,12 +1299,12 @@ impl KvStore {
             Some(DataValue::List { items, .. }) => {
                 if let Some(id_ref) = by_id {
                     let pos = match id_ref {
-                        IdRef::Numeric(id) => items.iter().position(|e| e.id == *id),
-                        IdRef::Hash(h) => {
+                        IdRef::Index(idx) => items.iter().position(|e| e.index == *idx),
+                        IdRef::Id(h) => {
                             let matches: Vec<usize> = items
                                 .iter()
                                 .enumerate()
-                                .filter(|(_, e)| e.hash.starts_with(h.as_str()))
+                                .filter(|(_, e)| e.id.starts_with(h.as_str()))
                                 .map(|(i, _)| i)
                                 .collect();
                             match matches.len() {
@@ -1383,8 +1384,8 @@ impl KvStore {
                         continue;
                     }
                     hits.push(SearchHit {
-                        id: e.id,
-                        hash: e.hash.clone(),
+                        index: e.index,
+                        id: e.id.clone(),
                         value: e.value.clone(),
                         ts: e.ts.clone(),
                         data: e.data.clone(),
@@ -1406,8 +1407,8 @@ impl KvStore {
                         continue;
                     }
                     hits.push(SearchHit {
-                        id: e.id,
-                        hash: e.hash.clone(),
+                        index: e.index,
+                        id: e.id.clone(),
                         value: e.value.clone(),
                         ts: e.ts.clone(),
                         data: e.data.clone(),
@@ -1421,10 +1422,10 @@ impl KvStore {
         Ok(hits)
     }
 
-    /// Look up entries by ID (numeric or hash) in a history or list.
+    /// Look up entries by index (numeric) or ID (stable hash) in a history or list.
     ///
     /// Returns matching entries as `SearchHit`s (same struct used by `search`).
-    /// Hash matching is prefix-based: `"A3f"` matches an entry with hash `"A3fBx2"`.
+    /// ID matching is prefix-based: `"A3f"` matches an entry with ID `"A3fBx2"`.
     /// Only works on History and List types; returns TypeMismatch for others.
     pub fn get_entries_by_id(&self, key: &str, ids: &[IdRef]) -> Result<Vec<SearchHit>, KvError> {
         let def = self.key_def(key)?;
@@ -1439,26 +1440,26 @@ impl KvStore {
             }
         }
 
-        let numeric_ids: HashSet<u64> = ids
+        let numeric_indexes: HashSet<u64> = ids
             .iter()
             .filter_map(|r| match r {
-                IdRef::Numeric(n) => Some(*n),
+                IdRef::Index(n) => Some(*n),
                 _ => None,
             })
             .collect();
-        let hash_prefixes: Vec<&str> = ids
+        let id_prefixes: Vec<&str> = ids
             .iter()
             .filter_map(|r| match r {
-                IdRef::Hash(h) => Some(h.as_str()),
+                IdRef::Id(h) => Some(h.as_str()),
                 _ => None,
             })
             .collect();
 
-        let matches_entry = |id: u64, hash: &str| -> bool {
-            if numeric_ids.contains(&id) {
+        let matches_entry = |index: u64, id: &str| -> bool {
+            if numeric_indexes.contains(&index) {
                 return true;
             }
-            hash_prefixes.iter().any(|prefix| hash.starts_with(prefix))
+            id_prefixes.iter().any(|prefix| id.starts_with(prefix))
         };
 
         let mut hits = Vec::new();
@@ -1466,10 +1467,10 @@ impl KvStore {
         match self.data.entries.get(key) {
             Some(DataValue::History { entries, .. }) => {
                 for e in entries {
-                    if matches_entry(e.id, &e.hash) {
+                    if matches_entry(e.index, &e.id) {
                         hits.push(SearchHit {
-                            id: e.id,
-                            hash: e.hash.clone(),
+                            index: e.index,
+                            id: e.id.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1480,10 +1481,10 @@ impl KvStore {
             }
             Some(DataValue::List { items, .. }) => {
                 for e in items {
-                    if matches_entry(e.id, &e.hash) {
+                    if matches_entry(e.index, &e.id) {
                         hits.push(SearchHit {
-                            id: e.id,
-                            hash: e.hash.clone(),
+                            index: e.index,
+                            id: e.id.clone(),
                             value: e.value.clone(),
                             ts: e.ts.clone(),
                             data: e.data.clone(),
@@ -1696,17 +1697,17 @@ impl KvStore {
         match self.data.entries.get_mut(key) {
             Some(DataValue::History { entries, .. }) => {
                 let entry = match id {
-                    IdRef::Numeric(n) => entries.iter_mut().find(|e| e.id == *n),
-                    IdRef::Hash(h) => {
+                    IdRef::Index(n) => entries.iter_mut().find(|e| e.index == *n),
+                    IdRef::Id(h) => {
                         let matches: Vec<_> = entries
                             .iter_mut()
-                            .filter(|e| e.hash.starts_with(h.as_str()))
+                            .filter(|e| e.id.starts_with(h.as_str()))
                             .collect();
                         match matches.len() {
                             0 => None,
                             1 => {
                                 // Re-find to satisfy borrow checker (collected vec consumes &mut)
-                                entries.iter_mut().find(|e| e.hash.starts_with(h.as_str()))
+                                entries.iter_mut().find(|e| e.id.starts_with(h.as_str()))
                             }
                             n => {
                                 return Err(KvError::AmbiguousHash {
@@ -1730,15 +1731,15 @@ impl KvStore {
             }
             Some(DataValue::List { items, .. }) => {
                 let entry = match id {
-                    IdRef::Numeric(n) => items.iter_mut().find(|e| e.id == *n),
-                    IdRef::Hash(h) => {
+                    IdRef::Index(n) => items.iter_mut().find(|e| e.index == *n),
+                    IdRef::Id(h) => {
                         let matches: Vec<_> = items
                             .iter_mut()
-                            .filter(|e| e.hash.starts_with(h.as_str()))
+                            .filter(|e| e.id.starts_with(h.as_str()))
                             .collect();
                         match matches.len() {
                             0 => None,
-                            1 => items.iter_mut().find(|e| e.hash.starts_with(h.as_str())),
+                            1 => items.iter_mut().find(|e| e.id.starts_with(h.as_str())),
                             n => {
                                 return Err(KvError::AmbiguousHash {
                                     prefix: h.clone(),
@@ -2108,19 +2109,19 @@ pub fn ts_in_range(ts: &str, range: &TimeRange) -> bool {
 // Display helpers (for CLI output)
 // ---------------------------------------------------------------------------
 
-/// Format a single entry line with numeric ID, hash, value, optional timestamp, and data suffix.
+/// Format a single entry line with numeric index, ID, value, optional timestamp, and data suffix.
 pub fn format_entry_line(
-    id: u64,
-    hash: &str,
+    index: u64,
+    id: &str,
     value: &str,
     ts: &str,
     data: &Option<serde_json::Value>,
 ) -> String {
     let data_suffix = format_data_suffix(data);
     if ts.is_empty() {
-        format!("{} [kv-{}]: {}{}", id, hash, value, data_suffix)
+        format!("{} [kv-{}]: {}{}", index, id, value, data_suffix)
     } else {
-        format!("{} [kv-{}]: {} ({}){}", id, hash, value, ts, data_suffix)
+        format!("{} [kv-{}]: {} ({}){}", index, id, value, ts, data_suffix)
     }
 }
 
@@ -2131,7 +2132,7 @@ pub fn format_value(value: &DataValue) -> String {
         DataValue::String { value } => value.clone(),
         DataValue::History { entries, .. } => entries
             .iter()
-            .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
+            .map(|e| format_entry_line(e.index, &e.id, &e.value, &e.ts, &e.data))
             .collect::<Vec<_>>()
             .join("\n"),
         DataValue::State { fields, .. } => {
@@ -2139,7 +2140,7 @@ pub fn format_value(value: &DataValue) -> String {
         }
         DataValue::List { items, .. } => items
             .iter()
-            .map(|e| format_entry_line(e.id, &e.hash, &e.value, &e.ts, &e.data))
+            .map(|e| format_entry_line(e.index, &e.id, &e.value, &e.ts, &e.data))
             .collect::<Vec<_>>()
             .join("\n"),
     }
@@ -2351,8 +2352,8 @@ max_entries = 5
                 assert_eq!(entries.len(), 3);
                 assert_eq!(entries[0].value, "d"); // newest first
                 assert_eq!(entries[2].value, "b"); // oldest kept
-                // IDs should be assigned
-                assert!(entries[0].id > 0);
+                // Indexes should be assigned
+                assert!(entries[0].index > 0);
             }
             _ => panic!("Expected history"),
         }
@@ -2702,14 +2703,14 @@ max_entries = 5
         store.push("tags", "beta", None, None).unwrap();
         store.push("tags", "gamma", None, None).unwrap();
 
-        // Get the ID of "beta"
-        let beta_id = match store.get("tags").unwrap() {
-            DataValue::List { items, .. } => items[1].id,
+        // Get the index of "beta"
+        let beta_idx = match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => items[1].index,
             _ => panic!("Expected list"),
         };
 
         let result = store
-            .remove("tags", None, Some(&IdRef::Numeric(beta_id)), false)
+            .remove("tags", None, Some(&IdRef::Index(beta_idx)), false)
             .unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "beta");
@@ -2833,17 +2834,17 @@ max_entries = 5
             .push("flavor_history", "earl grey", None, None)
             .unwrap();
 
-        // Get the ID of the second entry
-        let target_id = match store.get("flavor_history").unwrap() {
-            DataValue::History { entries, .. } => entries[1].id,
+        // Get the index of the second entry
+        let target_idx = match store.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => entries[1].index,
             _ => panic!("Expected history"),
         };
 
         let hits = store
-            .get_entries_by_id("flavor_history", &[IdRef::Numeric(target_id)])
+            .get_entries_by_id("flavor_history", &[IdRef::Index(target_idx)])
             .unwrap();
         assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].id, target_id);
+        assert_eq!(hits[0].index, target_idx);
         assert_eq!(hits[0].value, "lapsang");
     }
 
@@ -2854,17 +2855,17 @@ max_entries = 5
         store.push("tags", "beta", None, None).unwrap();
         store.push("tags", "gamma", None, None).unwrap();
 
-        // Read the actual ID of the second entry from the store
-        let target_id = match store.get("tags").unwrap() {
-            DataValue::List { items, .. } => items[1].id,
+        // Read the actual index of the second entry from the store
+        let target_idx = match store.get("tags").unwrap() {
+            DataValue::List { items, .. } => items[1].index,
             _ => panic!("Expected list"),
         };
 
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Numeric(target_id)])
+            .get_entries_by_id("tags", &[IdRef::Index(target_idx)])
             .unwrap();
         assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].id, target_id);
+        assert_eq!(hits[0].index, target_idx);
         assert_eq!(hits[0].value, "beta");
     }
 
@@ -2878,7 +2879,7 @@ max_entries = 5
         let hits = store
             .get_entries_by_id(
                 "tags",
-                &[IdRef::Numeric(1), IdRef::Numeric(2), IdRef::Numeric(3)],
+                &[IdRef::Index(1), IdRef::Index(2), IdRef::Index(3)],
             )
             .unwrap();
         assert_eq!(hits.len(), 3);
@@ -2895,7 +2896,7 @@ max_entries = 5
         store.push("tags", "gamma", None, None).unwrap();
 
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Numeric(1), IdRef::Numeric(3)])
+            .get_entries_by_id("tags", &[IdRef::Index(1), IdRef::Index(3)])
             .unwrap();
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].value, "alpha");
@@ -2912,7 +2913,7 @@ max_entries = 5
         let hits = store
             .get_entries_by_id(
                 "tags",
-                &[IdRef::Numeric(1), IdRef::Numeric(2), IdRef::Numeric(99)],
+                &[IdRef::Index(1), IdRef::Index(2), IdRef::Index(99)],
             )
             .unwrap();
         assert_eq!(hits.len(), 2);
@@ -2924,7 +2925,7 @@ max_entries = 5
         store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Numeric(99), IdRef::Numeric(100)])
+            .get_entries_by_id("tags", &[IdRef::Index(99), IdRef::Index(100)])
             .unwrap();
         assert!(hits.is_empty());
     }
@@ -2932,7 +2933,7 @@ max_entries = 5
     #[test]
     fn get_by_id_type_mismatch_counter() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.get_entries_by_id("warmth", &[IdRef::Numeric(1)]);
+        let result = store.get_entries_by_id("warmth", &[IdRef::Index(1)]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2940,7 +2941,7 @@ max_entries = 5
     #[test]
     fn get_by_id_type_mismatch_string() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.get_entries_by_id("current_mood", &[IdRef::Numeric(1)]);
+        let result = store.get_entries_by_id("current_mood", &[IdRef::Index(1)]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2948,7 +2949,7 @@ max_entries = 5
     #[test]
     fn get_by_id_type_mismatch_state() {
         let (store, _dir) = setup_store(test_schema());
-        let result = store.get_entries_by_id("tensor", &[IdRef::Numeric(1)]);
+        let result = store.get_entries_by_id("tensor", &[IdRef::Index(1)]);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
@@ -2957,7 +2958,7 @@ max_entries = 5
     fn get_by_id_empty_history() {
         let (store, _dir) = setup_store(test_schema());
         let hits = store
-            .get_entries_by_id("flavor_history", &[IdRef::Numeric(1)])
+            .get_entries_by_id("flavor_history", &[IdRef::Index(1)])
             .unwrap();
         assert!(hits.is_empty());
     }
@@ -2966,7 +2967,7 @@ max_entries = 5
     fn get_by_id_empty_list() {
         let (store, _dir) = setup_store(test_schema());
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Numeric(1)])
+            .get_entries_by_id("tags", &[IdRef::Index(1)])
             .unwrap();
         assert!(hits.is_empty());
     }
@@ -3062,11 +3063,11 @@ max_entries = 5
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
-                // Each push should get a unique ID
-                let ids: Vec<u64> = entries.iter().map(|e| e.id).collect();
-                assert_eq!(ids.len(), 3);
+                // Each push should get a unique index
+                let indexes: Vec<u64> = entries.iter().map(|e| e.index).collect();
+                assert_eq!(indexes.len(), 3);
                 // All unique
-                let mut unique = ids.clone();
+                let mut unique = indexes.clone();
                 unique.sort();
                 unique.dedup();
                 assert_eq!(unique.len(), 3);
@@ -3084,9 +3085,9 @@ max_entries = 5
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
-                assert_eq!(items[0].id, 1);
-                assert_eq!(items[1].id, 2);
-                assert_eq!(items[2].id, 3);
+                assert_eq!(items[0].index, 1);
+                assert_eq!(items[1].index, 2);
+                assert_eq!(items[2].index, 3);
             }
             _ => panic!("Expected list"),
         }
@@ -3110,9 +3111,9 @@ max_entries = 5
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
                 assert_eq!(items.len(), 3);
-                assert_eq!(items[0].id, 1); // a
-                assert_eq!(items[1].id, 3); // c
-                assert_eq!(items[2].id, 4); // d
+                assert_eq!(items[0].index, 1); // a
+                assert_eq!(items[1].index, 3); // c
+                assert_eq!(items[2].index, 4); // d
             }
             _ => panic!("Expected list"),
         }
@@ -3145,9 +3146,9 @@ max_entries = 5
                 assert_eq!(items[0].value, "alpha");
                 assert_eq!(items[1].value, "beta");
                 assert_eq!(items[2].value, "gamma");
-                // Should have auto-assigned IDs
-                assert!(items[0].id > 0);
-                assert!(items[1].id > items[0].id);
+                // Should have auto-assigned indexes
+                assert!(items[0].index > 0);
+                assert!(items[1].index > items[0].index);
                 // Timestamps should be empty (placeholder)
                 assert!(items[0].ts.is_empty());
             }
@@ -3183,10 +3184,10 @@ max_entries = 5
             DataValue::History { entries, .. } => {
                 assert_eq!(entries.len(), 2);
                 assert_eq!(entries[0].value, "bergamot");
-                // Should have auto-assigned IDs
-                assert!(entries[0].id > 0);
-                assert!(entries[1].id > 0);
-                assert_ne!(entries[0].id, entries[1].id);
+                // Should have auto-assigned indexes
+                assert!(entries[0].index > 0);
+                assert!(entries[1].index > 0);
+                assert_ne!(entries[0].index, entries[1].index);
             }
             _ => panic!("Expected history"),
         }
@@ -4840,7 +4841,7 @@ max_entries = 5
             .unwrap();
 
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Numeric(1)])
+            .get_entries_by_id("tags", &[IdRef::Index(1)])
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].data, Some(data));
@@ -4900,38 +4901,38 @@ max_entries = 5
         assert_eq!(items[0].data, Some(serde_json::json!({"x": 1})));
     }
 
-    // -- Hash ID tests --
+    // -- ID generation tests --
 
     #[test]
-    fn push_returns_push_result_with_hash_and_id() {
+    fn push_returns_push_result_with_index_and_id() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
-        assert_eq!(result.id, 1);
-        assert!(!result.hash.is_empty());
-        // Hash should be 5-6 base58 chars
-        assert!(result.hash.len() >= 4);
-        assert!(result.hash.len() <= 8);
+        assert_eq!(result.index, 1);
+        assert!(!result.id.is_empty());
+        // ID should be 5-6 base58 chars
+        assert!(result.id.len() >= 4);
+        assert!(result.id.len() <= 8);
     }
 
     #[test]
-    fn hash_is_stable_same_inputs() {
-        // generate_entry_hash is deterministic
-        let h1 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 1);
-        let h2 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 1);
+    fn id_is_stable_same_inputs() {
+        // generate_entry_id is deterministic
+        let h1 = generate_entry_id("tags", "2026-05-08T00:00:00+00:00", 1);
+        let h2 = generate_entry_id("tags", "2026-05-08T00:00:00+00:00", 1);
         assert_eq!(h1, h2);
     }
 
     #[test]
-    fn hash_is_unique_different_inputs() {
-        let h1 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 1);
-        let h2 = generate_entry_hash("tags", "2026-05-08T00:00:00+00:00", 2);
-        let h3 = generate_entry_hash("other", "2026-05-08T00:00:00+00:00", 1);
+    fn id_is_unique_different_inputs() {
+        let h1 = generate_entry_id("tags", "2026-05-08T00:00:00+00:00", 1);
+        let h2 = generate_entry_id("tags", "2026-05-08T00:00:00+00:00", 2);
+        let h3 = generate_entry_id("other", "2026-05-08T00:00:00+00:00", 1);
         assert_ne!(h1, h2);
         assert_ne!(h1, h3);
     }
 
     #[test]
-    fn backfill_old_entries_get_hashes_on_load() {
+    fn backfill_old_entries_get_ids_on_load() {
         let dir = TempDir::new().unwrap();
         let schema_path = dir.path().join("test.schema.toml");
         let data_path = dir.path().join("test.data.json");
@@ -4939,7 +4940,7 @@ max_entries = 5
         let mut f = fs::File::create(&schema_path).unwrap();
         f.write_all(test_schema().as_bytes()).unwrap();
 
-        // Write old-format data with no hash field
+        // Write old-format data with no hash field (on disk "id" is the numeric index)
         let old_data = r#"{
             "_schema": "test",
             "_updated": "2026-05-08T00:00:00+00:00",
@@ -4955,49 +4956,49 @@ max_entries = 5
         let store = KvStore::load(&schema_path, &data_path).unwrap();
         match store.data.entries.get("tags").unwrap() {
             DataValue::List { items, .. } => {
-                assert!(!items[0].hash.is_empty(), "hash should be back-filled");
-                assert!(!items[1].hash.is_empty(), "hash should be back-filled");
-                // Hashes should differ
-                assert_ne!(items[0].hash, items[1].hash);
+                assert!(!items[0].id.is_empty(), "id should be back-filled");
+                assert!(!items[1].id.is_empty(), "id should be back-filled");
+                // IDs should differ
+                assert_ne!(items[0].id, items[1].id);
             }
             _ => panic!("Expected list"),
         }
     }
 
     #[test]
-    fn get_by_numeric_id_still_works() {
+    fn get_by_numeric_index_still_works() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Numeric(result.id)])
+            .get_entries_by_id("tags", &[IdRef::Index(result.index)])
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].value, "alpha");
     }
 
     #[test]
-    fn get_by_hash_works() {
+    fn get_by_id_works() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Hash(result.hash.clone())])
+            .get_entries_by_id("tags", &[IdRef::Id(result.id.clone())])
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].value, "alpha");
-        assert_eq!(hits[0].hash, result.hash);
+        assert_eq!(hits[0].id, result.id);
     }
 
     #[test]
-    fn get_by_hash_prefix_works() {
+    fn get_by_id_prefix_works() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         // Use first 3 chars as prefix
-        let prefix = &result.hash[..3];
+        let prefix = &result.id[..3];
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Hash(prefix.to_string())])
+            .get_entries_by_id("tags", &[IdRef::Id(prefix.to_string())])
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].value, "alpha");
@@ -5012,21 +5013,21 @@ max_entries = 5
         let hits = store
             .get_entries_by_id(
                 "tags",
-                &[IdRef::Numeric(r1.id), IdRef::Hash(r2.hash.clone())],
+                &[IdRef::Index(r1.index), IdRef::Id(r2.id.clone())],
             )
             .unwrap();
         assert_eq!(hits.len(), 2);
     }
 
     #[test]
-    fn remove_by_hash_works() {
+    fn remove_by_id_works() {
         let (mut store, _dir) = setup_store(test_schema());
         store.push("tags", "alpha", None, None).unwrap();
         let r2 = store.push("tags", "beta", None, None).unwrap();
         store.push("tags", "gamma", None, None).unwrap();
 
         let result = store
-            .remove("tags", None, Some(&IdRef::Hash(r2.hash.clone())), false)
+            .remove("tags", None, Some(&IdRef::Id(r2.id.clone())), false)
             .unwrap();
         assert_eq!(result.removed.len(), 1);
         assert_eq!(result.removed[0], "beta");
@@ -5043,22 +5044,22 @@ max_entries = 5
     }
 
     #[test]
-    fn remove_by_ambiguous_hash_prefix_errors() {
+    fn remove_by_ambiguous_id_prefix_errors() {
         let (mut store, _dir) = setup_store(test_schema());
         store.push("tags", "alpha", None, None).unwrap();
         store.push("tags", "beta", None, None).unwrap();
 
-        // Manually set both entries to share a hash prefix.
+        // Manually set both entries to share an ID prefix.
         match store.data.entries.get_mut("tags").unwrap() {
             DataValue::List { items, .. } => {
-                items[0].hash = "ABCxyz1".to_string();
-                items[1].hash = "ABCxyz2".to_string();
+                items[0].id = "ABCxyz1".to_string();
+                items[1].id = "ABCxyz2".to_string();
             }
             _ => panic!("Expected list"),
         }
 
         // Removing by the shared prefix "ABC" should return an ambiguity error.
-        let result = store.remove("tags", None, Some(&IdRef::Hash("ABC".to_string())), false);
+        let result = store.remove("tags", None, Some(&IdRef::Id("ABC".to_string())), false);
         assert!(result.is_err(), "expected ambiguity error");
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -5074,40 +5075,40 @@ max_entries = 5
     }
 
     #[test]
-    fn hash_appears_in_last_output() {
+    fn id_appears_in_last_output() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         let items = store.last("tags", 1, None, &[]).unwrap();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].hash, result.hash);
+        assert_eq!(items[0].id, result.id);
     }
 
     #[test]
-    fn hash_appears_in_search_output() {
+    fn id_appears_in_search_output() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         let hits = store.search("tags", Some("alpha"), None, &[]).unwrap();
         assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].hash, result.hash);
+        assert_eq!(hits[0].id, result.id);
     }
 
     #[test]
-    fn hash_stored_on_entry_structs() {
+    fn id_stored_on_entry_structs() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
-                assert_eq!(items[0].hash, result.hash);
+                assert_eq!(items[0].id, result.id);
             }
             _ => panic!("Expected list"),
         }
     }
 
     #[test]
-    fn hash_stored_on_history_entry() {
+    fn id_stored_on_history_entry() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store
             .push("flavor_history", "bergamot", None, None)
@@ -5115,14 +5116,14 @@ max_entries = 5
 
         match store.get("flavor_history").unwrap() {
             DataValue::History { entries, .. } => {
-                assert_eq!(entries[0].hash, result.hash);
+                assert_eq!(entries[0].id, result.id);
             }
             _ => panic!("Expected history"),
         }
     }
 
     #[test]
-    fn hash_persists_through_save_load() {
+    fn id_persists_through_save_load() {
         let dir = TempDir::new().unwrap();
         let schema_path = dir.path().join("test.schema.toml");
         let data_path = dir.path().join("test.data.json");
@@ -5130,19 +5131,19 @@ max_entries = 5
         let mut f = fs::File::create(&schema_path).unwrap();
         f.write_all(test_schema().as_bytes()).unwrap();
 
-        let hash;
+        let saved_id;
         {
             let mut store = KvStore::load(&schema_path, &data_path).unwrap();
             let result = store.push("tags", "alpha", None, None).unwrap();
-            hash = result.hash;
+            saved_id = result.id;
             store.save().unwrap();
         }
 
-        // Reload and verify hash persisted
+        // Reload and verify ID persisted
         let store2 = KvStore::load(&schema_path, &data_path).unwrap();
         match store2.data.entries.get("tags").unwrap() {
             DataValue::List { items, .. } => {
-                assert_eq!(items[0].hash, hash);
+                assert_eq!(items[0].id, saved_id);
             }
             _ => panic!("Expected list"),
         }
@@ -5199,14 +5200,14 @@ max_entries = 5
     }
 
     #[test]
-    fn set_entry_memory_by_numeric_id() {
+    fn set_entry_memory_by_numeric_index() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         store
             .set_entry_memory(
                 "tags",
-                &IdRef::Numeric(result.id),
+                &IdRef::Index(result.index),
                 Some("kn-set1".to_string()),
             )
             .unwrap();
@@ -5220,21 +5221,21 @@ max_entries = 5
     }
 
     #[test]
-    fn set_entry_memory_by_hash() {
+    fn set_entry_memory_by_id() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store.push("tags", "alpha", None, None).unwrap();
 
         store
             .set_entry_memory(
                 "tags",
-                &IdRef::Hash(result.hash.clone()),
-                Some("kn-hash1".to_string()),
+                &IdRef::Id(result.id.clone()),
+                Some("kn-id1".to_string()),
             )
             .unwrap();
 
         match store.get("tags").unwrap() {
             DataValue::List { items, .. } => {
-                assert_eq!(items[0].memory, Some("kn-hash1".to_string()));
+                assert_eq!(items[0].memory, Some("kn-id1".to_string()));
             }
             _ => panic!("Expected list"),
         }
@@ -5245,13 +5246,13 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         store.push("tags", "alpha", None, None).unwrap();
 
-        let result = store.set_entry_memory("tags", &IdRef::Numeric(999), Some("kn-x".to_string()));
+        let result = store.set_entry_memory("tags", &IdRef::Index(999), Some("kn-x".to_string()));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Entry not found"));
     }
 
     #[test]
-    fn set_entry_memory_history_by_numeric_id() {
+    fn set_entry_memory_history_by_numeric_index() {
         let (mut store, _dir) = setup_store(test_schema());
         let result = store
             .push("flavor_history", "bergamot", None, None)
@@ -5260,7 +5261,7 @@ max_entries = 5
         store
             .set_entry_memory(
                 "flavor_history",
-                &IdRef::Numeric(result.id),
+                &IdRef::Index(result.index),
                 Some("kn-hist-set".to_string()),
             )
             .unwrap();
@@ -5357,7 +5358,7 @@ max_entries = 5
 
         // Set memory to empty string should clear it
         store
-            .set_entry_memory("tags", &IdRef::Numeric(result.id), Some("".to_string()))
+            .set_entry_memory("tags", &IdRef::Index(result.index), Some("".to_string()))
             .unwrap();
 
         match store.get("tags").unwrap() {
@@ -5377,7 +5378,7 @@ max_entries = 5
         store.push("tags", "without", None, None).unwrap();
 
         let hits = store
-            .get_entries_by_id("tags", &[IdRef::Numeric(r1.id)])
+            .get_entries_by_id("tags", &[IdRef::Index(r1.index)])
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].memory, Some("kn-byid1".to_string()));
@@ -5388,22 +5389,22 @@ max_entries = 5
         let (mut store, _dir) = setup_store(test_schema());
         store.inc("warmth", 1).unwrap();
 
-        let result = store.set_entry_memory("warmth", &IdRef::Numeric(1), Some("kn-x".to_string()));
+        let result = store.set_entry_memory("warmth", &IdRef::Index(1), Some("kn-x".to_string()));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Type mismatch"));
     }
 
     #[test]
-    fn set_entry_memory_ambiguous_hash_prefix_errors() {
+    fn set_entry_memory_ambiguous_id_prefix_errors() {
         let (mut store, _dir) = setup_store(test_schema());
         store.push("tags", "alpha", None, None).unwrap();
         store.push("tags", "beta", None, None).unwrap();
 
-        // Manually set both entries to share a hash prefix.
+        // Manually set both entries to share an ID prefix.
         match store.data.entries.get_mut("tags").unwrap() {
             DataValue::List { items, .. } => {
-                items[0].hash = "XYZaaa1".to_string();
-                items[1].hash = "XYZaaa2".to_string();
+                items[0].id = "XYZaaa1".to_string();
+                items[1].id = "XYZaaa2".to_string();
             }
             _ => panic!("Expected list"),
         }
@@ -5411,7 +5412,7 @@ max_entries = 5
         // Setting memory by the shared prefix "XYZ" should return an ambiguity error.
         let result = store.set_entry_memory(
             "tags",
-            &IdRef::Hash("XYZ".to_string()),
+            &IdRef::Id("XYZ".to_string()),
             Some("kn-x".to_string()),
         );
         assert!(result.is_err(), "expected ambiguity error");

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -118,7 +118,7 @@ pub enum KvError {
         key: String,
         id: String,
     },
-    AmbiguousHash {
+    AmbiguousId {
         prefix: String,
         count: usize,
     },
@@ -142,10 +142,10 @@ impl std::fmt::Display for KvError {
             KvError::EntryNotFound { key, id } => {
                 write!(f, "Entry not found: ID {} in key '{}'", id, key)
             }
-            KvError::AmbiguousHash { prefix, count } => {
+            KvError::AmbiguousId { prefix, count } => {
                 write!(
                     f,
-                    "hash prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
+                    "ID prefix 'kv-{}' is ambiguous: matches {} entries, provide more characters",
                     prefix, count
                 )
             }
@@ -1278,7 +1278,7 @@ impl KvStore {
                                 0 => None,
                                 1 => Some(matches[0]),
                                 n => {
-                                    return Err(KvError::AmbiguousHash {
+                                    return Err(KvError::AmbiguousId {
                                         prefix: h.clone(),
                                         count: n,
                                     });
@@ -1317,7 +1317,7 @@ impl KvStore {
                                 0 => None,
                                 1 => Some(matches[0]),
                                 n => {
-                                    return Err(KvError::AmbiguousHash {
+                                    return Err(KvError::AmbiguousId {
                                         prefix: h.clone(),
                                         count: n,
                                     });
@@ -1428,7 +1428,7 @@ impl KvStore {
         Ok(hits)
     }
 
-    /// Look up entries by index (numeric) or ID (stable hash) in a history or list.
+    /// Look up entries by index (numeric) or ID (stable ID) in a history or list.
     ///
     /// Returns matching entries as `SearchHit`s (same struct used by `search`).
     /// ID matching is prefix-based: `"A3f"` matches an entry with ID `"A3fBx2"`.
@@ -1716,7 +1716,7 @@ impl KvStore {
                                 entries.iter_mut().find(|e| e.id.starts_with(h.as_str()))
                             }
                             n => {
-                                return Err(KvError::AmbiguousHash {
+                                return Err(KvError::AmbiguousId {
                                     prefix: h.clone(),
                                     count: n,
                                 });
@@ -1747,7 +1747,7 @@ impl KvStore {
                             0 => None,
                             1 => items.iter_mut().find(|e| e.id.starts_with(h.as_str())),
                             n => {
-                                return Err(KvError::AmbiguousHash {
+                                return Err(KvError::AmbiguousId {
                                     prefix: h.clone(),
                                     count: n,
                                 });

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -967,7 +967,10 @@ impl KvStore {
                         if let Some(max) = def.max_entries {
                             entries.truncate(max);
                         }
-                        Ok(PushResult { index: next_idx, id })
+                        Ok(PushResult {
+                            index: next_idx,
+                            id,
+                        })
                     }
                     _ => Err(KvError::Other(anyhow::anyhow!(
                         "Data corruption: key '{}' has wrong runtime type",
@@ -1000,7 +1003,10 @@ impl KvStore {
                         {
                             items.drain(0..items.len() - max);
                         }
-                        Ok(PushResult { index: next_idx, id })
+                        Ok(PushResult {
+                            index: next_idx,
+                            id,
+                        })
                     }
                     _ => Err(KvError::Other(anyhow::anyhow!(
                         "Data corruption: key '{}' has wrong runtime type",
@@ -2877,10 +2883,7 @@ max_entries = 5
         store.push("tags", "gamma", None, None).unwrap();
 
         let hits = store
-            .get_entries_by_id(
-                "tags",
-                &[IdRef::Index(1), IdRef::Index(2), IdRef::Index(3)],
-            )
+            .get_entries_by_id("tags", &[IdRef::Index(1), IdRef::Index(2), IdRef::Index(3)])
             .unwrap();
         assert_eq!(hits.len(), 3);
         assert_eq!(hits[0].value, "alpha");
@@ -2966,9 +2969,7 @@ max_entries = 5
     #[test]
     fn get_by_id_empty_list() {
         let (store, _dir) = setup_store(test_schema());
-        let hits = store
-            .get_entries_by_id("tags", &[IdRef::Index(1)])
-            .unwrap();
+        let hits = store.get_entries_by_id("tags", &[IdRef::Index(1)]).unwrap();
         assert!(hits.is_empty());
     }
 
@@ -4840,9 +4841,7 @@ max_entries = 5
             .push("tags", "item", Some(data.clone()), None)
             .unwrap();
 
-        let hits = store
-            .get_entries_by_id("tags", &[IdRef::Index(1)])
-            .unwrap();
+        let hits = store.get_entries_by_id("tags", &[IdRef::Index(1)]).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].data, Some(data));
     }
@@ -5011,10 +5010,7 @@ max_entries = 5
         let r2 = store.push("tags", "beta", None, None).unwrap();
 
         let hits = store
-            .get_entries_by_id(
-                "tags",
-                &[IdRef::Index(r1.index), IdRef::Id(r2.id.clone())],
-            )
+            .get_entries_by_id("tags", &[IdRef::Index(r1.index), IdRef::Id(r2.id.clone())])
             .unwrap();
         assert_eq!(hits.len(), 2);
     }


### PR DESCRIPTION
Closes #310

## Summary

Renames kv entry fields to match semantics — numeric `id` becomes `index` (sequence number), `hash` becomes `id` (stable unique identifier). Pure refactor, zero behavior change.

- On-disk JSON format unchanged via `serde(rename)`
- `IdRef` variants renamed to `Index`/`Id`
- `generate_entry_hash` → `generate_entry_id`

**Files:** `src/kv.rs`, `src/handlers/kv.rs`

## Test plan

- [x] 863 tests passing, zero assertion changes
- [x] No CLI flag changes
- [x] No output format changes
- [x] No data migration required