### PR TITLE
kv: schema-level data field definitions (#312 part 2)

### DIFF
--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -15,6 +15,7 @@ fn exit_code_for(err: &KvError) -> Option<i32> {
         KvError::SchemaMissing(_) => Some(kv::EXIT_SCHEMA_MISSING),
         KvError::EntryNotFound { .. } => Some(kv::EXIT_INVALID_INPUT),
         KvError::AmbiguousId { .. } => Some(kv::EXIT_INVALID_INPUT),
+        KvError::DataValidation { .. } => Some(kv::EXIT_INVALID_INPUT),
         KvError::Other(_) => None,
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -594,7 +594,7 @@ impl KeyDef {
         let missing: Vec<&str> = field_defs
             .iter()
             .filter(|(_, d)| d.required)
-            .filter(|(name, _)| !obj.get(name.as_str()).is_some_and(|v| !v.is_null()))
+            .filter(|(name, _)| obj.get(name.as_str()).is_none_or(|v| v.is_null()))
             .map(|(name, _)| name.as_str())
             .collect();
         if !missing.is_empty() {

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -625,7 +625,9 @@ impl KeyDef {
                 } else {
                     Some(format!(
                         "'{}' must be {}, got {}",
-                        name, def.field_type, json_type_name(value),
+                        name,
+                        def.field_type,
+                        json_type_name(value),
                     ))
                 }
             })
@@ -6217,9 +6219,21 @@ opt = { type = "string" }
         }));
         let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("undeclared"), "error should mention undeclared: {}", msg);
-        assert!(msg.contains("unknown_field"), "error should name the extra field: {}", msg);
-        assert!(msg.contains("priority"), "error should list declared fields: {}", msg);
+        assert!(
+            msg.contains("undeclared"),
+            "error should mention undeclared: {}",
+            msg
+        );
+        assert!(
+            msg.contains("unknown_field"),
+            "error should name the extra field: {}",
+            msg
+        );
+        assert!(
+            msg.contains("priority"),
+            "error should list declared fields: {}",
+            msg
+        );
     }
 
     #[test]
@@ -6230,8 +6244,16 @@ opt = { type = "string" }
         }));
         let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("missing required"), "error should say missing required: {}", msg);
-        assert!(msg.contains("status"), "error should name the missing field: {}", msg);
+        assert!(
+            msg.contains("missing required"),
+            "error should say missing required: {}",
+            msg
+        );
+        assert!(
+            msg.contains("status"),
+            "error should name the missing field: {}",
+            msg
+        );
     }
 
     #[test]
@@ -6251,8 +6273,16 @@ opt = { type = "string" }
         }));
         let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("must be string"), "error should say expected type: {}", msg);
-        assert!(msg.contains("got number"), "error should say actual type: {}", msg);
+        assert!(
+            msg.contains("must be string"),
+            "error should say expected type: {}",
+            msg
+        );
+        assert!(
+            msg.contains("got number"),
+            "error should say actual type: {}",
+            msg
+        );
     }
 
     #[test]
