### PR TITLE
kv: --json output for entry-returning commands (#312)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ mx kv random shipped --count 3 --since 30d
 mx kv push decisions "adopted memory links" --memory kn-abc123
 mx kv set decisions --id 17 --memory kn-abc123
 mx kv last decisions --count 3 --memory
+
+# JSON output for scripting and jq piping
+mx kv last projects --count 5 --json | jq '.[].data.status'
+mx kv search projects --where status=active --json | jq 'map(.value)'
+mx kv count shipped --json | jq '.count'
 ```
 
 Every entry gets a stable entry ID (e.g. `kv-A3fB`) alongside its numeric index. Push prints both: `kv-A3fB (42)`. Anywhere a numeric index works, an entry ID also works -- `--id kv-A3fB`, mixed comma lists, remove. Ranges remain numeric only. Old data files are back-filled on first load.

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -648,6 +648,13 @@ prefix, which wins over the key-level fallback. The `SearchHit` struct
 (returned by `last`, `random`, `search`, `since`, and `get --id`) carries the
 per-entry `memory` field for the handler to resolve.
 
+`SearchHit` derives `serde::Serialize` to support the `--json` output flag.
+The serialized field names are the Rust struct names (`index`, `id`, `value`,
+`ts`, `data`, `memory`) -- deliberately different from the on-disk
+`serde(rename)` aliases used by `HistoryEntry` and `ListEntry`. The `data`
+and `memory` fields use `#[serde(skip_serializing_if = "Option::is_none")]`
+so they are omitted from JSON output when not set.
+
 
 // =========================================================================
 // BASE-D INTEGRATION

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -155,6 +155,10 @@ mx kv push projects "palmtop DSI fix" \
   --data '{"tags":["palmtop","i915"],"status":"active"}'
 mx kv search projects --where status=active
 mx kv search projects "DSI" --where tags=palmtop
+
+# JSON output for scripting and jq piping
+mx kv last projects --count 5 --json | jq '.[].data.status'
+mx kv count shipped --json | jq '.count'
 ```
 
 === State

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -79,6 +79,7 @@ mx kv push projects "palmtop DSI fix" \
 mx kv search projects --where status=active
 mx kv push decisions "adopted memory links" --memory kn-abc123
 mx kv set decisions --id 17 --memory kn-abc123
+mx kv last projects --count 5 --json | jq '.[].data.status'
 ```
 
 == Installation

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -138,6 +138,7 @@ KV commands use structured exit codes for scripting:
   flags: (
     ([`--id <spec>`], [string], [Entry identifier: numeric index (`35`), entry ID (`kv-A3fB`), range (`35-64`), or comma-separated (`1,kv-A3fB,12`)]),
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--json`], [flag], [Output as JSON. Collections emit a JSON array of entry objects. Scalars emit `{"value": "..."}`. Memory resolution is skipped in JSON mode; the raw `kn-` ID is included in each entry's `memory` field.]),
   ),
   examples: (
     "mx kv get session_goal",
@@ -149,6 +150,8 @@ KV commands use structured exit codes for scripting:
     "mx kv get shipped --id 35-64",
     "mx kv get shipped --id 1,kv-A3fB,12",
     "mx kv get shipped --id 35 --memory",
+    "mx kv get shipped --id 42 --json",
+    "mx kv get shipped --json",
   ),
 )
 
@@ -340,6 +343,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   flags: (
     ([`--count <n>`], [integer], [Number of entries to return (default: 1)]),
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--json`], [flag], [Output as a JSON array of entry objects]),
     ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Entries from a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Entries from a specific month (UTC)]),
@@ -358,6 +362,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv last shipped --since 1w",
     "mx kv last projects --where status=active",
     "mx kv last projects --where status=active --count 3",
+    "mx kv last projects --count 5 --json",
   ),
 )
 
@@ -374,12 +379,14 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   Entries are printed with their numeric index, entry ID, value, and timestamp.],
   flags: (
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--json`], [flag], [Output as a JSON array of entry objects]),
   ),
   examples: (
     "mx kv since decisions 1h",
     "mx kv since decisions 7d",
     "mx kv since decisions 2w --memory",
     "mx kv since decisions 2025-01-15T10:00:00Z",
+    "mx kv since shipped 1w --json",
   ),
 )
 
@@ -402,6 +409,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   See #link(<time-range-queries>)[Time-range queries] for details.],
   flags: (
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--json`], [flag], [Output as a JSON array of entry objects]),
     ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Search within a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Search within a specific month (UTC)]),
