### PR TITLE
Deprecate mx state in favor of mx kv (#297)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ Two env vars were removed in the path-alignment refactor (#259):
 
 - `MX_MEMORY_PATH` -- use `MX_SURREAL_ROOT` instead. Setting the old name now
   emits a one-line stderr note and is otherwise ignored.
-- `MX_STATE_SCHEMA` -- replaced by the `mx state ... --schema {id|path}` CLI
-  flag. The default schema ID is now `tensor` (was `crewu`).
+- `MX_STATE_SCHEMA` (deprecated) -- replaced by the `mx state ... --schema {id|path}` CLI
+  flag. The default schema ID is now `tensor` (was `crewu`). Note: `mx state`
+  itself is deprecated; use `mx kv` with structured data instead.
 
 For the full layout, the complete env-var reference (including SurrealDB
 connection vars, GitHub App auth, and tuning), legacy-fallback behavior, and

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -77,7 +77,7 @@ src/
    memory.rs        # mx memory subcommand handler
    kv.rs            # mx kv subcommand handler
    metadata.rs      # metadata subcommand handler (categories, tags, etc.)
-   state.rs         # mx state subcommand handler
+   state.rs         # mx state subcommand handler (deprecated)
  commit.rs          # encoding pipeline (hash + compress + encode)
  knowledge.rs       # KnowledgeEntry struct (the core data model)
  store.rs           # KnowledgeStore trait (abstract storage interface)
@@ -110,7 +110,7 @@ src/
  kv.rs              # KV store engine (schema TOML + data JSON)
  types.rs           # shared domain types (Agent, Category, Project, etc.)
  display.rs         # safe_truncate, formatting helpers
- tensor.rs          # emotional state tensor encode/decode
+ tensor.rs          # emotional state tensor encode/decode (deprecated, serves mx state)
  github.rs          # GitHub API operations (cleanup, comments)
  sync/              # GitHub sync (issues, wiki)
  convert.rs         # md2yaml / yaml2md conversion

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -161,7 +161,12 @@ mx kv last projects --count 5 --json | jq '.[].data.status'
 mx kv count shipped --json | jq '.count'
 ```
 
-=== State
+=== State (deprecated)
+
+#deprecated[
+  `mx state` is deprecated and will be removed in a future release. Use `mx kv`
+  with structured data (`--data`) instead.
+]
 
 The #link("state.html")[state] system encodes emotional state tensors -- multi-
 dimensional values compressed into a compact string format. Used for agent

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -18,7 +18,7 @@ persistent memory, encoded commits, or session management.
 - #link("memory.html")[Memory] -- knowledge graph operations
 - #link("codex.html")[Codex] -- session archival
 - #link("kv.html")[KV] -- local key-value store
-- #link("state.html")[State] -- emotional state tensors
+- #link("state.html")[State] -- emotional state tensors _(deprecated)_
 - #link("sync.html")[Sync] -- GitHub sync
 - #link("pr.html")[PR] -- pull request merge
 - #link("github.html")[GitHub] -- GitHub operations

--- a/docs/src/state.typ
+++ b/docs/src/state.typ
@@ -2,6 +2,12 @@
 
 #page-header("State", "Emotional state tensors for agent co-regulation.")
 
+#deprecated[
+  `mx state` is deprecated and will be removed in a future release. Use `mx kv`
+  with structured data (`--data`) instead. See the #link("kv.html")[KV documentation]
+  for the replacement workflow.
+]
+
 The state subsystem encodes multidimensional emotional state into compact tensor
 strings. A tensor is a vector of float values (each 0.0--1.0) mapped to named
 dimensions defined by a schema. Schemas are user-authored YAML files; the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,7 +123,7 @@ pub enum Commands {
         args: Vec<String>,
     },
 
-    /// Emotional state tensor operations
+    /// [DEPRECATED] Tensor state encoding and decoding. Use `mx kv` instead.
     State {
         #[command(subcommand)]
         command: StateCommands,
@@ -172,6 +172,7 @@ pub enum ConvertCommands {
 }
 
 #[derive(Subcommand)]
+/// [DEPRECATED] Tensor state subcommands. Use `mx kv` with structured data instead.
 pub enum StateCommands {
     /// Encode state tensor from dimensional values
     Encode {

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -8,6 +8,8 @@ pub(crate) fn handle_state(cmd: StateCommands) -> Result<()> {
     use std::io::{self, Read as IoRead};
     use std::path::PathBuf;
 
+    eprintln!("Warning: `mx state` is deprecated and will be removed in a future release. Use `mx kv` with structured data instead.");
+
     // Helper to load tensor schema by ID or path. The `--schema` argument
     // accepts either a schema ID (looked up under `$MX_HOME/state/schemas/`)
     // or a direct path to a YAML/JSON schema file.

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -8,7 +8,10 @@ pub(crate) fn handle_state(cmd: StateCommands) -> Result<()> {
     use std::io::{self, Read as IoRead};
     use std::path::PathBuf;
 
-    eprintln!("Warning: `mx state` is deprecated and will be removed in a future release. Use `mx kv` with structured data instead.");
+    eprintln!(
+        "Warning: `mx state` is deprecated and will be removed in a future release. \
+         Use `mx kv` with structured data instead."
+    );
 
     // Helper to load tensor schema by ID or path. The `--schema` argument
     // accepts either a schema ID (looked up under `$MX_HOME/state/schemas/`)


### PR DESCRIPTION
Closes #297

## Summary

Phase 1 deprecation of `mx state`. Adds stderr deprecation warning on every invocation, marks CLI doc comments as deprecated, adds deprecation notices to `state.typ`, `getting-started.typ`, and `README`. No functionality removed — all commands continue to work. Phase 2 (removal of ~1,600 lines) will be a separate future PR.

## Files changed

- `src/handlers/state.rs` — stderr deprecation warning on every `mx state` invocation
- `src/cli.rs` — CLI doc comments marked as deprecated
- `docs/src/state.typ` — deprecation notice added
- `docs/src/getting-started.typ` — deprecation notice added
- `README.md` — deprecation notice added

## Test plan

- [x] 869 tests passing, no behavior changes
- [ ] Verify `mx state` commands still function and print deprecation warning to stderr
- [ ] Verify docs render deprecation notices correctly