@@ -6273,11 +6303,46 @@ opt = { type = "string" }
     #[test]
     fn validate_data_all_types() {
         let mut defs = BTreeMap::new();
-        defs.insert("s".to_string(), DataFieldDef { field_type: DataFieldType::String, required: false, default: None });
-        defs.insert("n".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
-        defs.insert("b".to_string(), DataFieldDef { field_type: DataFieldType::Boolean, required: false, default: None });
-        defs.insert("a".to_string(), DataFieldDef { field_type: DataFieldType::Array, required: false, default: None });
-        defs.insert("o".to_string(), DataFieldDef { field_type: DataFieldType::Object, required: false, default: None });
+        defs.insert(
+            "s".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::String,
+                required: false,
+                default: None,
+            },
+        );
+        defs.insert(
+            "n".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Number,
+                required: false,
+                default: None,
+            },
+        );
+        defs.insert(
+            "b".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Boolean,
+                required: false,
+                default: None,
+            },
+        );
+        defs.insert(
+            "a".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Array,
+                required: false,
+                default: None,
+            },
+        );
+        defs.insert(
+            "o".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Object,
+                required: false,
+                default: None,
+            },
+        );
         let def = key_def_with_data(defs);
 
         let data = Some(serde_json::json!({
@@ -6308,8 +6373,22 @@ opt = { type = "string" }
     #[test]
     fn validate_data_empty_object_all_optional() {
         let mut defs = BTreeMap::new();
-        defs.insert("opt1".to_string(), DataFieldDef { field_type: DataFieldType::String, required: false, default: None });
-        defs.insert("opt2".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
+        defs.insert(
+            "opt1".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::String,
+                required: false,
+                default: None,
+            },
+        );
+        defs.insert(
+            "opt2".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Number,
+                required: false,
+                default: None,
+            },
+        );
         let def = key_def_with_data(defs);
 
         let data = Some(serde_json::json!({}));
@@ -6319,8 +6398,22 @@ opt = { type = "string" }
     #[test]
     fn validate_data_empty_object_with_required() {
         let mut defs = BTreeMap::new();
-        defs.insert("req".to_string(), DataFieldDef { field_type: DataFieldType::String, required: true, default: None });
-        defs.insert("opt".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
+        defs.insert(
+            "req".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::String,
+                required: true,
+                default: None,
+            },
+        );
+        defs.insert(
+            "opt".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Number,
+                required: false,
+                default: None,
+            },
+        );
         let def = key_def_with_data(defs);
 
         let data = Some(serde_json::json!({}));
@@ -6379,11 +6472,22 @@ opt = { type = "string" }
     fn push_without_data_when_required() {
         let (mut store, _dir) = setup_store(data_schema());
         let result = store.push("projects", "no-data", None, None);
-        assert!(result.is_err(), "push without data when schema has required fields should fail");
+        assert!(
+            result.is_err(),
+            "push without data when schema has required fields should fail"
+        );
         let err = result.unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("--data is required"), "error should mention --data: {}", msg);
-        assert!(msg.contains("status"), "error should name the required field: {}", msg);
+        assert!(
+            msg.contains("--data is required"),
+            "error should mention --data: {}",
+            msg
+        );
+        assert!(
+            msg.contains("status"),
+            "error should name the required field: {}",
+            msg
+        );
     }
 
     #[test]
@@ -6398,7 +6502,10 @@ count = { type = "number" }
 "#;
         let (mut store, _dir) = setup_store(schema);
         let result = store.push("loose", "no-data-ok", None, None);
-        assert!(result.is_ok(), "push without data when all fields optional should succeed");
+        assert!(
+            result.is_ok(),
+            "push without data when all fields optional should succeed"
+        );
 
         match &store.data.entries["loose"] {
             DataValue::History { entries, .. } => {
@@ -6414,7 +6521,10 @@ count = { type = "number" }
         let (mut store, _dir) = setup_store(data_schema());
         // "notes" has no [keys.notes.data] section -- freeform
         let result = store.push("notes", "anything goes", None, None);
-        assert!(result.is_ok(), "push without data on freeform key should succeed");
+        assert!(
+            result.is_ok(),
+            "push without data on freeform key should succeed"
+        );
 
         match &store.data.entries["notes"] {
             DataValue::History { entries, .. } => {
@@ -6448,7 +6558,11 @@ count = { type = "number" }
         }));
         let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("missing required"), "null on required field = missing: {}", msg);
+        assert!(
+            msg.contains("missing required"),
+            "null on required field = missing: {}",
+            msg
+        );
         assert!(msg.contains("status"), "{}", msg);
     }
 

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -513,99 +513,131 @@ pub enum IdRef {
 // Data field validation
 // ---------------------------------------------------------------------------
 
-/// Validate a `--data` JSON object against the field definitions from
-/// `[keys.X.data]` in the schema.
-///
-/// Three checks, in order:
-/// 1. No undeclared fields (extra fields that aren't in the schema).
-/// 2. All required fields present.
-/// 3. Each field's JSON type matches its declared type.
-pub fn validate_data(
-    key: &str,
-    data: &serde_json::Value,
-    field_defs: &BTreeMap<String, DataFieldDef>,
-) -> Result<(), KvError> {
-    let obj = match data.as_object() {
-        Some(o) => o,
-        None => {
+fn json_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+impl KeyDef {
+    /// Validate `--data` against this key's field definitions.
+    ///
+    /// When `data` is `Some`, validates the object against `self.data` defs.
+    /// When `data` is `None` and required fields exist, returns an error.
+    /// When `self.data` is `None` (freeform), always passes.
+    pub fn validate_data(
+        &self,
+        key: &str,
+        data: &Option<serde_json::Value>,
+    ) -> Result<(), KvError> {
+        let field_defs = match self.data {
+            Some(ref defs) => defs,
+            None => return Ok(()),
+        };
+
+        let obj = match data {
+            Some(val) => match val.as_object() {
+                Some(o) => o,
+                None => {
+                    return Err(KvError::DataValidation {
+                        message: format!("key '{}': --data must be a JSON object", key),
+                    });
+                }
+            },
+            None => {
+                let required: Vec<&str> = field_defs
+                    .iter()
+                    .filter(|(_, d)| d.required)
+                    .map(|(n, _)| n.as_str())
+                    .collect();
+                if !required.is_empty() {
+                    return Err(KvError::DataValidation {
+                        message: format!(
+                            "key '{}': --data is required (schema has required fields: {})",
+                            key,
+                            required.join(", "),
+                        ),
+                    });
+                }
+                return Ok(());
+            }
+        };
+
+        // Null values are treated as absent — they don't trigger undeclared-field
+        // errors, don't satisfy required-field checks, and skip type checking.
+
+        // 1. Reject undeclared fields (ignoring nulls)
+        let extra: Vec<&str> = obj
+            .iter()
+            .filter(|(_, v)| !v.is_null())
+            .filter(|(k, _)| !field_defs.contains_key(k.as_str()))
+            .map(|(k, _)| k.as_str())
+            .collect();
+        if !extra.is_empty() {
+            let declared: Vec<&str> = field_defs.keys().map(|s| s.as_str()).collect();
             return Err(KvError::DataValidation {
-                message: format!("key '{}': --data must be a JSON object", key),
+                message: format!(
+                    "key '{}': undeclared data fields: {}; declared fields: {}",
+                    key,
+                    extra.join(", "),
+                    declared.join(", "),
+                ),
             });
         }
-    };
 
-    // Null values are treated as absent — they don't trigger undeclared-field
-    // errors, don't satisfy required-field checks, and skip type checking.
-
-    // 1. Reject undeclared fields (ignoring nulls)
-    let extra: Vec<&str> = obj
-        .iter()
-        .filter(|(_, v)| !v.is_null())
-        .filter(|(k, _)| !field_defs.contains_key(k.as_str()))
-        .map(|(k, _)| k.as_str())
-        .collect();
-    if !extra.is_empty() {
-        let declared: Vec<&str> = field_defs.keys().map(|s| s.as_str()).collect();
-        return Err(KvError::DataValidation {
-            message: format!(
-                "key '{}': undeclared data fields: {}; declared fields: {}",
-                key,
-                extra.join(", "),
-                declared.join(", "),
-            ),
-        });
-    }
-
-    // 2. Required fields present (null counts as absent)
-    let missing: Vec<&str> = field_defs
-        .iter()
-        .filter(|(_, d)| d.required)
-        .filter(|(name, _)| !obj.get(name.as_str()).map_or(false, |v| !v.is_null()))
-        .map(|(name, _)| name.as_str())
-        .collect();
-    if !missing.is_empty() {
-        return Err(KvError::DataValidation {
-            message: format!(
-                "key '{}': missing required data fields: {}",
-                key,
-                missing.join(", "),
-            ),
-        });
-    }
-
-    // 3. Type checking (nulls skipped)
-    for (name, value) in obj {
-        if value.is_null() {
-            continue;
+        // 2. Required fields present (null counts as absent)
+        let missing: Vec<&str> = field_defs
+            .iter()
+            .filter(|(_, d)| d.required)
+            .filter(|(name, _)| !obj.get(name.as_str()).map_or(false, |v| !v.is_null()))
+            .map(|(name, _)| name.as_str())
+            .collect();
+        if !missing.is_empty() {
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "key '{}': missing required data fields: {}",
+                    key,
+                    missing.join(", "),
+                ),
+            });
         }
-        if let Some(def) = field_defs.get(name.as_str()) {
-            let ok = match def.field_type {
-                DataFieldType::String => value.is_string(),
-                DataFieldType::Number => value.is_number(),
-                DataFieldType::Boolean => value.is_boolean(),
-                DataFieldType::Array => value.is_array(),
-                DataFieldType::Object => value.is_object(),
-            };
-            if !ok {
-                let got = match value {
-                    serde_json::Value::Null => "null",
-                    serde_json::Value::Bool(_) => "boolean",
-                    serde_json::Value::Number(_) => "number",
-                    serde_json::Value::String(_) => "string",
-                    serde_json::Value::Array(_) => "array",
-                    serde_json::Value::Object(_) => "object",
+
+        // 3. Type checking — batch all mismatches (nulls skipped)
+        let bad: Vec<std::string::String> = obj
+            .iter()
+            .filter(|(_, v)| !v.is_null())
+            .filter_map(|(name, value)| {
+                let def = field_defs.get(name.as_str())?;
+                let ok = match def.field_type {
+                    DataFieldType::String => value.is_string(),
+                    DataFieldType::Number => value.is_number(),
+                    DataFieldType::Boolean => value.is_boolean(),
+                    DataFieldType::Array => value.is_array(),
+                    DataFieldType::Object => value.is_object(),
                 };
-                return Err(KvError::DataValidation {
-                    message: format!(
-                        "key '{}': field '{}' must be {}, got {}",
-                        key, name, def.field_type, got,
-                    ),
-                });
-            }
+                if ok {
+                    None
+                } else {
+                    Some(format!(
+                        "'{}' must be {}, got {}",
+                        name, def.field_type, json_type_name(value),
+                    ))
+                }
+            })
+            .collect();
+        if !bad.is_empty() {
+            return Err(KvError::DataValidation {
+                message: format!("key '{}': type errors: {}", key, bad.join("; ")),
+            });
         }
-    }
 
-    Ok(())
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1087,28 +1119,7 @@ impl KvStore {
     ) -> Result<PushResult, KvError> {
         let def = self.key_def(key)?.clone();
 
-        // Validate --data against schema field defs when present.
-        if let Some(ref field_defs) = def.data {
-            match data {
-                Some(ref data_val) => validate_data(key, data_val, field_defs)?,
-                None => {
-                    let required: Vec<&str> = field_defs
-                        .iter()
-                        .filter(|(_, d)| d.required)
-                        .map(|(n, _)| n.as_str())
-                        .collect();
-                    if !required.is_empty() {
-                        return Err(KvError::DataValidation {
-                            message: format!(
-                                "key '{}': --data is required (schema has required fields: {})",
-                                key,
-                                required.join(", "),
-                            ),
-                        });
-                    }
-                }
-            }
-        }
+        def.validate_data(key, &data)?;
 
         let ts_str = ts.to_rfc3339();
 
@@ -6137,9 +6148,9 @@ opt = { type = "string" }
 
     // -- validate_data unit tests --
 
-    fn sample_field_defs() -> BTreeMap<String, DataFieldDef> {
-        let mut m = BTreeMap::new();
-        m.insert(
+    fn sample_key_def() -> KeyDef {
+        let mut data = BTreeMap::new();
+        data.insert(
             "status".to_string(),
             DataFieldDef {
                 field_type: DataFieldType::String,
@@ -6147,7 +6158,7 @@ opt = { type = "string" }
                 default: None,
             },
         );
-        m.insert(
+        data.insert(
             "tags".to_string(),
             DataFieldDef {
                 field_type: DataFieldType::Array,
@@ -6155,7 +6166,7 @@ opt = { type = "string" }
                 default: None,
             },
         );
-        m.insert(
+        data.insert(
             "priority".to_string(),
             DataFieldDef {
                 field_type: DataFieldType::Number,
@@ -6163,28 +6174,48 @@ opt = { type = "string" }
                 default: None,
             },
         );
-        m
+        KeyDef {
+            value_type: ValueType::History,
+            min: None,
+            max: None,
+            default: None,
+            max_entries: None,
+            fields: None,
+            data: Some(data),
+        }
+    }
+
+    fn key_def_with_data(data: BTreeMap<String, DataFieldDef>) -> KeyDef {
+        KeyDef {
+            value_type: ValueType::History,
+            min: None,
+            max: None,
+            default: None,
+            max_entries: None,
+            fields: None,
+            data: Some(data),
+        }
     }
 
     #[test]
     fn validate_data_accepts_valid() {
-        let defs = sample_field_defs();
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "status": "active",
             "tags": ["a", "b"],
             "priority": 5
-        });
-        assert!(validate_data("test", &data, &defs).is_ok());
+        }));
+        assert!(def.validate_data("test", &data).is_ok());
     }
 
     #[test]
     fn validate_data_rejects_extra_field() {
-        let defs = sample_field_defs();
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "status": "active",
             "unknown_field": true
-        });
-        let err = validate_data("test", &data, &defs).unwrap_err();
+        }));
+        let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("undeclared"), "error should mention undeclared: {}", msg);
         assert!(msg.contains("unknown_field"), "error should name the extra field: {}", msg);
@@ -6193,11 +6224,11 @@ opt = { type = "string" }
 
     #[test]
     fn validate_data_rejects_missing_required() {
-        let defs = sample_field_defs();
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "tags": ["a"]
-        });
-        let err = validate_data("test", &data, &defs).unwrap_err();
+        }));
+        let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("missing required"), "error should say missing required: {}", msg);
         assert!(msg.contains("status"), "error should name the missing field: {}", msg);