@@ -418,6 +426,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv search projects --where status=active",
     "mx kv search projects \"DSI\" --where status=active",
     "mx kv search projects --where tags=palmtop --where status=active",
+    "mx kv search projects --where status=active --json",
   ),
 )
 
@@ -443,6 +452,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   Time-range flags restrict the count to entries within the specified period.
   See #link(<time-range-queries>)[Time-range queries] for details.],
   flags: (
+    ([`--json`], [flag], [Output as JSON: `{"count": N}` with optional `total` and `latest_ts` fields when filtering is active]),
     ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Count within a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Count within a specific month (UTC)]),
@@ -460,6 +470,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv count shipped --since 1w",
     "mx kv count projects --where status=active",
     "mx kv count projects --where status=active --since 30d",
+    "mx kv count shipped --json",
   ),
 )
 
@@ -483,6 +494,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
   flags: (
     ([`--count <n>`], [integer], [Number of random entries to return (default: 1, must be >= 1)]),
     ([`--memory`], [flag], [Resolve and display any linked memory entry]),
+    ([`--json`], [flag], [Output as a JSON array of entry objects]),
     ([`--where <key=value>`], [string], [Filter by structured data field (repeatable, ANDed). Top-level fields only.]),
     ([`--day <YYYY-MM-DD>`], [string], [Sample from entries on a specific day (UTC)]),
     ([`--month <YYYY-MM>`], [string], [Sample from entries in a specific month (UTC)]),
@@ -498,6 +510,7 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv random shipped --count 3 --since 30d",
     "mx kv random decisions --month 2026-04 --count 3",
     "mx kv random projects --where status=active --count 3",
+    "mx kv random ideas --count 3 --json",
   ),
 )
 
@@ -913,3 +926,91 @@ links are supplementary context.
 
 #note[Memory links are only available on history, list, and state types.
 String and counter keys do not support `--memory`.]
