### PR TITLE
fix(kv): address PR #322 review — 🦝 raccoon-assembled

### DIFF
--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -770,12 +770,6 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         );
                         return Ok(kv::EXIT_INVALID_INPUT);
                     }
-                    if val.as_object().is_some_and(|o| o.is_empty()) && value.is_none() {
-                        eprintln!(
-                            "Error: --data is an empty object and no value was given — nothing to update"
-                        );
-                        return Ok(kv::EXIT_INVALID_INPUT);
-                    }
                     Some(val)
                 }
                 None => None,

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -535,6 +535,178 @@ pub enum IdRef {
 }
 
 // ---------------------------------------------------------------------------
+// Entry-lookup helpers shared by History and List arms
+// ---------------------------------------------------------------------------
+
+/// `HistoryEntry` and `ListEntry` are structurally identical — same fields,
+/// same role in `update_entry`. They exist as separate types because the
+/// outer `DataValue` variant distinguishes append-only history semantics from
+/// mutable list semantics, but at the entry level there's no difference.
+/// This trait acknowledges that and lets the update path be written once.
+///
+/// Shared interface for `HistoryEntry` and `ListEntry` so generic helpers
+/// can operate over both types without duplicating the logic.
+trait EntryFields {
+    fn entry_index(&self) -> u64;
+    fn entry_id(&self) -> &str;
+    fn entry_data(&self) -> &Option<serde_json::Value>;
+    fn entry_id_str(&self) -> String;
+    fn set_value(&mut self, v: &str);
+    fn set_data(&mut self, d: Option<serde_json::Value>);
+}
+
+impl EntryFields for HistoryEntry {
+    fn entry_index(&self) -> u64 { self.index }
+    fn entry_id(&self) -> &str { &self.id }
+    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
+    fn entry_id_str(&self) -> String { self.id.clone() }
+    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
+    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+}
+
+impl EntryFields for ListEntry {
+    fn entry_index(&self) -> u64 { self.index }
+    fn entry_id(&self) -> &str { &self.id }
+    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
+    fn entry_id_str(&self) -> String { self.id.clone() }
+    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
+    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+}
+
+/// Return the Vec position of the entry identified by `id`, or an error.
+///
+/// Uses `position()` so the caller can index the slice directly (`&mut v[pos]`)
+/// — no second search pass and no `.unwrap()`.
+fn find_entry_idx<E: EntryFields>(
+    entries: &[E],
+    id: &IdRef,
+    key: &str,
+) -> Result<usize, KvError> {
+    match id {
+        IdRef::Index(n) => entries
+            .iter()
+            .position(|e| e.entry_index() == *n)
+            .ok_or_else(|| KvError::EntryNotFound {
+                key: key.to_string(),
+                id: format!("{:?}", id),
+            }),
+        IdRef::Id(h) => {
+            let positions: Vec<usize> = entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| e.entry_id().starts_with(h.as_str()))
+                .map(|(i, _)| i)
+                .collect();
+            match positions.len() {
+                0 => Err(KvError::EntryNotFound {
+                    key: key.to_string(),
+                    id: format!("{:?}", id),
+                }),
+                1 => Ok(positions[0]),
+                n => Err(KvError::AmbiguousId {
+                    prefix: h.clone(),
+                    count: n,
+                }),
+            }
+        }
+    }
+}
+
+/// Perform the validated update on `entries[idx]` and return an `UpdateResult`.
+///
+/// Extracted so the `History` and `List` arms of `update_entry` share a single
+/// code path instead of duplicating ~30 lines each.
+fn apply_entry_update<E: EntryFields>(
+    entries: &mut Vec<E>,
+    id: &IdRef,
+    key: &str,
+    def: &KeyDef,
+    new_value: Option<&str>,
+    new_data: Option<&serde_json::Value>,
+) -> Result<UpdateResult, KvError> {
+    let idx = find_entry_idx(entries, id, key)?;
+
+    // Compute merged data from the read-only borrow first.
+    let merged_data = {
+        let entry_data = entries[idx].entry_data();
+        let merged = merge_entry_data(entry_data, new_data, key)?;
+        def.validate_data(key, &merged)?;
+        merged
+    };
+
+    // Commit — safe to index directly because `idx` was verified above.
+    let entry = &mut entries[idx];
+    if let Some(v) = new_value {
+        entry.set_value(v);
+    }
+    entry.set_data(merged_data);
+    Ok(UpdateResult {
+        index: entry.entry_index(),
+        id: entry.entry_id_str(),
+    })
+}
+
+/// Merge `new_data` (a JSON-object patch) into `existing`.
+///
+/// - `None` patch → return existing unchanged.
+/// - Non-null patch fields overwrite / insert; null patch fields delete.
+/// - Empty result → `None`.
+fn merge_entry_data(
+    existing: &Option<serde_json::Value>,
+    patch: Option<&serde_json::Value>,
+    key: &str,
+) -> Result<Option<serde_json::Value>, KvError> {
+    let patch = match patch {
+        None => return Ok(existing.clone()),
+        Some(p) => p,
+    };
+
+    match existing {
+        None => {
+            let patch_obj = patch.as_object().ok_or_else(|| KvError::DataValidation {
+                message: format!("key '{}': --data must be a JSON object", key),
+            })?;
+            let obj: serde_json::Map<_, _> = patch_obj
+                .iter()
+                .filter(|(_, v)| !v.is_null())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            Ok(if obj.is_empty() {
+                None
+            } else {
+                Some(serde_json::Value::Object(obj))
+            })
+        }
+        Some(existing_val) => {
+            let mut merged_obj = existing_val
+                .as_object()
+                .ok_or_else(|| {
+                    KvError::Other(anyhow::anyhow!(
+                        "Data corruption: key '{}' entry has non-object data",
+                        key
+                    ))
+                })?
+                .clone();
+            let patch_obj = patch.as_object().ok_or_else(|| KvError::DataValidation {
+                message: format!("key '{}': --data must be a JSON object", key),
+            })?;
+            for (k, v) in patch_obj {
+                if v.is_null() {
+                    merged_obj.remove(k);
+                } else {
+                    merged_obj.insert(k.clone(), v.clone());
+                }
+            }
+            Ok(if merged_obj.is_empty() {
+                None
+            } else {
+                Some(serde_json::Value::Object(merged_obj))
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Data field validation
 // ---------------------------------------------------------------------------
 
@@ -2259,181 +2431,66 @@ impl KvStore {
         new_value: Option<&str>,
         new_data: Option<serde_json::Value>,
     ) -> Result<UpdateResult, KvError> {
+        // Item 4: reject empty-object data with no value — nothing to update.
+        // Engine-level guard so library consumers get it, not just CLI callers.
+        if new_value.is_none()
+            && new_data.as_ref().is_some_and(|d| d.as_object().is_some_and(|o| o.is_empty()))
+        {
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "key '{}': --data is an empty object and no value was given — nothing to update",
+                    key
+                ),
+            });
+        }
+
         let def = self.key_def(key)?.clone();
+
+        // Guard: key must be a History or List — anything else is a type error.
         match def.value_type {
             ValueType::History | ValueType::List => {}
-            _ => {
+            ValueType::Counter | ValueType::String => {
                 return Err(KvError::TypeMismatch {
                     key: key.to_string(),
-                    expected: "history or list".to_string(),
+                    expected: "update not supported for this entry type".to_string(),
                     got: def.value_type.to_string(),
+                });
+            }
+            ValueType::State => {
+                return Err(KvError::TypeMismatch {
+                    key: key.to_string(),
+                    expected: "history or list (state fields are set with 'mx kv set')".to_string(),
+                    got: "state".to_string(),
                 });
             }
         }
 
-        // Compute merged data on a clone so we can validate before mutating.
-        // This closure captures what we need from the entry without a mutable borrow.
-        let compute_merged =
-            |entry_data: &Option<serde_json::Value>| -> Result<Option<serde_json::Value>, KvError> {
-                match (entry_data, &new_data) {
-                    (_, None) => Ok(entry_data.clone()),
-                    (None, Some(patch)) => {
-                        if !patch.is_object() {
-                            return Err(KvError::DataValidation {
-                                message: format!("key '{}': --data must be a JSON object", key),
-                            });
-                        }
-                        let mut obj = serde_json::Map::new();
-                        for (k, v) in patch.as_object().unwrap() {
-                            if !v.is_null() {
-                                obj.insert(k.clone(), v.clone());
-                            }
-                        }
-                        Ok(if obj.is_empty() {
-                            None
-                        } else {
-                            Some(serde_json::Value::Object(obj))
-                        })
-                    }
-                    (Some(existing), Some(patch)) => {
-                        let mut merged_obj = match existing.as_object() {
-                            Some(o) => o.clone(),
-                            None => {
-                                return Err(KvError::Other(anyhow::anyhow!(
-                                    "Data corruption: key '{}' entry has non-object data",
-                                    key
-                                )));
-                            }
-                        };
-                        let patch_obj = match patch.as_object() {
-                            Some(p) => p,
-                            None => {
-                                return Err(KvError::DataValidation {
-                                    message: format!("key '{}': --data must be a JSON object", key),
-                                });
-                            }
-                        };
-                        for (k, v) in patch_obj {
-                            if v.is_null() {
-                                merged_obj.remove(k);
-                            } else {
-                                merged_obj.insert(k.clone(), v.clone());
-                            }
-                        }
-                        Ok(if merged_obj.is_empty() {
-                            None
-                        } else {
-                            Some(serde_json::Value::Object(merged_obj))
-                        })
-                    }
-                }
-            };
+        let patch = new_data.as_ref();
 
         match self.data.entries.get_mut(key) {
             Some(DataValue::History { entries, .. }) => {
-                // First pass: read-only to compute merged_data and validate.
-                let merged_data = {
-                    let entry = match id {
-                        IdRef::Index(n) => entries.iter().find(|e| e.index == *n),
-                        IdRef::Id(h) => {
-                            let matches: Vec<_> = entries
-                                .iter()
-                                .filter(|e| e.id.starts_with(h.as_str()))
-                                .collect();
-                            match matches.len() {
-                                0 => None,
-                                1 => entries.iter().find(|e| e.id.starts_with(h.as_str())),
-                                n => {
-                                    return Err(KvError::AmbiguousId {
-                                        prefix: h.clone(),
-                                        count: n,
-                                    });
-                                }
-                            }
-                        }
-                    };
-                    let entry = match entry {
-                        Some(e) => e,
-                        None => {
-                            return Err(KvError::EntryNotFound {
-                                key: key.to_string(),
-                                id: format!("{:?}", id),
-                            });
-                        }
-                    };
-                    let merged = compute_merged(&entry.data)?;
-                    def.validate_data(key, &merged)?;
-                    merged
-                };
-                // Second pass: mutable to commit the write.
-                let entry = match id {
-                    IdRef::Index(n) => entries.iter_mut().find(|e| e.index == *n),
-                    IdRef::Id(h) => entries.iter_mut().find(|e| e.id.starts_with(h.as_str())),
-                };
-                let entry = entry.unwrap(); // safe: existence confirmed above
-                if let Some(v) = new_value {
-                    entry.value = v.to_string();
-                }
-                entry.data = merged_data;
-                Ok(UpdateResult {
-                    index: entry.index,
-                    id: entry.id.clone(),
-                })
+                apply_entry_update(entries, id, key, &def, new_value, patch)
             }
             Some(DataValue::List { items, .. }) => {
-                // First pass: read-only to compute merged_data and validate.
-                let merged_data = {
-                    let entry = match id {
-                        IdRef::Index(n) => items.iter().find(|e| e.index == *n),
-                        IdRef::Id(h) => {
-                            let matches: Vec<_> = items
-                                .iter()
-                                .filter(|e| e.id.starts_with(h.as_str()))
-                                .collect();
-                            match matches.len() {
-                                0 => None,
-                                1 => items.iter().find(|e| e.id.starts_with(h.as_str())),
-                                n => {
-                                    return Err(KvError::AmbiguousId {
-                                        prefix: h.clone(),
-                                        count: n,
-                                    });
-                                }
-                            }
-                        }
-                    };
-                    let entry = match entry {
-                        Some(e) => e,
-                        None => {
-                            return Err(KvError::EntryNotFound {
-                                key: key.to_string(),
-                                id: format!("{:?}", id),
-                            });
-                        }
-                    };
-                    let merged = compute_merged(&entry.data)?;
-                    def.validate_data(key, &merged)?;
-                    merged
-                };
-                // Second pass: mutable to commit the write.
-                let entry = match id {
-                    IdRef::Index(n) => items.iter_mut().find(|e| e.index == *n),
-                    IdRef::Id(h) => items.iter_mut().find(|e| e.id.starts_with(h.as_str())),
-                };
-                let entry = entry.unwrap(); // safe: existence confirmed above
-                if let Some(v) = new_value {
-                    entry.value = v.to_string();
-                }
-                entry.data = merged_data;
-                Ok(UpdateResult {
-                    index: entry.index,
-                    id: entry.id.clone(),
-                })
+                apply_entry_update(items, id, key, &def, new_value, patch)
             }
-            _ => Err(KvError::EntryNotFound {
+            None => Err(KvError::EntryNotFound {
                 key: key.to_string(),
-                id: format!("{:?}", id),
+                id: "no entries found".to_string(),
             }),
+            // Schema says history/list (filtered by the type guard above) but the
+            // data file disagrees — this is data corruption, not a user error.
+            // Return `Other` rather than panicking so the engine never aborts.
+            Some(DataValue::Counter { .. }) | Some(DataValue::String { .. }) => {
+                Err(KvError::Other(anyhow::anyhow!(
+                    "data corruption: key '{}' schema is history/list but stored value is a scalar",
+                    key
+                )))
+            }
+            Some(DataValue::State { .. }) => Err(KvError::Other(anyhow::anyhow!(
+                "data corruption: key '{}' schema is history/list but stored value is a state map",
+                key
+            ))),
         }
     }
 

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -538,50 +538,62 @@ pub enum IdRef {
 // Entry-lookup helpers shared by History and List arms
 // ---------------------------------------------------------------------------
 
-/// `HistoryEntry` and `ListEntry` are structurally identical — same fields,
-/// same role in `update_entry`. They exist as separate types because the
-/// outer `DataValue` variant distinguishes append-only history semantics from
-/// mutable list semantics, but at the entry level there's no difference.
-/// This trait acknowledges that and lets the update path be written once.
+/// Shared access to the field set used by `update_entry`.
 ///
-/// Shared interface for `HistoryEntry` and `ListEntry` so generic helpers
-/// can operate over both types without duplicating the logic.
+/// `HistoryEntry` and `ListEntry` are structurally identical — same fields,
+/// same role here. They exist as separate types because the outer `DataValue`
+/// variant distinguishes append-only history semantics from mutable list
+/// semantics, but at the entry level there's no difference. This trait
+/// acknowledges that and lets the update path be written once.
 trait EntryFields {
     fn entry_index(&self) -> u64;
     fn entry_id(&self) -> &str;
     fn entry_data(&self) -> &Option<serde_json::Value>;
-    fn entry_id_str(&self) -> String;
     fn set_value(&mut self, v: &str);
     fn set_data(&mut self, d: Option<serde_json::Value>);
 }
 
 impl EntryFields for HistoryEntry {
-    fn entry_index(&self) -> u64 { self.index }
-    fn entry_id(&self) -> &str { &self.id }
-    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
-    fn entry_id_str(&self) -> String { self.id.clone() }
-    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
-    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+    fn entry_index(&self) -> u64 {
+        self.index
+    }
+    fn entry_id(&self) -> &str {
+        &self.id
+    }
+    fn entry_data(&self) -> &Option<serde_json::Value> {
+        &self.data
+    }
+    fn set_value(&mut self, v: &str) {
+        self.value = v.to_string();
+    }
+    fn set_data(&mut self, d: Option<serde_json::Value>) {
+        self.data = d;
+    }
 }
 
 impl EntryFields for ListEntry {
-    fn entry_index(&self) -> u64 { self.index }
-    fn entry_id(&self) -> &str { &self.id }
-    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
-    fn entry_id_str(&self) -> String { self.id.clone() }
-    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
-    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+    fn entry_index(&self) -> u64 {
+        self.index
+    }
+    fn entry_id(&self) -> &str {
+        &self.id
+    }
+    fn entry_data(&self) -> &Option<serde_json::Value> {
+        &self.data
+    }
+    fn set_value(&mut self, v: &str) {
+        self.value = v.to_string();
+    }
+    fn set_data(&mut self, d: Option<serde_json::Value>) {
+        self.data = d;
+    }
 }
 
 /// Return the Vec position of the entry identified by `id`, or an error.
 ///
 /// Uses `position()` so the caller can index the slice directly (`&mut v[pos]`)
 /// — no second search pass and no `.unwrap()`.
-fn find_entry_idx<E: EntryFields>(
-    entries: &[E],
-    id: &IdRef,
-    key: &str,
-) -> Result<usize, KvError> {
+fn find_entry_idx<E: EntryFields>(entries: &[E], id: &IdRef, key: &str) -> Result<usize, KvError> {
     match id {
         IdRef::Index(n) => entries
             .iter()
@@ -617,7 +629,7 @@ fn find_entry_idx<E: EntryFields>(
 /// Extracted so the `History` and `List` arms of `update_entry` share a single
 /// code path instead of duplicating ~30 lines each.
 fn apply_entry_update<E: EntryFields>(
-    entries: &mut Vec<E>,
+    entries: &mut [E],
     id: &IdRef,
     key: &str,
     def: &KeyDef,
@@ -642,7 +654,7 @@ fn apply_entry_update<E: EntryFields>(
     entry.set_data(merged_data);
     Ok(UpdateResult {
         index: entry.entry_index(),
-        id: entry.entry_id_str(),
+        id: entry.entry_id().to_string(),
     })
 }
 
@@ -682,7 +694,7 @@ fn merge_entry_data(
                 .as_object()
                 .ok_or_else(|| {
                     KvError::Other(anyhow::anyhow!(
-                        "Data corruption: key '{}' entry has non-object data",
+                        "data corruption: key '{}' entry has non-object data",
                         key
                     ))
                 })?
@@ -2431,19 +2443,6 @@ impl KvStore {
         new_value: Option<&str>,
         new_data: Option<serde_json::Value>,
     ) -> Result<UpdateResult, KvError> {
-        // Item 4: reject empty-object data with no value — nothing to update.
-        // Engine-level guard so library consumers get it, not just CLI callers.
-        if new_value.is_none()
-            && new_data.as_ref().is_some_and(|d| d.as_object().is_some_and(|o| o.is_empty()))
-        {
-            return Err(KvError::DataValidation {
-                message: format!(
-                    "key '{}': --data is an empty object and no value was given — nothing to update",
-                    key
-                ),
-            });
-        }
-
         let def = self.key_def(key)?.clone();
 
         // Guard: key must be a History or List — anything else is a type error.
@@ -2452,7 +2451,7 @@ impl KvStore {
             ValueType::Counter | ValueType::String => {
                 return Err(KvError::TypeMismatch {
                     key: key.to_string(),
-                    expected: "update not supported for this entry type".to_string(),
+                    expected: "history or list".to_string(),
                     got: def.value_type.to_string(),
                 });
             }
@@ -2463,6 +2462,22 @@ impl KvStore {
                     got: "state".to_string(),
                 });
             }
+        }
+
+        // Item 4: reject empty-object data with no value — nothing to update.
+        // Engine-level guard so library consumers get it, not just CLI callers.
+        // Runs after key_def and type guard so schema errors take precedence.
+        if new_value.is_none()
+            && new_data
+                .as_ref()
+                .is_some_and(|d| d.as_object().is_some_and(|o| o.is_empty()))
+        {
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "key '{}': --data is an empty object and no value was given — nothing to update",
+                    key
+                ),
+            });
         }
 
         let patch = new_data.as_ref();
@@ -2476,7 +2491,7 @@ impl KvStore {
             }
             None => Err(KvError::EntryNotFound {
                 key: key.to_string(),
-                id: "no entries found".to_string(),
+                id: "(no entries pushed)".to_string(),
             }),
             // Schema says history/list (filtered by the type guard above) but the
             // data file disagrees — this is data corruption, not a user error.


### PR DESCRIPTION
## 🦝 From the Dumpster, With Love

Cory left review on PR #322. Four items. We released six raccoons into the codebase with the same task and watched them diverge. Then I read every trace, picked the parts that didn't smell, and stitched the result on top of garbaggio's decomposition. Two reviewers ran the dumpster-dive afterward — Lil Grabby pressure-tested with 10 adversarial cases, Roach reviewed with the production lens — and we patched seven more things they found before this PR opened.

The four asks:
1. `update_entry` did a read pass to find the entry, then a mutable re-find with `.unwrap()` because "safe: existence confirmed above" (a comment is not a contract). Now it captures `usize` from the first scan and writes via `entries[idx]`.
2. ~60 lines of near-identical History/List code. Now: one `EntryFields` trait, two trivial impls, three free fns (`find_entry_idx`, `apply_entry_update`, `merge_entry_data`). `update_entry` shrinks from ~170 lines to ~55.
3. The catch-all `_ => EntryNotFound` swallowed everything — Counter/String/State, None, data corruption. Now: explicit `Counter | String → TypeMismatch` (early guard, grammatical message), `State → TypeMismatch` with a hint to use `mx kv set`, inner `Counter|String|State` arms return `KvError::Other("data corruption: ...")` (compiler-enforced exhaustive so a new `DataValue` variant won't fall through silently), `None → EntryNotFound { id: "(no entries pushed)" }`.
4. The `--data '{}'` rejection lived in the CLI handler, so a library caller passing `update_entry(key, id, None, Some({}))` programmatically got nothing. Moved into `update_entry` as a `DataValidation` early return — same exit code (`EXIT_INVALID_INPUT`) preserved.

## Who Built What

| Raccoon | Contribution |
|---------|-------------|
| 🦝 **garbaggio** | Cleanest decomposition: `find_entry_idx` + `apply_entry_update` + `merge_entry_data`. THIS is what the structural decomposer is supposed to do — code, not just trace. Base of the merge. |
| 🦝 **trashboat** | Spotted that HistoryEntry and ListEntry are structurally identical (same fields, same role) and that the duplication is a symptom of a deeper redundancy. The trait doc comment credits this insight. Also: corruption-safe explicit arms (`KvError::Other`) instead of a panicking `unreachable!()`. |
| 🦝 **lil-grabby** | Best edge-case audit table going in. Best wording for the empty-data guard message (`"key '{key}': --data is an empty object and no value was given — nothing to update"`). Then came back as pressure-tester and found a real bug: the Counter/String error message rendered as `"is counter, not update not supported for this entry type"` — gibberish through the Display template. Saved the user from a confusing error. |
| 🦝 **roach** | Code reviewer. Caught the `clippy::ptr_arg` warning (`&mut Vec<E>` → `&mut [E]`) that would have become a CI failure the moment anyone added `-D warnings`. Flagged the stilted `id: "no entries found"` rendering and the guard-order suggestion. Verified `mx kv set` actually exists before letting the error message claim it does. Inward lens working. |
| 🦝 **el-notario** | The drift watch was on this run — Item 2 is exactly the "structural decomposer becoming documenter" trap. Verdict: code-side, the helper was real (`update_entry_in_vec`) but garbaggio's was tighter, so el-notario shipped the assembly instead. Contract table in the trace was the best of the six. |
| 🦝 **one-ply** | Opinion mandate landed: trace finally had a paragraph defending the design call, not just sparse code. Implementation was tight (`KvEntryMut` trait + `find_and_update_vec`) but used `DataValidation` for Counter/String/State, which is the wrong error category. The trace was the win. |

## DJ's Take

Six raccoons, one task. Convergence was high — everyone reached for a trait + generic helper for Item 2. Garbaggio won assembly because his factoring extracted `merge_entry_data` too (the others kept the merge logic as an inline closure), and because his `update_entry` body collapsed to ~55 lines of straight-line code with single-line History/List arms. Trashboat's contribution was structural insight: he diagnosed that the deeper fix is merging HistoryEntry and ListEntry into one struct (out of scope here — touches serialization and tests). El-notario built a strong assembly but garbaggio's was tighter. Roach incomplete-deduped (only the mutable commit — read pass still inline). Lil-grabby used closures instead of a trait, which is more idiomatic Rust in some ways but loses readability at the call site. One-ply was the smallest delta but picked the wrong error variants for Item 3.

The Item 3 question — "what error do you return when the catch-all fires?" — broke the swarm into three camps. Two raccoons (el-notario, lil-grabby) returned `TypeMismatch { got: def.value_type.to_string() }`, which has a real bug: by the time you reach the inner match, `def.value_type` IS History or List (the early guard filtered everything else), so the rendered message reads "expected history or list, got history". Trashboat alone returned `KvError::Other("data corruption: ...")` — semantically correct because if Counter/String/State data is sitting under a History/List schema, that IS corruption. I took trashboat's reading, layered it on garbaggio's base, kept garbaggio's early-guard messages for the normal user-error case, and replaced his `unreachable!()` with explicit corruption arms (so the engine never panics on disk drift).

The review loop caught seven more things across two reviewers. Lil-grabby's grammatical-error test exposed that "expected: 'update not supported for this entry type'" plugged into the Display template as `"is counter, not update not supported for this entry type"` — gibberish. Fix: switch to noun-phrase wording (`"history or list"`) that the template was designed for. Roach caught the ptr_arg clippy warning under `-D warnings`. Both agreed the empty-data guard should run AFTER the key lookup so typo'd keys don't get hidden behind "empty data" errors. All fixed in iter 1, both reviewers said ship in iter 2.

## Test Results

- **341/341 GREEN.** 309 lib unit tests + 22 `update_pressure.rs` integration tests + 10 adversarial pressure tests written by Lil Grabby during the review loop (NOT committed — diagnostic only).
- `cargo build` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- Existing tests asserting `TypeMismatch` for Counter keys still pass — the early guard catches them with friendly messages before the inner match.

## Known Issues

- `find_entry_idx` collects all prefix matches into `Vec<usize>` for the ambiguity check. On a 100k-entry list with a one-char prefix, that's a 100k allocation. Both reviewers flagged it. Skipped because (a) no regression vs the PR #322 base — the same shape existed there, and (b) a `take(2)` short-circuit would lose the exact `AmbiguousId.count` payload, which is informative. If anyone ever cares, separate ticket.
- `EntryFields::set_value(&mut self, v: &str)` allocates internally via `to_string()`. Fine today (CLI passes `&str`). If a future caller passes `&String`, they allocate twice. Skipped because no measurable cost today.
- The deeper structural redundancy trashboat surfaced — HistoryEntry and ListEntry are structurally identical — would be solved cleanly by merging the structs and giving the outer `DataValue` variants the semantic distinction. Out of scope: touches serialization, public API, and test fixtures.

## Stats

- Run: `2026-05-21-112051`
- Mode: compete (6 raccoons, same task)
- Crew: trashboat · el-notario · roach · lil-grabby · garbaggio · one-ply
- Assembler: el-notario (lieutenant)
- Reviewers: lil-grabby (pressure-test) + roach (review)
- Iterations: 2
- Branch: `scrapyard/2026-05-21-112051` (built on `scrapyard/2026-05-19-175308`, PR #322's branch)
- Commits in this branch: 2 (assembly + iter-1 fix)
- Lines: `src/kv.rs` +228 −162 net (`update_entry` body alone dropped from ~170 to ~55 lines), `src/handlers/kv.rs` −6
- Notable firsts: first time DJ ran the review loop with mid-run grammatical-error bug found by adversarial pressure-tests.

---

*— DJ & the Trash Pandas* 🦝🔥

*Six raccoons, one match arm, four bugs, two reviewers, zero panics. The Display template was the bug; the test suite never read its own error messages out loud.*