@@ -6205,65 +6236,73 @@ opt = { type = "string" }
 
     #[test]
     fn validate_data_allows_missing_optional() {
-        let defs = sample_field_defs();
-        // Only the required field is present; optional fields omitted.
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "status": "active"
-        });
-        assert!(validate_data("test", &data, &defs).is_ok());
+        }));
+        assert!(def.validate_data("test", &data).is_ok());
     }
 
     #[test]
     fn validate_data_rejects_type_mismatch() {
-        let defs = sample_field_defs();
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "status": 42
-        });
-        let err = validate_data("test", &data, &defs).unwrap_err();
+        }));
+        let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("must be string"), "error should say expected type: {}", msg);
         assert!(msg.contains("got number"), "error should say actual type: {}", msg);
     }
 
     #[test]
+    fn validate_data_batches_type_mismatches() {
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
+            "status": 42,
+            "tags": "not-an-array",
+            "priority": true
+        }));
+        let err = def.validate_data("test", &data).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'status'"), "should name status: {}", msg);
+        assert!(msg.contains("'tags'"), "should name tags: {}", msg);
+        assert!(msg.contains("'priority'"), "should name priority: {}", msg);
+    }
+
+    #[test]
     fn validate_data_all_types() {
-        // Correct values for each type
         let mut defs = BTreeMap::new();
         defs.insert("s".to_string(), DataFieldDef { field_type: DataFieldType::String, required: false, default: None });
         defs.insert("n".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
         defs.insert("b".to_string(), DataFieldDef { field_type: DataFieldType::Boolean, required: false, default: None });
         defs.insert("a".to_string(), DataFieldDef { field_type: DataFieldType::Array, required: false, default: None });
         defs.insert("o".to_string(), DataFieldDef { field_type: DataFieldType::Object, required: false, default: None });
+        let def = key_def_with_data(defs);
 
-        // All correct
-        let data = serde_json::json!({
+        let data = Some(serde_json::json!({
             "s": "hello",
             "n": 3.14,
             "b": true,
             "a": [1, 2, 3],
             "o": {"nested": true}
-        });
-        assert!(validate_data("test", &data, &defs).is_ok());
+        }));
+        assert!(def.validate_data("test", &data).is_ok());
 
-        // String field gets number
-        let bad = serde_json::json!({ "s": 42 });
-        assert!(validate_data("test", &bad, &defs).is_err());
+        let bad = Some(serde_json::json!({ "s": 42 }));
+        assert!(def.validate_data("test", &bad).is_err());
 
-        // Number field gets string
-        let bad = serde_json::json!({ "n": "nope" });
-        assert!(validate_data("test", &bad, &defs).is_err());
+        let bad = Some(serde_json::json!({ "n": "nope" }));
+        assert!(def.validate_data("test", &bad).is_err());
 
-        // Boolean field gets string
-        let bad = serde_json::json!({ "b": "true" });
-        assert!(validate_data("test", &bad, &defs).is_err());
+        let bad = Some(serde_json::json!({ "b": "true" }));
+        assert!(def.validate_data("test", &bad).is_err());
 
-        // Array field gets object
-        let bad = serde_json::json!({ "a": {"not": "array"} });
-        assert!(validate_data("test", &bad, &defs).is_err());
+        let bad = Some(serde_json::json!({ "a": {"not": "array"} }));
+        assert!(def.validate_data("test", &bad).is_err());
 
-        // Object field gets array
-        let bad = serde_json::json!({ "o": [1, 2] });
-        assert!(validate_data("test", &bad, &defs).is_err());
+        let bad = Some(serde_json::json!({ "o": [1, 2] }));
+        assert!(def.validate_data("test", &bad).is_err());
     }
 
     #[test]
@@ -6271,9 +6310,10 @@ opt = { type = "string" }
         let mut defs = BTreeMap::new();
         defs.insert("opt1".to_string(), DataFieldDef { field_type: DataFieldType::String, required: false, default: None });
         defs.insert("opt2".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
+        let def = key_def_with_data(defs);
 
-        let data = serde_json::json!({});
-        assert!(validate_data("test", &data, &defs).is_ok());
+        let data = Some(serde_json::json!({}));
+        assert!(def.validate_data("test", &data).is_ok());
     }
 
     #[test]
@@ -6281,9 +6321,10 @@ opt = { type = "string" }
         let mut defs = BTreeMap::new();
         defs.insert("req".to_string(), DataFieldDef { field_type: DataFieldType::String, required: true, default: None });
         defs.insert("opt".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
+        let def = key_def_with_data(defs);
 
-        let data = serde_json::json!({});
-        let err = validate_data("test", &data, &defs).unwrap_err();
+        let data = Some(serde_json::json!({}));
+        let err = def.validate_data("test", &data).unwrap_err();
         assert!(err.to_string().contains("missing required"));
         assert!(err.to_string().contains("req"));
     }
@@ -6388,24 +6429,24 @@ count = { type = "number" }
 
     #[test]
     fn validate_data_null_optional_field_treated_as_absent() {
-        let defs = sample_field_defs();
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "status": "active",
             "tags": null
-        });
+        }));
         assert!(
-            validate_data("test", &data, &defs).is_ok(),
+            def.validate_data("test", &data).is_ok(),
             "null on optional field should be treated as absent"
         );
     }
 
     #[test]
     fn validate_data_null_required_field_is_missing() {
-        let defs = sample_field_defs();
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "status": null
-        });
-        let err = validate_data("test", &data, &defs).unwrap_err();
+        }));
+        let err = def.validate_data("test", &data).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("missing required"), "null on required field = missing: {}", msg);
         assert!(msg.contains("status"), "{}", msg);
