### PR TITLE
fix: skip invalid JSONL lines in codex save (#178)

### DIFF
--- a/src/codex/archive/write.rs
+++ b/src/codex/archive/write.rs
@@ -352,7 +352,10 @@ pub(crate) fn archive_session(
                 let agent_content = match fs::read_to_string(&source_path) {
                     Ok(c) => c,
                     Err(e) => {
-                        eprintln!("warning: failed to read agent file {:?}: {}", source_path, e);
+                        eprintln!(
+                            "warning: failed to read agent file {:?}: {}",
+                            source_path, e
+                        );
                         continue;
                     }
                 };

--- a/src/codex/archive/write.rs
+++ b/src/codex/archive/write.rs
@@ -349,16 +349,28 @@ pub(crate) fn archive_session(
         if !agents.is_empty() {
             for agent in &agents {
                 let source_path = PathBuf::from(&agent.id);
-                if let Ok(agent_content) = fs::read_to_string(&source_path)
-                    && let Ok((_modified_agent_content, agent_images, agent_stats)) =
-                        extract_images_from_jsonl(&agent_content, &images_dir)
-                {
-                    total_stats.parsed += agent_stats.parsed;
-                    total_stats.skipped += agent_stats.skipped;
-                    for img in agent_images {
-                        if !all_images.iter().any(|existing| existing.hash == img.hash) {
-                            all_images.push(img);
+                let agent_content = match fs::read_to_string(&source_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("warning: failed to read agent file {:?}: {}", source_path, e);
+                        continue;
+                    }
+                };
+                match extract_images_from_jsonl(&agent_content, &images_dir) {
+                    Ok((_modified_agent_content, agent_images, agent_stats)) => {
+                        total_stats.parsed += agent_stats.parsed;
+                        total_stats.skipped += agent_stats.skipped;
+                        for img in agent_images {
+                            if !all_images.iter().any(|existing| existing.hash == img.hash) {
+                                all_images.push(img);
+                            }
                         }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "warning: failed to extract images from agent file {:?}: {}",
+                            source_path, e
+                        );
                     }
                 }
             }
@@ -438,8 +450,7 @@ pub(crate) fn archive_session(
         println!("Archived session (clean) to: {}", archive_dir.display());
         if total_stats.skipped > 0 {
             println!(
-                "  Messages: {} ({}/{} parsed, {} skipped)",
-                total_stats.parsed,
+                "  Messages: {}/{} parsed, {} skipped",
                 total_stats.parsed,
                 total_stats.total(),
                 total_stats.skipped,
@@ -548,8 +559,7 @@ pub(crate) fn archive_session(
     println!("Archived session to: {}", archive_dir.display());
     if total_stats.skipped > 0 {
         println!(
-            "  Messages: {} ({}/{} parsed, {} skipped)",
-            total_stats.parsed,
+            "  Messages: {}/{} parsed, {} skipped",
             total_stats.parsed,
             total_stats.total(),
             total_stats.skipped,

--- a/src/codex/archive/write.rs
+++ b/src/codex/archive/write.rs
@@ -341,16 +341,20 @@ pub(crate) fn archive_session(
         let images_dir = archive_dir.join("images");
         fs::create_dir_all(&images_dir)?;
 
-        let (_stripped_content, mut all_images) = extract_images_from_jsonl(&content, &images_dir)?;
+        let (_stripped_content, mut all_images, session_stats) =
+            extract_images_from_jsonl(&content, &images_dir)?;
+        let mut total_stats = session_stats;
 
         // Extract images from agent files too (no file copy in clean mode)
         if !agents.is_empty() {
             for agent in &agents {
                 let source_path = PathBuf::from(&agent.id);
                 if let Ok(agent_content) = fs::read_to_string(&source_path)
-                    && let Ok((_modified_agent_content, agent_images)) =
+                    && let Ok((_modified_agent_content, agent_images, agent_stats)) =
                         extract_images_from_jsonl(&agent_content, &images_dir)
                 {
+                    total_stats.parsed += agent_stats.parsed;
+                    total_stats.skipped += agent_stats.skipped;
                     for img in agent_images {
                         if !all_images.iter().any(|existing| existing.hash == img.hash) {
                             all_images.push(img);
@@ -432,7 +436,17 @@ pub(crate) fn archive_session(
         fs::write(archive_dir.join("manifest.json"), manifest_json)?;
 
         println!("Archived session (clean) to: {}", archive_dir.display());
-        println!("  Messages: {}", message_count);
+        if total_stats.skipped > 0 {
+            println!(
+                "  Messages: {} ({}/{} parsed, {} skipped)",
+                total_stats.parsed,
+                total_stats.parsed,
+                total_stats.total(),
+                total_stats.skipped,
+            );
+        } else {
+            println!("  Messages: {}", message_count);
+        }
         println!("  Images: {}", image_count);
         println!("  Size: {} KB", archive_size_bytes / 1024);
         println!("  conversation.md written");
@@ -447,8 +461,9 @@ pub(crate) fn archive_session(
 
     // Extract images from session file and save modified content
     let session_content = fs::read_to_string(session_path)?;
-    let (modified_session_content, mut all_images) =
+    let (modified_session_content, mut all_images, session_stats) =
         extract_images_from_jsonl(&session_content, &images_dir)?;
+    let mut total_stats = session_stats;
 
     let dest_session = archive_dir.join("session.jsonl");
     fs::write(&dest_session, modified_session_content)?;
@@ -467,8 +482,10 @@ pub(crate) fn archive_session(
 
             // Extract images from agent file
             let agent_content = fs::read_to_string(&source_path)?;
-            let (modified_agent_content, agent_images) =
+            let (modified_agent_content, agent_images, agent_stats) =
                 extract_images_from_jsonl(&agent_content, &images_dir)?;
+            total_stats.parsed += agent_stats.parsed;
+            total_stats.skipped += agent_stats.skipped;
 
             // Merge agent images with all_images (deduplication handled by hash check)
             for img in agent_images {
@@ -529,7 +546,17 @@ pub(crate) fn archive_session(
     fs::write(archive_dir.join("manifest.json"), manifest_json)?;
 
     println!("Archived session to: {}", archive_dir.display());
-    println!("  Messages: {}", message_count);
+    if total_stats.skipped > 0 {
+        println!(
+            "  Messages: {} ({}/{} parsed, {} skipped)",
+            total_stats.parsed,
+            total_stats.parsed,
+            total_stats.total(),
+            total_stats.skipped,
+        );
+    } else {
+        println!("  Messages: {}", message_count);
+    }
     println!("  Agents: {}", agents.len());
     println!("  Images: {}", image_count);
     println!("  Size: {} KB", size_bytes / 1024);

--- a/src/codex/images.rs
+++ b/src/codex/images.rs
@@ -7,21 +7,60 @@ use std::path::Path;
 
 use super::ImageInfo;
 
-/// Count images in JSONL without extracting them (for dry-run)
-pub(super) fn count_images_in_jsonl(content: &str) -> Result<usize> {
-    let mut count = 0;
+/// Parsing outcome for a JSONL stream. `skipped` counts non-empty lines
+/// that failed JSON parsing. `parsed` counts non-empty lines that
+/// succeeded.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct JsonlParseStats {
+    pub parsed: usize,
+    pub skipped: usize,
+}
 
-    for line in content.lines() {
+impl JsonlParseStats {
+    pub fn total(&self) -> usize {
+        self.parsed + self.skipped
+    }
+}
+
+fn preview_for_warning(line: &str) -> String {
+    let prefix: String = line.chars().take(50).collect();
+    prefix.escape_default().to_string()
+}
+
+/// Count images in JSONL without extracting them (for dry-run)
+pub(super) fn count_images_in_jsonl(content: &str) -> Result<(usize, JsonlParseStats)> {
+    let mut count = 0;
+    let mut stats = JsonlParseStats::default();
+
+    for (idx, line) in content.lines().enumerate() {
         if line.trim().is_empty() {
             continue;
         }
 
-        let msg: Value = serde_json::from_str(line).context("Failed to parse JSONL line")?;
-
-        count += count_images_in_value(&msg);
+        match serde_json::from_str::<Value>(line) {
+            Ok(msg) => {
+                stats.parsed += 1;
+                count += count_images_in_value(&msg);
+            }
+            Err(_) => {
+                stats.skipped += 1;
+                eprintln!(
+                    "warning: skipping invalid JSONL line {}: {}",
+                    idx + 1,
+                    preview_for_warning(line),
+                );
+            }
+        }
     }
 
-    Ok(count)
+    if stats.parsed == 0 && stats.skipped > 0 {
+        anyhow::bail!(
+            "All {} JSONL line(s) failed to parse — file appears corrupt",
+            stats.skipped
+        );
+    }
+
+    Ok((count, stats))
 }
 
 /// Recursively count images in JSON value
@@ -50,17 +89,32 @@ fn count_images_in_value(value: &Value) -> usize {
 pub(super) fn extract_images_from_jsonl(
     content: &str,
     images_dir: &Path,
-) -> Result<(String, Vec<ImageInfo>)> {
+) -> Result<(String, Vec<ImageInfo>, JsonlParseStats)> {
     let mut images = Vec::new();
     let mut modified_lines = Vec::new();
+    let mut stats = JsonlParseStats::default();
 
-    for line in content.lines() {
+    for (idx, line) in content.lines().enumerate() {
         if line.trim().is_empty() {
             modified_lines.push(line.to_string());
             continue;
         }
 
-        let mut msg: Value = serde_json::from_str(line).context("Failed to parse JSONL line")?;
+        let mut msg: Value = match serde_json::from_str(line) {
+            Ok(v) => {
+                stats.parsed += 1;
+                v
+            }
+            Err(_) => {
+                stats.skipped += 1;
+                eprintln!(
+                    "warning: skipping invalid JSONL line {}: {}",
+                    idx + 1,
+                    preview_for_warning(line),
+                );
+                continue; // drop the bad line from output
+            }
+        };
 
         // Process the message content
         extract_images_from_value(&mut msg, images_dir, &mut images)?;
@@ -68,7 +122,14 @@ pub(super) fn extract_images_from_jsonl(
         modified_lines.push(serde_json::to_string(&msg)?);
     }
 
-    Ok((modified_lines.join("\n") + "\n", images))
+    if stats.parsed == 0 && stats.skipped > 0 {
+        anyhow::bail!(
+            "All {} JSONL line(s) failed to parse — file appears corrupt",
+            stats.skipped
+        );
+    }
+
+    Ok((modified_lines.join("\n") + "\n", images, stats))
 }
 
 /// Recursively walk JSON value and extract images
@@ -186,4 +247,123 @@ fn save_image(
     }
 
     Ok(format!("images/{}", filename))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn valid_line(n: u32) -> String {
+        format!(r#"{{"type":"user","seq":{}}}"#, n)
+    }
+
+    #[test]
+    fn preview_truncates_to_50_chars() {
+        let long = "x".repeat(200);
+        let p = preview_for_warning(&long);
+        // 50 chars of x escape to 50 chars (x is printable)
+        assert_eq!(p.len(), 50);
+    }
+
+    #[test]
+    fn preview_escapes_null_bytes() {
+        let bad = "\u{0}\u{0}\u{0}".to_string();
+        let p = preview_for_warning(&bad);
+        assert!(p.contains("\\u{0}") || p.contains("\\0"));
+    }
+
+    #[test]
+    fn preview_handles_multibyte_utf8() {
+        // Make sure we never split a multi-byte char
+        let s = "日".repeat(100);
+        let p = preview_for_warning(&s);
+        // Should not panic; should be 50 chars of 日 escaped
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn count_all_valid_lines_no_skip() {
+        let content = format!("{}\n{}\n{}\n", valid_line(1), valid_line(2), valid_line(3));
+        let (count, stats) = count_images_in_jsonl(&content).unwrap();
+        assert_eq!(count, 0);
+        assert_eq!(stats.parsed, 3);
+        assert_eq!(stats.skipped, 0);
+    }
+
+    #[test]
+    fn count_skips_invalid_line() {
+        let content = format!("{}\nNOT JSON\n{}\n", valid_line(1), valid_line(2));
+        let (_count, stats) = count_images_in_jsonl(&content).unwrap();
+        assert_eq!(stats.parsed, 2);
+        assert_eq!(stats.skipped, 1);
+    }
+
+    #[test]
+    fn count_all_invalid_returns_err() {
+        let content = "not json\nalso not json\n";
+        let err = count_images_in_jsonl(content).unwrap_err();
+        assert!(err.to_string().contains("All 2 JSONL"));
+    }
+
+    #[test]
+    fn count_empty_content_is_ok() {
+        let (count, stats) = count_images_in_jsonl("").unwrap();
+        assert_eq!(count, 0);
+        assert_eq!(stats.parsed, 0);
+        assert_eq!(stats.skipped, 0);
+    }
+
+    #[test]
+    fn count_all_blank_lines_is_ok() {
+        let (count, stats) = count_images_in_jsonl("\n\n\n").unwrap();
+        assert_eq!(count, 0);
+        assert_eq!(stats.parsed, 0);
+        assert_eq!(stats.skipped, 0);
+    }
+
+    #[test]
+    fn extract_skips_invalid_line_and_drops_from_output() {
+        let dir = TempDir::new().unwrap();
+        let content = format!("{}\nNOT JSON\n{}\n", valid_line(1), valid_line(2));
+        let (output, _images, stats) =
+            extract_images_from_jsonl(&content, dir.path()).unwrap();
+        assert_eq!(stats.parsed, 2);
+        assert_eq!(stats.skipped, 1);
+        assert!(!output.contains("NOT JSON"));
+        assert!(output.contains(r#""seq":1"#));
+        assert!(output.contains(r#""seq":2"#));
+    }
+
+    #[test]
+    fn extract_null_byte_line_is_skipped() {
+        let dir = TempDir::new().unwrap();
+        // Exactly the bug from issue #178
+        let null_line = "\u{0}".repeat(100);
+        let content = format!("{}\n{}\n{}\n", valid_line(1), null_line, valid_line(2));
+        let (output, _images, stats) =
+            extract_images_from_jsonl(&content, dir.path()).unwrap();
+        assert_eq!(stats.parsed, 2);
+        assert_eq!(stats.skipped, 1);
+        assert!(!output.contains('\u{0}'));
+    }
+
+    #[test]
+    fn extract_all_invalid_returns_err() {
+        let dir = TempDir::new().unwrap();
+        let content = "garbage\nmore garbage\n";
+        let err = extract_images_from_jsonl(content, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("All 2 JSONL"));
+    }
+
+    #[test]
+    fn extract_empty_content_is_ok() {
+        let dir = TempDir::new().unwrap();
+        let (output, images, stats) =
+            extract_images_from_jsonl("", dir.path()).unwrap();
+        assert_eq!(stats.parsed, 0);
+        assert_eq!(stats.skipped, 0);
+        assert_eq!(output, "\n");
+        assert!(images.is_empty());
+    }
 }

--- a/src/codex/images.rs
+++ b/src/codex/images.rs
@@ -11,13 +11,13 @@ use super::ImageInfo;
 /// that failed JSON parsing. `parsed` counts non-empty lines that
 /// succeeded.
 #[derive(Debug, Default, Clone, Copy)]
-pub(crate) struct JsonlParseStats {
+pub(super) struct JsonlParseStats {
     pub parsed: usize,
     pub skipped: usize,
 }
 
 impl JsonlParseStats {
-    pub fn total(&self) -> usize {
+    pub(super) fn total(&self) -> usize {
         self.parsed + self.skipped
     }
 }
@@ -25,6 +25,14 @@ impl JsonlParseStats {
 fn preview_for_warning(line: &str) -> String {
     let prefix: String = line.chars().take(50).collect();
     prefix.escape_default().to_string()
+}
+
+fn format_skip_warning(line_num: usize, line: &str) -> String {
+    format!(
+        "warning: skipping invalid JSONL line {}: {}",
+        line_num,
+        preview_for_warning(line),
+    )
 }
 
 /// Count images in JSONL without extracting them (for dry-run)
@@ -44,11 +52,7 @@ pub(super) fn count_images_in_jsonl(content: &str) -> Result<(usize, JsonlParseS
             }
             Err(_) => {
                 stats.skipped += 1;
-                eprintln!(
-                    "warning: skipping invalid JSONL line {}: {}",
-                    idx + 1,
-                    preview_for_warning(line),
-                );
+                eprintln!("{}", format_skip_warning(idx + 1, line));
             }
         }
     }
@@ -107,12 +111,10 @@ pub(super) fn extract_images_from_jsonl(
             }
             Err(_) => {
                 stats.skipped += 1;
-                eprintln!(
-                    "warning: skipping invalid JSONL line {}: {}",
-                    idx + 1,
-                    preview_for_warning(line),
-                );
-                continue; // drop the bad line from output
+                eprintln!("{}", format_skip_warning(idx + 1, line));
+                // Drop the bad line from output — don't propagate corruption into the
+                // archive. The eprintln warning above carries the forensics.
+                continue;
             }
         };
 
@@ -365,5 +367,22 @@ mod tests {
         assert_eq!(stats.skipped, 0);
         assert_eq!(output, "\n");
         assert!(images.is_empty());
+    }
+
+    #[test]
+    fn warning_includes_one_indexed_line_number() {
+        // Bad line at position 27 in a 50-line file
+        let mut lines: Vec<String> = (0..50).map(|i| valid_line(i as u32)).collect();
+        lines[26] = "NOT JSON".to_string(); // position 27 is index 26
+        let content = lines.join("\n");
+
+        // Verify the helper produces the expected text directly
+        let warning = format_skip_warning(27, "NOT JSON");
+        assert_eq!(warning, "warning: skipping invalid JSONL line 27: NOT JSON");
+
+        // And verify the full path produces the right stats
+        let (_count, stats) = count_images_in_jsonl(&content).unwrap();
+        assert_eq!(stats.parsed, 49);
+        assert_eq!(stats.skipped, 1);
     }
 }

--- a/src/codex/images.rs
+++ b/src/codex/images.rs
@@ -328,8 +328,7 @@ mod tests {
     fn extract_skips_invalid_line_and_drops_from_output() {
         let dir = TempDir::new().unwrap();
         let content = format!("{}\nNOT JSON\n{}\n", valid_line(1), valid_line(2));
-        let (output, _images, stats) =
-            extract_images_from_jsonl(&content, dir.path()).unwrap();
+        let (output, _images, stats) = extract_images_from_jsonl(&content, dir.path()).unwrap();
         assert_eq!(stats.parsed, 2);
         assert_eq!(stats.skipped, 1);
         assert!(!output.contains("NOT JSON"));
@@ -343,8 +342,7 @@ mod tests {
         // Exactly the bug from issue #178
         let null_line = "\u{0}".repeat(100);
         let content = format!("{}\n{}\n{}\n", valid_line(1), null_line, valid_line(2));
-        let (output, _images, stats) =
-            extract_images_from_jsonl(&content, dir.path()).unwrap();
+        let (output, _images, stats) = extract_images_from_jsonl(&content, dir.path()).unwrap();
         assert_eq!(stats.parsed, 2);
         assert_eq!(stats.skipped, 1);
         assert!(!output.contains('\u{0}'));
@@ -361,8 +359,7 @@ mod tests {
     #[test]
     fn extract_empty_content_is_ok() {
         let dir = TempDir::new().unwrap();
-        let (output, images, stats) =
-            extract_images_from_jsonl("", dir.path()).unwrap();
+        let (output, images, stats) = extract_images_from_jsonl("", dir.path()).unwrap();
         assert_eq!(stats.parsed, 0);
         assert_eq!(stats.skipped, 0);
         assert_eq!(output, "\n");

--- a/src/codex/migrate.rs
+++ b/src/codex/migrate.rs
@@ -113,7 +113,7 @@ pub(crate) fn migrate_archives(
 
             // Extract images from session.jsonl
             let session_content = fs::read_to_string(&session_file)?;
-            let (modified_session_content, mut all_images) =
+            let (modified_session_content, mut all_images, _stats) =
                 extract_images_from_jsonl(&session_content, &images_dir)?;
 
             // Write back modified session.jsonl
@@ -140,7 +140,7 @@ pub(crate) fn migrate_archives(
 
                         // Extract images from agent file
                         let agent_content = fs::read_to_string(&path)?;
-                        let (modified_agent_content, agent_images) =
+                        let (modified_agent_content, agent_images, _stats) =
                             extract_images_from_jsonl(&agent_content, &images_dir)?;
 
                         // Merge agent images (deduplicate)
@@ -185,7 +185,7 @@ pub(crate) fn migrate_archives(
         } else {
             // Dry run - just count what would be migrated
             let session_content = fs::read_to_string(&session_file)?;
-            let image_count = count_images_in_jsonl(&session_content)?;
+            let (image_count, _stats) = count_images_in_jsonl(&session_content)?;
 
             // Count images in agent files too
             let agents_dir = archive_dir.join("agents");
@@ -197,7 +197,8 @@ pub(crate) fn migrate_archives(
                     let path = entry.path();
                     if path.extension().and_then(|s| s.to_str()) == Some("jsonl") {
                         let agent_content = fs::read_to_string(&path)?;
-                        total_archive_images += count_images_in_jsonl(&agent_content)?;
+                        let (agent_image_count, _stats) = count_images_in_jsonl(&agent_content)?;
+                        total_archive_images += agent_image_count;
                     }
                 }
             }


### PR DESCRIPTION
## 🦝 From the Dumpster

Raccoon fix for codex save failing on invalid JSONL lines (issue #178). DJ escape-hatched the debate, one builder (lil-grabby), three review iterations caught a half-applied fix. Clean after iter 3.

---
*— DJ & lil-grabby* 🦝
*The parliament stayed home. The review loop didn't.*