+
+== JSON output <json-output>
+
+The `--json` flag outputs results as pretty-printed JSON instead of the
+human-readable format. It is available on six commands: `get`, `last`,
+`search`, `random`, `since`, and `count`.
+
+JSON output is designed for scripting and piping to tools like `jq`. When
+`--json` is active, human formatting is skipped and `--memory` resolution
+is not performed -- the raw `kn-` ID is included in each entry's `memory`
+field for the caller to resolve if needed.
+
+=== Entry format
+
+Commands that return entries (`get`, `last`, `search`, `random`, `since`)
+emit a JSON array of entry objects. Each object has this shape:
+
+```json
+{
+  "index": 42,
+  "id": "A3fB",
+  "value": "palmtop DSI fix",
+  "ts": "2026-05-08T14:30:00+00:00",
+  "data": {"status": "active", "tags": ["palmtop", "i915"]},
+  "memory": "kn-e1f646aa"
+}
+```
+
+/ `index`: Numeric sequence index (integer).
+/ `id`: Stable entry ID (base58 string, without the `kv-` prefix).
+/ `value`: The entry's text value.
+/ `ts`: Timestamp in ISO-8601 format.
+/ `data`: Structured data object, omitted when the entry has no data.
+/ `memory`: Per-entry memory link (`kn-` ID), omitted when not set.
+
+The `data` and `memory` fields are omitted entirely (not `null`) when they
+have no value. This keeps the output clean and avoids forcing callers to
+handle nulls.
+
+=== Special output shapes
+
+`get --json` without `--id` adapts to the key type:
+
+- *History and list keys:* JSON array of all entries (same format as above).
+- *Scalar keys* (string, counter, state): `{"value": "..."}` -- the
+  formatted value as a string.
+
+`count --json` emits a count object:
+
+```json
+{"count": 12}
+```
+
+When filtering is active (value substring, `--where`, or time range), the
+object includes additional context:
+
+```json
+{"count": 5, "total": 12, "latest_ts": "2026-05-08T14:30:00+00:00"}
+```
+
+/ `count`: Number of matched entries (always present).
+/ `total`: Total entries before filtering (present when filtering).
+/ `latest_ts`: Timestamp of the most recent matched entry (present when filtering).
+
+=== Piping to `jq`
+
+The primary use case for `--json` is piping to `jq` for complex queries
+that go beyond what `--where` provides:
+
+```bash
+# Extract all status values
+mx kv last projects --json | jq '.[].data.status'
+
+# Filter by a nested condition
+mx kv search projects --where status=active --json \
+  | jq 'map(select(.data.tags | contains(["rust"])))'
+
+# Get the count as a bare number
+mx kv count shipped --json | jq '.count'
+
+# Build a CSV of shipped items
+mx kv last shipped --count 100 --json \
+  | jq -r '.[] | [.index, .id, .value, .ts] | @csv'
+```
+
+#note[`--json` is available on `get`, `last`, `search`, `random`, `since`,
+and `count`. It is not available on `push`, `pop`, `set`, `inc`, `dec`,
+`remove`, `reset`, `keys`, or `dump` (which already has `--format json`).]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1693,6 +1693,10 @@ pub enum KvCommands {
         /// Resolve and display linked memory entry (kn- reference)
         #[arg(long)]
         memory: bool,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Set a value (string/counter), or set a field on a state type
@@ -1779,6 +1783,10 @@ pub enum KvCommands {
         #[arg(long)]
         memory: bool,
 
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+
         /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]
         where_clauses: Vec<String>,
@@ -1798,6 +1806,10 @@ pub enum KvCommands {
         /// Resolve and display linked memory entry (kn- reference)
         #[arg(long)]
         memory: bool,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Dump all state
@@ -1846,6 +1858,10 @@ pub enum KvCommands {
         #[arg(long)]
         memory: bool,
 
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+
         /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]
         where_clauses: Vec<String>,
@@ -1867,6 +1883,10 @@ pub enum KvCommands {
         #[arg(long)]
         memory: bool,
 
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+
         /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]
         where_clauses: Vec<String>,
@@ -1882,6 +1902,10 @@ pub enum KvCommands {
 
         /// Count only entries matching this substring
         value: Option<String>,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
 
         /// Filter by structured data fields (key=value, top-level fields only, repeatable)
         #[arg(long = "where")]

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -283,8 +283,41 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 match store.get(&key) {
                     Ok(val) => {
                         if json {
-                            let json_val = serde_json::json!({"value": kv::format_value(val)});
-                            println!("{}", serde_json::to_string_pretty(&json_val)?);
+                            match val {
+                                kv::DataValue::History { entries, .. } => {
+                                    let hits: Vec<kv::SearchHit> = entries
+                                        .iter()
+                                        .map(|e| kv::SearchHit {
+                                            index: e.index,
+                                            id: e.id.clone(),
+                                            value: e.value.clone(),
+                                            ts: e.ts.clone(),
+                                            data: e.data.clone(),
+                                            memory: e.memory.clone(),
+                                        })
+                                        .collect();
+                                    println!("{}", serde_json::to_string_pretty(&hits)?);
+                                }
+                                kv::DataValue::List { items, .. } => {
+                                    let hits: Vec<kv::SearchHit> = items
+                                        .iter()
+                                        .map(|e| kv::SearchHit {
+                                            index: e.index,
+                                            id: e.id.clone(),
+                                            value: e.value.clone(),
+                                            ts: e.ts.clone(),
+                                            data: e.data.clone(),
+                                            memory: e.memory.clone(),
+                                        })
+                                        .collect();
+                                    println!("{}", serde_json::to_string_pretty(&hits)?);
+                                }
+                                _ => {
+                                    let json_val =
+                                        serde_json::json!({"value": kv::format_value(val)});
+                                    println!("{}", serde_json::to_string_pretty(&json_val)?);
+                                }
+                            }
                             return Ok(kv::EXIT_OK);
                         }
                         println!("{}", kv::format_value(val));
@@ -588,7 +621,18 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         } => match store.since(&key, &timeref) {
             Ok(entries) => {
                 if json {
-                    println!("{}", serde_json::to_string_pretty(&entries)?);
+                    let hits: Vec<kv::SearchHit> = entries
+                        .iter()
+                        .map(|e| kv::SearchHit {
+                            index: e.index,
+                            id: e.id.clone(),
+                            value: e.value.clone(),
+                            ts: e.ts.clone(),
+                            data: e.data.clone(),
+                            memory: e.memory.clone(),
+                        })
+                        .collect();
+                    println!("{}", serde_json::to_string_pretty(&hits)?);
                     return Ok(kv::EXIT_OK);
                 }
                 for entry in &entries {
@@ -756,7 +800,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             match store.count(&key, value.as_deref(), range.as_ref(), &parsed_where) {
                 Ok(result) => {
                     if json {
-                        let json_val = serde_json::json!({"count": result.matched});
+                        let mut json_val = serde_json::json!({"count": result.matched});
+                        if let Some(total) = result.total {
+                            json_val["total"] = serde_json::json!(total);
+                        }
+                        if let Some(ref ts) = result.latest_ts {
+                            json_val["latest_ts"] = serde_json::json!(ts);
+                        }
                         println!("{}", serde_json::to_string_pretty(&json_val)?);
                         return Ok(kv::EXIT_OK);
                     }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -209,7 +209,12 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
     };
 
     match cmd {
-        KvCommands::Get { key, id, memory } => {
+        KvCommands::Get {
+            key,
+            id,
+            memory,
+            json,
+        } => {
             if let Some(id_spec) = id {
                 // ID-based entry lookup on history/list
                 let ids = match parse_id_spec(&id_spec) {
@@ -221,6 +226,11 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 };
                 match store.get_entries_by_id(&key, &ids) {
                     Ok(hits) => {
+                        if json {
+                            println!("{}", serde_json::to_string_pretty(&hits)?);
+                            return Ok(kv::EXIT_OK);
+                        }
+
                         for hit in &hits {
                             println!(
                                 "{}",
@@ -272,6 +282,11 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 // Original scalar get behavior
                 match store.get(&key) {
                     Ok(val) => {
+                        if json {
+                            let json_val = serde_json::json!({"value": kv::format_value(val)});
+                            println!("{}", serde_json::to_string_pretty(&json_val)?);
+                            return Ok(kv::EXIT_OK);
+                        }
                         println!("{}", kv::format_value(val));
                         if memory {
                             resolve_memory(&store, &key, verbose);
@@ -477,6 +492,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             key,
             count,
             memory,
+            json,
             where_clauses,
             time_range,
         } => {
@@ -490,6 +506,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             };
             match store.last(&key, count, range.as_ref(), &parsed_where) {
                 Ok(hits) => {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&hits)?);
+                        return Ok(kv::EXIT_OK);
+                    }
                     for hit in &hits {
                         println!(
                             "{}",
@@ -518,6 +538,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             key,
             count,
             memory,
+            json,
             where_clauses,
             time_range,
         } => {
@@ -531,6 +552,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             };
             match store.random(&key, count, range.as_ref(), &parsed_where) {
                 Ok(hits) => {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&hits)?);
+                        return Ok(kv::EXIT_OK);
+                    }
                     for hit in &hits {
                         println!(
                             "{}",
@@ -559,8 +584,13 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             key,
             timeref,
             memory,
+            json,
         } => match store.since(&key, &timeref) {
             Ok(entries) => {
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&entries)?);
+                    return Ok(kv::EXIT_OK);
+                }
                 for entry in &entries {
                     println!(
                         "{}",
@@ -654,6 +684,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             key,
             query,
             memory,
+            json,
             where_clauses,
             time_range,
         } => {
@@ -674,6 +705,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
 
             match store.search(&key, query.as_deref(), range.as_ref(), &parsed_where) {
                 Ok(hits) => {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&hits)?);
+                        return Ok(kv::EXIT_OK);
+                    }
                     if hits.is_empty() {
                         eprintln!("No matching entries");
                         Ok(kv::EXIT_OK)
@@ -706,6 +741,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
         KvCommands::Count {
             key,
             value,
+            json,
             where_clauses,
             time_range,
         } => {
@@ -719,6 +755,11 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             };
             match store.count(&key, value.as_deref(), range.as_ref(), &parsed_where) {
                 Ok(result) => {
+                    if json {
+                        let json_val = serde_json::json!({"count": result.matched});
+                        println!("{}", serde_json::to_string_pretty(&json_val)?);
+                        return Ok(kv::EXIT_OK);
+                    }
                     match result.total {
                         Some(total) => {
                             // Filtered: show matched/total (pct%) — latest: ...

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -5767,4 +5767,113 @@ max_entries = 5
             "should NOT use on-disk 'h' alias"
         );
     }
+
+    #[test]
+    fn since_json_uses_search_hit_field_names() {
+        // Verify that converting HistoryEntry to SearchHit for since --json
+        // produces "index" and "id" field names, not the on-disk renames
+        // ("id" for index, "hash" for id) that HistoryEntry uses.
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let ts = Utc::now() - chrono::Duration::minutes(5);
+        store
+            .push_with_ts("flavor_history", "recent_flavor", ts, None, None)
+            .unwrap();
+
+        let entries = store.since("flavor_history", "1h").unwrap();
+        assert_eq!(entries.len(), 1);
+
+        // Convert to SearchHit (same transform the handler does)
+        let hits: Vec<SearchHit> = entries
+            .iter()
+            .map(|e| SearchHit {
+                index: e.index,
+                id: e.id.clone(),
+                value: e.value.clone(),
+                ts: e.ts.clone(),
+                data: e.data.clone(),
+                memory: e.memory.clone(),
+            })
+            .collect();
+
+        let json_str = serde_json::to_string_pretty(&hits).unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        let obj = &parsed[0];
+
+        // Must have "index" (numeric) and "id" (string hash)
+        assert!(
+            obj.get("index").is_some(),
+            "should have 'index' field, got: {}",
+            json_str
+        );
+        assert!(
+            obj.get("id").is_some(),
+            "should have 'id' field, got: {}",
+            json_str
+        );
+        assert!(obj["index"].is_number(), "index should be a number");
+        assert!(obj["id"].is_string(), "id should be a string (hash)");
+
+        // Must NOT have the on-disk rename aliases
+        assert!(
+            obj.get("hash").is_none(),
+            "should NOT have 'hash' field (on-disk alias for id)"
+        );
+
+        // "id" should be the hash, not the numeric index
+        assert_eq!(obj["value"], "recent_flavor");
+    }
+
+    #[test]
+    fn count_json_includes_total_and_latest_ts() {
+        // Verify the count result carries total and latest_ts for filtered queries
+        // so that --json output can include them.
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let ts1 = DateTime::parse_from_rfc3339("2026-04-20T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let ts2 = DateTime::parse_from_rfc3339("2026-04-22T15:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        store
+            .push_with_ts("flavor_history", "bergamot", ts1, None, None)
+            .unwrap();
+        store
+            .push_with_ts("flavor_history", "lapsang", ts1, None, None)
+            .unwrap();
+        store
+            .push_with_ts("flavor_history", "bergamot earl grey", ts2, None, None)
+            .unwrap();
+
+        let result = store
+            .count("flavor_history", Some("bergamot"), None, &[])
+            .unwrap();
+
+        // Build JSON the same way the handler does
+        let mut json_val = serde_json::json!({"count": result.matched});
+        if let Some(total) = result.total {
+            json_val["total"] = serde_json::json!(total);
+        }
+        if let Some(ref ts) = result.latest_ts {
+            json_val["latest_ts"] = serde_json::json!(ts);
+        }
+
+        let obj: serde_json::Value = json_val;
+
+        assert_eq!(obj["count"], 2, "2 entries match 'bergamot'");
+        assert_eq!(obj["total"], 3, "3 total entries");
+        assert!(
+            obj.get("latest_ts").is_some(),
+            "should include latest_ts for filtered count"
+        );
+        let latest = obj["latest_ts"].as_str().unwrap();
+        assert!(
+            latest.contains("2026-04-22"),
+            "latest_ts should be the most recent matching entry"
+        );
+    }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -409,13 +409,15 @@ pub struct RemoveResult {
 }
 
 /// Search result entry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct SearchHit {
     pub index: u64,
     pub id: String,
     pub value: String,
     pub ts: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<String>,
 }
 
@@ -5655,5 +5657,102 @@ max_entries = 5
         let store2 = KvStore::load(&schema_path, &data_path).unwrap();
         assert!(store2.schema.keys.contains_key("existing"));
         assert!(store2.schema.keys.contains_key("newkey"));
+    }
+
+    // -- SearchHit JSON serialization --
+
+    #[test]
+    fn search_hit_serializes_all_fields() {
+        let hit = SearchHit {
+            index: 7,
+            id: "A3fB".to_string(),
+            value: "test entry".to_string(),
+            ts: "2026-05-08T12:00:00Z".to_string(),
+            data: Some(serde_json::json!({"status": "active"})),
+            memory: Some("kn-abc123".to_string()),
+        };
+        let json_str = serde_json::to_string_pretty(&hit).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(parsed["index"], 7);
+        assert_eq!(parsed["id"], "A3fB");
+        assert_eq!(parsed["value"], "test entry");
+        assert_eq!(parsed["ts"], "2026-05-08T12:00:00Z");
+        assert_eq!(parsed["data"]["status"], "active");
+        assert_eq!(parsed["memory"], "kn-abc123");
+    }
+
+    #[test]
+    fn search_hit_omits_null_data_and_memory() {
+        let hit = SearchHit {
+            index: 1,
+            id: "Bf2C".to_string(),
+            value: "no extras".to_string(),
+            ts: "2026-05-08T12:00:00Z".to_string(),
+            data: None,
+            memory: None,
+        };
+        let json_str = serde_json::to_string(&hit).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(parsed.get("data").is_none(), "data should be omitted when None");
+        assert!(parsed.get("memory").is_none(), "memory should be omitted when None");
+        // Required fields are present
+        assert!(parsed.get("index").is_some());
+        assert!(parsed.get("id").is_some());
+        assert!(parsed.get("value").is_some());
+        assert!(parsed.get("ts").is_some());
+    }
+
+    #[test]
+    fn search_hit_vec_serializes_as_json_array() {
+        let hits = vec![
+            SearchHit {
+                index: 1,
+                id: "aaa".to_string(),
+                value: "first".to_string(),
+                ts: "2026-05-08T10:00:00Z".to_string(),
+                data: None,
+                memory: None,
+            },
+            SearchHit {
+                index: 2,
+                id: "bbb".to_string(),
+                value: "second".to_string(),
+                ts: "2026-05-08T11:00:00Z".to_string(),
+                data: Some(serde_json::json!({"priority": "high"})),
+                memory: Some("kn-xyz".to_string()),
+            },
+        ];
+        let json_str = serde_json::to_string_pretty(&hits).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        assert!(parsed.is_array());
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["value"], "first");
+        assert!(arr[0].get("data").is_none());
+        assert_eq!(arr[1]["value"], "second");
+        assert_eq!(arr[1]["data"]["priority"], "high");
+        assert_eq!(arr[1]["memory"], "kn-xyz");
+    }
+
+    #[test]
+    fn search_hit_uses_rust_field_names_not_disk_renames() {
+        // SearchHit deliberately uses Rust field names (index, id) for JSON output,
+        // NOT the on-disk serde rename aliases used by HistoryEntry/ListEntry.
+        let hit = SearchHit {
+            index: 42,
+            id: "test".to_string(),
+            value: "v".to_string(),
+            ts: "2026-01-01T00:00:00Z".to_string(),
+            data: None,
+            memory: None,
+        };
+        let json_str = serde_json::to_string(&hit).unwrap();
+        assert!(json_str.contains("\"index\""), "should use 'index' not 'i'");
+        assert!(json_str.contains("\"id\""), "should use 'id' not 'h'");
+        assert!(!json_str.contains("\"i\":"), "should NOT use on-disk 'i' alias");
+        assert!(!json_str.contains("\"h\":"), "should NOT use on-disk 'h' alias");
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -5695,8 +5695,14 @@ max_entries = 5
         let json_str = serde_json::to_string(&hit).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
-        assert!(parsed.get("data").is_none(), "data should be omitted when None");
-        assert!(parsed.get("memory").is_none(), "memory should be omitted when None");
+        assert!(
+            parsed.get("data").is_none(),
+            "data should be omitted when None"
+        );
+        assert!(
+            parsed.get("memory").is_none(),
+            "memory should be omitted when None"
+        );
         // Required fields are present
         assert!(parsed.get("index").is_some());
         assert!(parsed.get("id").is_some());
@@ -5752,7 +5758,13 @@ max_entries = 5
         let json_str = serde_json::to_string(&hit).unwrap();
         assert!(json_str.contains("\"index\""), "should use 'index' not 'i'");
         assert!(json_str.contains("\"id\""), "should use 'id' not 'h'");
-        assert!(!json_str.contains("\"i\":"), "should NOT use on-disk 'i' alias");
-        assert!(!json_str.contains("\"h\":"), "should NOT use on-disk 'h' alias");
+        assert!(
+            !json_str.contains("\"i\":"),
+            "should NOT use on-disk 'i' alias"
+        );
+        assert!(
+            !json_str.contains("\"h\":"),
+            "should NOT use on-disk 'h' alias"
+        );
     }
 }


### PR DESCRIPTION
Partially addresses #312 (part 1 of 3)

## Summary

Adds `--json` flag to `last`, `search`, `random`, `get`, `since`, `count`. Outputs entries as pretty-printed JSON array of SearchHit objects. `count --json` outputs `{"count": N}`. `get --json` (scalar) outputs `{"value": "..."}`. Skips human formatting and inline memory resolution when JSON mode is active.

## Files

- `src/kv.rs`
- `src/cli.rs`
- `src/handlers/kv.rs`

## Tests

4 new tests, 867 total passing.

## Examples

```
mx kv last projects --count 5 --json | jq '.[].data.status'
mx kv search projects --where status=active --json | jq 'map(.value)'
mx kv count shipped --json
```