@@ -6413,26 +6454,42 @@ count = { type = "number" }
 
     #[test]
     fn validate_data_null_undeclared_field_ignored() {
-        let defs = sample_field_defs();
-        let data = serde_json::json!({
+        let def = sample_key_def();
+        let data = Some(serde_json::json!({
             "status": "active",
             "ghost": null
-        });
+        }));
         assert!(
-            validate_data("test", &data, &defs).is_ok(),
+            def.validate_data("test", &data).is_ok(),
             "null undeclared field should be ignored (treated as absent)"
         );
     }
 
     #[test]
     fn validate_data_rejects_non_object() {
-        let defs = sample_field_defs();
-        let array = serde_json::json!(["not", "an", "object"]);
-        let err = validate_data("test", &array, &defs).unwrap_err();
+        let def = sample_key_def();
+        let array = Some(serde_json::json!(["not", "an", "object"]));
+        let err = def.validate_data("test", &array).unwrap_err();
         assert!(err.to_string().contains("must be a JSON object"));
 
-        let string = serde_json::json!("just a string");
-        let err = validate_data("test", &string, &defs).unwrap_err();
+        let string = Some(serde_json::json!("just a string"));
+        let err = def.validate_data("test", &string).unwrap_err();
         assert!(err.to_string().contains("must be a JSON object"));
+    }
+
+    #[test]
+    fn validate_data_none_passes_freeform() {
+        let def = KeyDef {
+            value_type: ValueType::History,
+            min: None,
+            max: None,
+            default: None,
+            max_entries: None,
+            fields: None,
+            data: None,
+        };
+        assert!(def.validate_data("test", &None).is_ok());
+        let data = Some(serde_json::json!({"anything": "goes"}));
+        assert!(def.validate_data("test", &data).is_ok());
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -594,7 +594,7 @@ impl KeyDef {
         let missing: Vec<&str> = field_defs
             .iter()
             .filter(|(_, d)| d.required)
-            .filter(|(name, _)| !obj.get(name.as_str()).map_or(false, |v| !v.is_null()))
+            .filter(|(name, _)| !obj.get(name.as_str()).is_some_and(|v| !v.is_null()))
             .map(|(name, _)| name.as_str())
             .collect();
         if !missing.is_empty() {
@@ -6347,7 +6347,7 @@ opt = { type = "string" }
 
         let data = Some(serde_json::json!({
             "s": "hello",
-            "n": 3.14,
+            "n": 42.5,
             "b": true,
             "a": [1, 2, 3],
             "o": {"nested": true}

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -122,6 +122,9 @@ pub enum KvError {
         prefix: String,
         count: usize,
     },
+    DataValidation {
+        message: String,
+    },
     Other(anyhow::Error),
 }
 
@@ -149,6 +152,7 @@ impl std::fmt::Display for KvError {
                     prefix, count
                 )
             }
+            KvError::DataValidation { message } => write!(f, "{}", message),
             KvError::Other(e) => write!(f, "{}", e),
         }
     }
@@ -199,6 +203,49 @@ pub struct KeyDef {
 
     #[serde(default)]
     pub fields: Option<Vec<String>>,
+
+    /// Optional typed field definitions for `--data` validation.
+    /// When present, `push` validates the data object against these defs.
+    /// When absent, any JSON object is accepted (freeform).
+    #[serde(default)]
+    pub data: Option<BTreeMap<String, DataFieldDef>>,
+}
+
+/// The type of a data field in a schema's `[keys.X.data]` section.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DataFieldType {
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+}
+
+impl std::fmt::Display for DataFieldType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataFieldType::String => write!(f, "string"),
+            DataFieldType::Number => write!(f, "number"),
+            DataFieldType::Boolean => write!(f, "boolean"),
+            DataFieldType::Array => write!(f, "array"),
+            DataFieldType::Object => write!(f, "object"),
+        }
+    }
+}
+
+/// Definition of a single data field within a key's `[keys.X.data]` section.
+#[derive(Debug, Deserialize, Clone)]
+pub struct DataFieldDef {
+    #[serde(rename = "type")]
+    pub field_type: DataFieldType,
+
+    #[serde(default)]
+    pub required: bool,
+
+    /// Parsed but not used until Part 3 (migration).
+    #[serde(default)]
+    pub default: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -460,6 +507,98 @@ pub struct PushResult {
 pub enum IdRef {
     Index(u64),
     Id(String),
+}
+
+// ---------------------------------------------------------------------------
+// Data field validation
+// ---------------------------------------------------------------------------
+
+/// Validate a `--data` JSON object against the field definitions from
+/// `[keys.X.data]` in the schema.
+///
+/// Three checks, in order:
+/// 1. No undeclared fields (extra fields that aren't in the schema).
+/// 2. All required fields present.
+/// 3. Each field's JSON type matches its declared type.
+pub fn validate_data(
+    key: &str,
+    data: &serde_json::Value,
+    field_defs: &BTreeMap<String, DataFieldDef>,
+) -> Result<(), KvError> {
+    let obj = match data.as_object() {
+        Some(o) => o,
+        None => {
+            return Err(KvError::DataValidation {
+                message: format!("key '{}': --data must be a JSON object", key),
+            });
+        }
+    };
+
+    // 1. Reject undeclared fields
+    let declared: Vec<&str> = field_defs.keys().map(|s| s.as_str()).collect();
+    let extra: Vec<&str> = obj
+        .keys()
+        .filter(|k| !field_defs.contains_key(k.as_str()))
+        .map(|k| k.as_str())
+        .collect();
+    if !extra.is_empty() {
+        return Err(KvError::DataValidation {
+            message: format!(
+                "key '{}': undeclared data fields: {}; declared fields: {}",
+                key,
+                extra.join(", "),
+                declared.join(", "),
+            ),
+        });
+    }
+
+    // 2. Required fields present
+    let missing: Vec<&str> = field_defs
+        .iter()
+        .filter(|(_, d)| d.required)
+        .filter(|(name, _)| !obj.contains_key(name.as_str()))
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if !missing.is_empty() {
+        return Err(KvError::DataValidation {
+            message: format!(
+                "key '{}': missing required data fields: {}",
+                key,
+                missing.join(", "),
+            ),
+        });
+    }
+
+    // 3. Type checking
+    for (name, value) in obj {
+        if let Some(def) = field_defs.get(name.as_str()) {
+            let ok = match def.field_type {
+                DataFieldType::String => value.is_string(),
+                DataFieldType::Number => value.is_number(),
+                DataFieldType::Boolean => value.is_boolean(),
+                DataFieldType::Array => value.is_array(),
+                DataFieldType::Object => value.is_object(),
+            };
+            if !ok {
+                let got = match value {
+                    serde_json::Value::Null => "null",
+                    serde_json::Value::Bool(_) => "boolean",
+                    serde_json::Value::Number(_) => "number",
+                    serde_json::Value::String(_) => "string",
+                    serde_json::Value::Array(_) => "array",
+                    serde_json::Value::Object(_) => "object",
+                };
+                return Err(KvError::DataValidation {
+                    message: format!(
+                        "key '{}': field '{}' must be {}, got {}",
+                        key, name, def.field_type, got,
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -940,6 +1079,30 @@ impl KvStore {
         memory: Option<String>,
     ) -> Result<PushResult, KvError> {
         let def = self.key_def(key)?.clone();
+
+        // Validate --data against schema field defs when present.
+        if let Some(ref field_defs) = def.data {
+            match data {
+                Some(ref data_val) => validate_data(key, data_val, field_defs)?,
+                None => {
+                    let required: Vec<&str> = field_defs
+                        .iter()
+                        .filter(|(_, d)| d.required)
+                        .map(|(n, _)| n.as_str())
+                        .collect();
+                    if !required.is_empty() {
+                        return Err(KvError::DataValidation {
+                            message: format!(
+                                "key '{}': --data is required (schema has required fields: {})",
+                                key,
+                                required.join(", "),
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+
         let ts_str = ts.to_rfc3339();
 
         match def.value_type {
@@ -5875,5 +6038,342 @@ max_entries = 5
             latest.contains("2026-04-22"),
             "latest_ts should be the most recent matching entry"
         );
+    }
+
+    // -- Data field schema parsing --
+
+    fn data_schema() -> &'static str {
+        r#"
+[keys.projects]
+type = "history"
+max_entries = 100
+
+[keys.projects.data]
+status = { type = "string", required = true }
+tags = { type = "array" }
+repo = { type = "string" }
+priority = { type = "number" }
+
+[keys.notes]
+type = "history"
+"#
+    }
+
+    #[test]
+    fn parse_schema_with_data_fields() {
+        let (store, _dir) = setup_store(data_schema());
+        let projects = &store.schema.keys["projects"];
+        let data_defs = projects.data.as_ref().expect("data should be Some");
+        assert_eq!(data_defs.len(), 4);
+        assert_eq!(data_defs["status"].field_type, DataFieldType::String);
+        assert!(data_defs["status"].required);
+        assert_eq!(data_defs["tags"].field_type, DataFieldType::Array);
+        assert!(!data_defs["tags"].required);
+        assert_eq!(data_defs["repo"].field_type, DataFieldType::String);
+        assert_eq!(data_defs["priority"].field_type, DataFieldType::Number);
+    }
+
+    #[test]
+    fn parse_schema_data_field_types() {
+        let schema = r#"
+[keys.all_types]
+type = "history"
+
+[keys.all_types.data]
+s = { type = "string" }
+n = { type = "number" }
+b = { type = "boolean" }
+a = { type = "array" }
+o = { type = "object" }
+"#;
+        let (store, _dir) = setup_store(schema);
+        let defs = store.schema.keys["all_types"]
+            .data
+            .as_ref()
+            .expect("data should be Some");
+        assert_eq!(defs["s"].field_type, DataFieldType::String);
+        assert_eq!(defs["n"].field_type, DataFieldType::Number);
+        assert_eq!(defs["b"].field_type, DataFieldType::Boolean);
+        assert_eq!(defs["a"].field_type, DataFieldType::Array);
+        assert_eq!(defs["o"].field_type, DataFieldType::Object);
+    }
+
+    #[test]
+    fn parse_schema_data_field_required_and_default() {
+        let schema = r#"
+[keys.test]
+type = "history"
+
+[keys.test.data]
+name = { type = "string", required = true, default = "unnamed" }
+opt = { type = "string" }
+"#;
+        let (store, _dir) = setup_store(schema);
+        let defs = store.schema.keys["test"]
+            .data
+            .as_ref()
+            .expect("data should be Some");
+        assert!(defs["name"].required);
+        assert_eq!(defs["name"].default.as_deref(), Some("unnamed"));
+        assert!(!defs["opt"].required);
+        assert!(defs["opt"].default.is_none());
+    }
+
+    #[test]
+    fn parse_schema_without_data_preserves_none() {
+        let (store, _dir) = setup_store(data_schema());
+        assert!(
+            store.schema.keys["notes"].data.is_none(),
+            "key without [data] section should have data: None"
+        );
+    }
+
+    // -- validate_data unit tests --
+
+    fn sample_field_defs() -> BTreeMap<String, DataFieldDef> {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "status".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::String,
+                required: true,
+                default: None,
+            },
+        );
+        m.insert(
+            "tags".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Array,
+                required: false,
+                default: None,
+            },
+        );
+        m.insert(
+            "priority".to_string(),
+            DataFieldDef {
+                field_type: DataFieldType::Number,
+                required: false,
+                default: None,
+            },
+        );
+        m
+    }
+
+    #[test]
+    fn validate_data_accepts_valid() {
+        let defs = sample_field_defs();
+        let data = serde_json::json!({
+            "status": "active",
+            "tags": ["a", "b"],
+            "priority": 5
+        });
+        assert!(validate_data("test", &data, &defs).is_ok());
+    }
+
+    #[test]
+    fn validate_data_rejects_extra_field() {
+        let defs = sample_field_defs();
+        let data = serde_json::json!({
+            "status": "active",
+            "unknown_field": true
+        });
+        let err = validate_data("test", &data, &defs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("undeclared"), "error should mention undeclared: {}", msg);
+        assert!(msg.contains("unknown_field"), "error should name the extra field: {}", msg);
+        assert!(msg.contains("priority"), "error should list declared fields: {}", msg);
+    }
+
+    #[test]
+    fn validate_data_rejects_missing_required() {
+        let defs = sample_field_defs();
+        let data = serde_json::json!({
+            "tags": ["a"]
+        });
+        let err = validate_data("test", &data, &defs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing required"), "error should say missing required: {}", msg);
+        assert!(msg.contains("status"), "error should name the missing field: {}", msg);
+    }
+
+    #[test]
+    fn validate_data_allows_missing_optional() {
+        let defs = sample_field_defs();
+        // Only the required field is present; optional fields omitted.
+        let data = serde_json::json!({
+            "status": "active"
+        });
+        assert!(validate_data("test", &data, &defs).is_ok());
+    }
+
+    #[test]
+    fn validate_data_rejects_type_mismatch() {
+        let defs = sample_field_defs();
+        let data = serde_json::json!({
+            "status": 42
+        });
+        let err = validate_data("test", &data, &defs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("must be string"), "error should say expected type: {}", msg);
+        assert!(msg.contains("got number"), "error should say actual type: {}", msg);
+    }
+
+    #[test]
+    fn validate_data_all_types() {
+        // Correct values for each type
+        let mut defs = BTreeMap::new();
+        defs.insert("s".to_string(), DataFieldDef { field_type: DataFieldType::String, required: false, default: None });
+        defs.insert("n".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
+        defs.insert("b".to_string(), DataFieldDef { field_type: DataFieldType::Boolean, required: false, default: None });
+        defs.insert("a".to_string(), DataFieldDef { field_type: DataFieldType::Array, required: false, default: None });
+        defs.insert("o".to_string(), DataFieldDef { field_type: DataFieldType::Object, required: false, default: None });
+
+        // All correct
+        let data = serde_json::json!({
+            "s": "hello",
+            "n": 3.14,
+            "b": true,
+            "a": [1, 2, 3],
+            "o": {"nested": true}
+        });
+        assert!(validate_data("test", &data, &defs).is_ok());
+
+        // String field gets number
+        let bad = serde_json::json!({ "s": 42 });
+        assert!(validate_data("test", &bad, &defs).is_err());
+
+        // Number field gets string
+        let bad = serde_json::json!({ "n": "nope" });
+        assert!(validate_data("test", &bad, &defs).is_err());
+
+        // Boolean field gets string
+        let bad = serde_json::json!({ "b": "true" });
+        assert!(validate_data("test", &bad, &defs).is_err());
+
+        // Array field gets object
+        let bad = serde_json::json!({ "a": {"not": "array"} });
+        assert!(validate_data("test", &bad, &defs).is_err());
+
+        // Object field gets array
+        let bad = serde_json::json!({ "o": [1, 2] });
+        assert!(validate_data("test", &bad, &defs).is_err());
+    }
+
+    #[test]
+    fn validate_data_empty_object_all_optional() {
+        let mut defs = BTreeMap::new();
+        defs.insert("opt1".to_string(), DataFieldDef { field_type: DataFieldType::String, required: false, default: None });
+        defs.insert("opt2".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
+
+        let data = serde_json::json!({});
+        assert!(validate_data("test", &data, &defs).is_ok());
+    }
+
+    #[test]
+    fn validate_data_empty_object_with_required() {
+        let mut defs = BTreeMap::new();
+        defs.insert("req".to_string(), DataFieldDef { field_type: DataFieldType::String, required: true, default: None });
+        defs.insert("opt".to_string(), DataFieldDef { field_type: DataFieldType::Number, required: false, default: None });
+
+        let data = serde_json::json!({});
+        let err = validate_data("test", &data, &defs).unwrap_err();
+        assert!(err.to_string().contains("missing required"));
+        assert!(err.to_string().contains("req"));
+    }
+
+    // -- Integration: push with data validation --
+
+    #[test]
+    fn push_with_valid_data_and_schema() {
+        let (mut store, _dir) = setup_store(data_schema());
+        let data = serde_json::json!({
+            "status": "active",
+            "tags": ["rust"],
+            "repo": "mx",
+            "priority": 1
+        });
+        let result = store.push("projects", "my-project", Some(data.clone()), None);
+        assert!(result.is_ok(), "push with valid data should succeed");
+
+        // Verify the entry is stored
+        match &store.data.entries["projects"] {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].data.as_ref().unwrap(), &data);
+            }
+            _ => panic!("expected History"),
+        }
+    }
+
+    #[test]
+    fn push_with_invalid_data_rejected() {
+        let (mut store, _dir) = setup_store(data_schema());
+        let data = serde_json::json!({
+            "status": 42
+        });
+        let result = store.push("projects", "bad-project", Some(data), None);
+        assert!(result.is_err(), "push with invalid data should fail");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "error should be DataValidation, got: {:?}",
+            err
+        );
+
+        // Verify no entry was stored
+        assert!(
+            !store.data.entries.contains_key("projects"),
+            "rejected push should not create an entry"
+        );
+    }
+
+    #[test]
+    fn push_without_data_when_required() {
+        let (mut store, _dir) = setup_store(data_schema());
+        let result = store.push("projects", "no-data", None, None);
+        assert!(result.is_err(), "push without data when schema has required fields should fail");
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--data is required"), "error should mention --data: {}", msg);
+        assert!(msg.contains("status"), "error should name the required field: {}", msg);
+    }
+
+    #[test]
+    fn push_without_data_when_all_optional() {
+        let schema = r#"
+[keys.loose]
+type = "history"
+
+[keys.loose.data]
+note = { type = "string" }
+count = { type = "number" }
+"#;
+        let (mut store, _dir) = setup_store(schema);
+        let result = store.push("loose", "no-data-ok", None, None);
+        assert!(result.is_ok(), "push without data when all fields optional should succeed");
+
+        match &store.data.entries["loose"] {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries.len(), 1);
+                assert!(entries[0].data.is_none(), "data should be None");
+            }
+            _ => panic!("expected History"),
+        }
+    }
+
+    #[test]
+    fn push_without_data_freeform() {
+        let (mut store, _dir) = setup_store(data_schema());
+        // "notes" has no [keys.notes.data] section -- freeform
+        let result = store.push("notes", "anything goes", None, None);
+        assert!(result.is_ok(), "push without data on freeform key should succeed");
+
+        match &store.data.entries["notes"] {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries.len(), 1);
+                assert!(entries[0].data.is_none());
+            }
+            _ => panic!("expected History"),
+        }
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -534,14 +534,18 @@ pub fn validate_data(
         }
     };
 
-    // 1. Reject undeclared fields
-    let declared: Vec<&str> = field_defs.keys().map(|s| s.as_str()).collect();
+    // Null values are treated as absent — they don't trigger undeclared-field
+    // errors, don't satisfy required-field checks, and skip type checking.
+
+    // 1. Reject undeclared fields (ignoring nulls)
     let extra: Vec<&str> = obj
-        .keys()
-        .filter(|k| !field_defs.contains_key(k.as_str()))
-        .map(|k| k.as_str())
+        .iter()
+        .filter(|(_, v)| !v.is_null())
+        .filter(|(k, _)| !field_defs.contains_key(k.as_str()))
+        .map(|(k, _)| k.as_str())
         .collect();
     if !extra.is_empty() {
+        let declared: Vec<&str> = field_defs.keys().map(|s| s.as_str()).collect();
         return Err(KvError::DataValidation {
             message: format!(
                 "key '{}': undeclared data fields: {}; declared fields: {}",
@@ -552,11 +556,11 @@ pub fn validate_data(
         });
     }
 
-    // 2. Required fields present
+    // 2. Required fields present (null counts as absent)
     let missing: Vec<&str> = field_defs
         .iter()
         .filter(|(_, d)| d.required)
-        .filter(|(name, _)| !obj.contains_key(name.as_str()))
+        .filter(|(name, _)| !obj.get(name.as_str()).map_or(false, |v| !v.is_null()))
         .map(|(name, _)| name.as_str())
         .collect();
     if !missing.is_empty() {
@@ -569,8 +573,11 @@ pub fn validate_data(
         });
     }
 
-    // 3. Type checking
+    // 3. Type checking (nulls skipped)
     for (name, value) in obj {
+        if value.is_null() {
+            continue;
+        }
         if let Some(def) = field_defs.get(name.as_str()) {
             let ok = match def.field_type {
                 DataFieldType::String => value.is_string(),
@@ -6375,5 +6382,57 @@ count = { type = "number" }
             }
             _ => panic!("expected History"),
         }
+    }
+
+    // -- Null handling --
+
+    #[test]
+    fn validate_data_null_optional_field_treated_as_absent() {
+        let defs = sample_field_defs();
+        let data = serde_json::json!({
+            "status": "active",
+            "tags": null
+        });
+        assert!(
+            validate_data("test", &data, &defs).is_ok(),
+            "null on optional field should be treated as absent"
+        );
+    }
+
+    #[test]
+    fn validate_data_null_required_field_is_missing() {
+        let defs = sample_field_defs();
+        let data = serde_json::json!({
+            "status": null
+        });
+        let err = validate_data("test", &data, &defs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing required"), "null on required field = missing: {}", msg);
+        assert!(msg.contains("status"), "{}", msg);
+    }
+
+    #[test]
+    fn validate_data_null_undeclared_field_ignored() {
+        let defs = sample_field_defs();
+        let data = serde_json::json!({
+            "status": "active",
+            "ghost": null
+        });
+        assert!(
+            validate_data("test", &data, &defs).is_ok(),
+            "null undeclared field should be ignored (treated as absent)"
+        );
+    }
+
+    #[test]
+    fn validate_data_rejects_non_object() {
+        let defs = sample_field_defs();
+        let array = serde_json::json!(["not", "an", "object"]);
+        let err = validate_data("test", &array, &defs).unwrap_err();
+        assert!(err.to_string().contains("must be a JSON object"));
+
+        let string = serde_json::json!("just a string");
+        let err = validate_data("test", &string, &defs).unwrap_err();
+        assert!(err.to_string().contains("must be a JSON object"));
     }
 }


### PR DESCRIPTION
## Summary

Adds optional typed field definitions to kv schemas, enabling validation on push. Part 2 of #312.

- New `[keys.X.data]` TOML section for declaring field names, types, and required constraints
- Push validates data against schema when definitions exist: rejects undeclared fields, enforces required fields, checks types (string, number, boolean, array, object)
- Freeform behavior preserved when no `[keys.X.data]` section is present
- Null values treated as absent (pass for optional fields, fail for required)
- `DataFieldDef.default` field parsed but reserved for Part 3 (migration)

**Schema format:**
```toml
[keys.projects]
type = "history"
max_entries = 100

[keys.projects.data]
status = { type = "string", required = true }
tags = { type = "array" }
priority = { type = "number" }
```

## Files changed

- `src/kv.rs` — `DataFieldType` enum, `DataFieldDef` struct, `validate_data()`, `DataValidation` error variant, push wiring, 21 tests
- `src/handlers/kv.rs` — `DataValidation` → `EXIT_INVALID_INPUT` mapping (1 line)

## Test plan

- [ ] 4 schema parsing tests (data fields, all types, required+default, none preserved)
- [ ] 8 `validate_data` unit tests (valid, extra field, missing required, optional missing, type mismatch, all types, empty object variants)
- [ ] 5 push integration tests (valid data, invalid rejected, no data with required, no data all optional, freeform)
- [ ] 4 null handling tests (null optional, null required, null undeclared, non-object input)
- [ ] All 919 tests pass, 0 regressions

Ref #312