### PR TITLE
feat: mx-pr-fixes — raccoon-assembled

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1870,6 +1870,25 @@ pub enum KvCommands {
         all: bool,
     },
 
+    /// Update an existing entry's value and/or structured data in-place.
+    /// Preserves the entry's ID, position, and timestamp.
+    Update {
+        /// Key name
+        key: String,
+
+        /// New value text (omit to update only --data)
+        value: Option<String>,
+
+        /// Target entry by ID (numeric index or kv-HASH prefix). Required.
+        #[arg(long)]
+        id: String,
+
+        /// JSON object to merge into the entry's structured data.
+        /// Null field values delete that field from the merged result.
+        #[arg(long)]
+        data: Option<String>,
+    },
+
     /// Search entries in a list/history by substring and/or structured data filters
     Search {
         /// Key name

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -770,12 +770,6 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         );
                         return Ok(kv::EXIT_INVALID_INPUT);
                     }
-                    if val.as_object().is_some_and(|o| o.is_empty()) && value.is_none() {
-                        eprintln!(
-                            "Error: --data is an empty object and no value was given — nothing to update"
-                        );
-                        return Ok(kv::EXIT_INVALID_INPUT);
-                    }
                     Some(val)
                 }
                 None => None,

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -725,6 +725,67 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             }
         }
 
+        KvCommands::Update {
+            key,
+            value,
+            id,
+            data,
+        } => {
+            // 1. Reject the no-op case (both fields missing).
+            if value.is_none() && data.is_none() {
+                eprintln!("Error: provide a value argument and/or --data to update");
+                return Ok(kv::EXIT_INVALID_INPUT);
+            }
+
+            // 2. Parse the ID into IdRef (numeric or kv-HASH).
+            let id_ref = match parse_single_id(&id) {
+                Ok(r) => r,
+                Err(msg) => {
+                    eprintln!("Error: {}", msg);
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
+            };
+
+            // 3. Parse --data as JSON object (mirror push's checks).
+            let parsed_data = match data {
+                Some(ref json_str) => {
+                    let val: serde_json::Value = match serde_json::from_str(json_str) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("Error: invalid JSON for --data: {}", e);
+                            return Ok(kv::EXIT_INVALID_INPUT);
+                        }
+                    };
+                    if !val.is_object() {
+                        eprintln!(
+                            "Error: --data must be a JSON object, got {}",
+                            match val {
+                                serde_json::Value::Array(_) => "array",
+                                serde_json::Value::String(_) => "string",
+                                serde_json::Value::Number(_) => "number",
+                                serde_json::Value::Bool(_) => "boolean",
+                                serde_json::Value::Null => "null",
+                                serde_json::Value::Object(_) => unreachable!(),
+                            }
+                        );
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
+                    Some(val)
+                }
+                None => None,
+            };
+
+            // 4. Dispatch to engine.
+            match store.update_entry(&key, &id_ref, value.as_deref(), parsed_data) {
+                Ok(result) => {
+                    store.save()?;
+                    println!("Updated entry {} (kv-{})", result.index, result.id);
+                    Ok(kv::EXIT_OK)
+                }
+                Err(e) => handle_kv_err(e),
+            }
+        }
+
         KvCommands::Search {
             key,
             query,

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -770,6 +770,10 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         );
                         return Ok(kv::EXIT_INVALID_INPUT);
                     }
+                    if val.as_object().is_some_and(|o| o.is_empty()) && value.is_none() {
+                        eprintln!("Error: --data is an empty object and no value was given — nothing to update");
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
                     Some(val)
                 }
                 None => None,

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -771,7 +771,9 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                         return Ok(kv::EXIT_INVALID_INPUT);
                     }
                     if val.as_object().is_some_and(|o| o.is_empty()) && value.is_none() {
-                        eprintln!("Error: --data is an empty object and no value was given — nothing to update");
+                        eprintln!(
+                            "Error: --data is an empty object and no value was given — nothing to update"
+                        );
                         return Ok(kv::EXIT_INVALID_INPUT);
                     }
                     Some(val)

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -2273,52 +2273,61 @@ impl KvStore {
 
         // Compute merged data on a clone so we can validate before mutating.
         // This closure captures what we need from the entry without a mutable borrow.
-        let compute_merged = |entry_data: &Option<serde_json::Value>| -> Result<Option<serde_json::Value>, KvError> {
-            match (entry_data, &new_data) {
-                (_, None) => Ok(entry_data.clone()),
-                (None, Some(patch)) => {
-                    if !patch.is_object() {
-                        return Err(KvError::DataValidation {
-                            message: format!("key '{}': --data must be a JSON object", key),
-                        });
-                    }
-                    let mut obj = serde_json::Map::new();
-                    for (k, v) in patch.as_object().unwrap() {
-                        if !v.is_null() {
-                            obj.insert(k.clone(), v.clone());
-                        }
-                    }
-                    Ok(if obj.is_empty() { None } else { Some(serde_json::Value::Object(obj)) })
-                }
-                (Some(existing), Some(patch)) => {
-                    let mut merged_obj = match existing.as_object() {
-                        Some(o) => o.clone(),
-                        None => {
-                            return Err(KvError::Other(anyhow::anyhow!(
-                                "Data corruption: key '{}' entry has non-object data",
-                                key
-                            )));
-                        }
-                    };
-                    let patch_obj = match patch.as_object() {
-                        Some(p) => p,
-                        None => {
+        let compute_merged =
+            |entry_data: &Option<serde_json::Value>| -> Result<Option<serde_json::Value>, KvError> {
+                match (entry_data, &new_data) {
+                    (_, None) => Ok(entry_data.clone()),
+                    (None, Some(patch)) => {
+                        if !patch.is_object() {
                             return Err(KvError::DataValidation {
                                 message: format!("key '{}': --data must be a JSON object", key),
                             });
                         }
-                    };
-                    for (k, v) in patch_obj {
-                        if v.is_null() {
-                            merged_obj.remove(k);
-                        } else {
-                            merged_obj.insert(k.clone(), v.clone());
+                        let mut obj = serde_json::Map::new();
+                        for (k, v) in patch.as_object().unwrap() {
+                            if !v.is_null() {
+                                obj.insert(k.clone(), v.clone());
+                            }
                         }
+                        Ok(if obj.is_empty() {
+                            None
+                        } else {
+                            Some(serde_json::Value::Object(obj))
+                        })
                     }
-                    Ok(if merged_obj.is_empty() { None } else { Some(serde_json::Value::Object(merged_obj)) })
+                    (Some(existing), Some(patch)) => {
+                        let mut merged_obj = match existing.as_object() {
+                            Some(o) => o.clone(),
+                            None => {
+                                return Err(KvError::Other(anyhow::anyhow!(
+                                    "Data corruption: key '{}' entry has non-object data",
+                                    key
+                                )));
+                            }
+                        };
+                        let patch_obj = match patch.as_object() {
+                            Some(p) => p,
+                            None => {
+                                return Err(KvError::DataValidation {
+                                    message: format!("key '{}': --data must be a JSON object", key),
+                                });
+                            }
+                        };
+                        for (k, v) in patch_obj {
+                            if v.is_null() {
+                                merged_obj.remove(k);
+                            } else {
+                                merged_obj.insert(k.clone(), v.clone());
+                            }
+                        }
+                        Ok(if merged_obj.is_empty() {
+                            None
+                        } else {
+                            Some(serde_json::Value::Object(merged_obj))
+                        })
+                    }
                 }
-            }
-        };
+            };
 
         match self.data.entries.get_mut(key) {
             Some(DataValue::History { entries, .. }) => {
@@ -2366,7 +2375,10 @@ impl KvStore {
                     entry.value = v.to_string();
                 }
                 entry.data = merged_data;
-                Ok(UpdateResult { index: entry.index, id: entry.id.clone() })
+                Ok(UpdateResult {
+                    index: entry.index,
+                    id: entry.id.clone(),
+                })
             }
             Some(DataValue::List { items, .. }) => {
                 // First pass: read-only to compute merged_data and validate.
@@ -2413,7 +2425,10 @@ impl KvStore {
                     entry.value = v.to_string();
                 }
                 entry.data = merged_data;
-                Ok(UpdateResult { index: entry.index, id: entry.id.clone() })
+                Ok(UpdateResult {
+                    index: entry.index,
+                    id: entry.id.clone(),
+                })
             }
             _ => Err(KvError::EntryNotFound {
                 key: key.to_string(),
@@ -7646,9 +7661,7 @@ count = { type = "number" }
     #[test]
     fn update_value_only_preserves_ts_and_id_history() {
         let (mut store, _dir) = setup_store(test_schema());
-        let push = store
-            .push("flavor_history", "mint", None, None)
-            .unwrap();
+        let push = store.push("flavor_history", "mint", None, None).unwrap();
         let before = get_history_entry(&store, "flavor_history", push.index);
 
         let result = store
@@ -7793,9 +7806,7 @@ count = { type = "number" }
     #[test]
     fn update_data_on_entry_with_no_data() {
         let (mut store, _dir) = setup_store(test_schema());
-        let push = store
-            .push("flavor_history", "oolong", None, None)
-            .unwrap();
+        let push = store.push("flavor_history", "oolong", None, None).unwrap();
 
         let patch = serde_json::json!({"a": 1});
         store
@@ -7832,7 +7843,10 @@ count = { type = "number" }
             err
         );
         let after = get_history_entry(&store, "items", push.index);
-        assert_eq!(after.data, before.data, "entry must be unchanged on failure");
+        assert_eq!(
+            after.data, before.data,
+            "entry must be unchanged on failure"
+        );
     }
 
     #[test]
@@ -7856,7 +7870,10 @@ count = { type = "number" }
             err
         );
         let after = get_history_entry(&store, "items", push.index);
-        assert_eq!(after.data, before.data, "entry must be unchanged on failure");
+        assert_eq!(
+            after.data, before.data,
+            "entry must be unchanged on failure"
+        );
     }
 
     #[test]
@@ -7876,14 +7893,20 @@ count = { type = "number" }
         let after = get_history_entry(&store, "items", push.index);
 
         let data = after.data.as_ref().unwrap();
-        assert_eq!(data["status"], serde_json::json!("open"), "required field preserved in merge");
+        assert_eq!(
+            data["status"],
+            serde_json::json!("open"),
+            "required field preserved in merge"
+        );
         assert_eq!(data["count"], serde_json::json!(2), "count updated");
     }
 
     #[test]
     fn update_entry_not_found_by_index() {
         let (mut store, _dir) = setup_store(test_schema());
-        store.push("flavor_history", "darjeeling", None, None).unwrap();
+        store
+            .push("flavor_history", "darjeeling", None, None)
+            .unwrap();
 
         let err = store
             .update_entry("flavor_history", &IdRef::Index(999), Some("new"), None)
@@ -7921,12 +7944,14 @@ count = { type = "number" }
         store.push("tags", "alpha", None, None).unwrap();
         store.push("tags", "beta", None, None).unwrap();
         // Empty prefix matches every entry — always ambiguous when there are 2+.
-        let err = store.update_entry(
-            "tags",
-            &IdRef::Id("".to_string()),
-            Some("beta-updated"),
-            None,
-        ).unwrap_err();
+        let err = store
+            .update_entry(
+                "tags",
+                &IdRef::Id("".to_string()),
+                Some("beta-updated"),
+                None,
+            )
+            .unwrap_err();
         match err {
             KvError::AmbiguousId { count, .. } => assert_eq!(count, 2),
             other => panic!("expected AmbiguousId, got {:?}", other),
@@ -7949,9 +7974,7 @@ count = { type = "number" }
     #[test]
     fn update_id_lookup_by_prefix_unique() {
         let (mut store, _dir) = setup_store(test_schema());
-        let push = store
-            .push("flavor_history", "gyokuro", None, None)
-            .unwrap();
+        let push = store.push("flavor_history", "gyokuro", None, None).unwrap();
 
         // Take first 4 chars of id as prefix
         let prefix = push.id[..4.min(push.id.len())].to_string();

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -520,6 +520,13 @@ pub struct PushResult {
     pub id: String,
 }
 
+/// Result of an `update_entry` operation.
+#[derive(Debug)]
+pub struct UpdateResult {
+    pub index: u64,
+    pub id: String,
+}
+
 /// Reference to a kv entry by either its numeric index or its stable ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdRef {
@@ -2226,6 +2233,187 @@ impl KvStore {
                         id: format!("{:?}", id),
                     }),
                 }
+            }
+            _ => Err(KvError::EntryNotFound {
+                key: key.to_string(),
+                id: format!("{:?}", id),
+            }),
+        }
+    }
+
+    /// Update an existing entry in a history or list in-place.
+    ///
+    /// Preserves the entry's `index`, `id`, `ts`, and position in the list.
+    /// When `new_value` is `Some`, replaces the entry's `value`.
+    /// When `new_data` is `Some`, performs a shallow object merge into the existing
+    /// `data` field. Null values in the patch *delete* the corresponding field from
+    /// the merged object (not "set to null"). Validation runs on the merged result
+    /// before the write commits.
+    ///
+    /// At least one of `new_value` or `new_data` must be `Some`; callers (handler
+    /// layer) are expected to reject the both-None case before calling.
+    pub fn update_entry(
+        &mut self,
+        key: &str,
+        id: &IdRef,
+        new_value: Option<&str>,
+        new_data: Option<serde_json::Value>,
+    ) -> Result<UpdateResult, KvError> {
+        let def = self.key_def(key)?.clone();
+        match def.value_type {
+            ValueType::History | ValueType::List => {}
+            _ => {
+                return Err(KvError::TypeMismatch {
+                    key: key.to_string(),
+                    expected: "history or list".to_string(),
+                    got: def.value_type.to_string(),
+                });
+            }
+        }
+
+        // Compute merged data on a clone so we can validate before mutating.
+        // This closure captures what we need from the entry without a mutable borrow.
+        let compute_merged = |entry_data: &Option<serde_json::Value>| -> Result<Option<serde_json::Value>, KvError> {
+            match (entry_data, &new_data) {
+                (_, None) => Ok(entry_data.clone()),
+                (None, Some(patch)) => {
+                    if !patch.is_object() {
+                        return Err(KvError::DataValidation {
+                            message: format!("key '{}': --data must be a JSON object", key),
+                        });
+                    }
+                    let mut obj = serde_json::Map::new();
+                    for (k, v) in patch.as_object().unwrap() {
+                        if !v.is_null() {
+                            obj.insert(k.clone(), v.clone());
+                        }
+                    }
+                    Ok(if obj.is_empty() { None } else { Some(serde_json::Value::Object(obj)) })
+                }
+                (Some(existing), Some(patch)) => {
+                    let mut merged_obj = match existing.as_object() {
+                        Some(o) => o.clone(),
+                        None => {
+                            return Err(KvError::Other(anyhow::anyhow!(
+                                "Data corruption: key '{}' entry has non-object data",
+                                key
+                            )));
+                        }
+                    };
+                    let patch_obj = match patch.as_object() {
+                        Some(p) => p,
+                        None => {
+                            return Err(KvError::DataValidation {
+                                message: format!("key '{}': --data must be a JSON object", key),
+                            });
+                        }
+                    };
+                    for (k, v) in patch_obj {
+                        if v.is_null() {
+                            merged_obj.remove(k);
+                        } else {
+                            merged_obj.insert(k.clone(), v.clone());
+                        }
+                    }
+                    Ok(if merged_obj.is_empty() { None } else { Some(serde_json::Value::Object(merged_obj)) })
+                }
+            }
+        };
+
+        match self.data.entries.get_mut(key) {
+            Some(DataValue::History { entries, .. }) => {
+                // First pass: read-only to compute merged_data and validate.
+                let merged_data = {
+                    let entry = match id {
+                        IdRef::Index(n) => entries.iter().find(|e| e.index == *n),
+                        IdRef::Id(h) => {
+                            let matches: Vec<_> = entries
+                                .iter()
+                                .filter(|e| e.id.starts_with(h.as_str()))
+                                .collect();
+                            match matches.len() {
+                                0 => None,
+                                1 => entries.iter().find(|e| e.id.starts_with(h.as_str())),
+                                n => {
+                                    return Err(KvError::AmbiguousId {
+                                        prefix: h.clone(),
+                                        count: n,
+                                    });
+                                }
+                            }
+                        }
+                    };
+                    let entry = match entry {
+                        Some(e) => e,
+                        None => {
+                            return Err(KvError::EntryNotFound {
+                                key: key.to_string(),
+                                id: format!("{:?}", id),
+                            });
+                        }
+                    };
+                    let merged = compute_merged(&entry.data)?;
+                    def.validate_data(key, &merged)?;
+                    merged
+                };
+                // Second pass: mutable to commit the write.
+                let entry = match id {
+                    IdRef::Index(n) => entries.iter_mut().find(|e| e.index == *n),
+                    IdRef::Id(h) => entries.iter_mut().find(|e| e.id.starts_with(h.as_str())),
+                };
+                let entry = entry.unwrap(); // safe: existence confirmed above
+                if let Some(v) = new_value {
+                    entry.value = v.to_string();
+                }
+                entry.data = merged_data;
+                Ok(UpdateResult { index: entry.index, id: entry.id.clone() })
+            }
+            Some(DataValue::List { items, .. }) => {
+                // First pass: read-only to compute merged_data and validate.
+                let merged_data = {
+                    let entry = match id {
+                        IdRef::Index(n) => items.iter().find(|e| e.index == *n),
+                        IdRef::Id(h) => {
+                            let matches: Vec<_> = items
+                                .iter()
+                                .filter(|e| e.id.starts_with(h.as_str()))
+                                .collect();
+                            match matches.len() {
+                                0 => None,
+                                1 => items.iter().find(|e| e.id.starts_with(h.as_str())),
+                                n => {
+                                    return Err(KvError::AmbiguousId {
+                                        prefix: h.clone(),
+                                        count: n,
+                                    });
+                                }
+                            }
+                        }
+                    };
+                    let entry = match entry {
+                        Some(e) => e,
+                        None => {
+                            return Err(KvError::EntryNotFound {
+                                key: key.to_string(),
+                                id: format!("{:?}", id),
+                            });
+                        }
+                    };
+                    let merged = compute_merged(&entry.data)?;
+                    def.validate_data(key, &merged)?;
+                    merged
+                };
+                // Second pass: mutable to commit the write.
+                let entry = match id {
+                    IdRef::Index(n) => items.iter_mut().find(|e| e.index == *n),
+                    IdRef::Id(h) => items.iter_mut().find(|e| e.id.starts_with(h.as_str())),
+                };
+                let entry = entry.unwrap(); // safe: existence confirmed above
+                if let Some(v) = new_value {
+                    entry.value = v.to_string();
+                }
+                entry.data = merged_data;
+                Ok(UpdateResult { index: entry.index, id: entry.id.clone() })
             }
             _ => Err(KvError::EntryNotFound {
                 key: key.to_string(),
@@ -7409,5 +7597,410 @@ type = "counter"
         } else {
             panic!("expected history");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // update_entry tests
+    // -----------------------------------------------------------------------
+
+    fn test_schema_with_data() -> &'static str {
+        r#"
+[keys.items]
+type = "history"
+
+[keys.items.data]
+status = { type = "string", required = true }
+count = { type = "number" }
+
+[keys.shelf]
+type = "list"
+
+[keys.shelf.data]
+status = { type = "string", required = true }
+count = { type = "number" }
+"#
+    }
+
+    fn get_history_entry(store: &KvStore, key: &str, index: u64) -> HistoryEntry {
+        match store.get(key).unwrap() {
+            DataValue::History { entries, .. } => entries
+                .iter()
+                .find(|e| e.index == index)
+                .cloned()
+                .expect("entry not found"),
+            _ => panic!("expected history"),
+        }
+    }
+
+    fn get_list_entry(store: &KvStore, key: &str, index: u64) -> ListEntry {
+        match store.get(key).unwrap() {
+            DataValue::List { items, .. } => items
+                .iter()
+                .find(|e| e.index == index)
+                .cloned()
+                .expect("entry not found"),
+            _ => panic!("expected list"),
+        }
+    }
+
+    #[test]
+    fn update_value_only_preserves_ts_and_id_history() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let push = store
+            .push("flavor_history", "mint", None, None)
+            .unwrap();
+        let before = get_history_entry(&store, "flavor_history", push.index);
+
+        let result = store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Index(push.index),
+                Some("peppermint"),
+                None,
+            )
+            .unwrap();
+        let after = get_history_entry(&store, "flavor_history", push.index);
+
+        assert_eq!(result.index, push.index);
+        assert_eq!(result.id, push.id);
+        assert_eq!(after.value, "peppermint");
+        assert_eq!(after.ts, before.ts, "ts must be preserved");
+        assert_eq!(after.id, before.id, "id must be preserved");
+        assert_eq!(after.data, before.data, "data must be unchanged");
+    }
+
+    #[test]
+    fn update_value_only_preserves_ts_and_id_list() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let push = store.push("tags", "alpha", None, None).unwrap();
+        let before = get_list_entry(&store, "tags", push.index);
+
+        let result = store
+            .update_entry("tags", &IdRef::Index(push.index), Some("beta"), None)
+            .unwrap();
+        let after = get_list_entry(&store, "tags", push.index);
+
+        assert_eq!(result.index, push.index);
+        assert_eq!(result.id, push.id);
+        assert_eq!(after.value, "beta");
+        assert_eq!(after.ts, before.ts, "ts must be preserved");
+        assert_eq!(after.id, before.id, "id must be preserved");
+        assert_eq!(after.data, before.data, "data must be unchanged");
+    }
+
+    #[test]
+    fn update_data_merges_with_existing_history() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let initial_data = serde_json::json!({"a": 1, "b": 2});
+        let push = store
+            .push("flavor_history", "chai", Some(initial_data), None)
+            .unwrap();
+        let before = get_history_entry(&store, "flavor_history", push.index);
+
+        let patch = serde_json::json!({"b": 3});
+        store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Index(push.index),
+                None,
+                Some(patch),
+            )
+            .unwrap();
+        let after = get_history_entry(&store, "flavor_history", push.index);
+
+        let data = after.data.as_ref().unwrap();
+        assert_eq!(data["a"], serde_json::json!(1), "a must be unchanged");
+        assert_eq!(data["b"], serde_json::json!(3), "b must be updated");
+        assert_eq!(after.ts, before.ts, "ts must be preserved");
+        assert_eq!(after.id, before.id, "id must be preserved");
+        assert_eq!(after.value, before.value, "value must be unchanged");
+    }
+
+    #[test]
+    fn update_data_merges_with_existing_list() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let initial_data = serde_json::json!({"a": 1, "b": 2});
+        let push = store
+            .push("tags", "item", Some(initial_data), None)
+            .unwrap();
+        let before = get_list_entry(&store, "tags", push.index);
+
+        let patch = serde_json::json!({"b": 3});
+        store
+            .update_entry("tags", &IdRef::Index(push.index), None, Some(patch))
+            .unwrap();
+        let after = get_list_entry(&store, "tags", push.index);
+
+        let data = after.data.as_ref().unwrap();
+        assert_eq!(data["a"], serde_json::json!(1), "a must be unchanged");
+        assert_eq!(data["b"], serde_json::json!(3), "b must be updated");
+        assert_eq!(after.ts, before.ts, "ts must be preserved");
+        assert_eq!(after.id, before.id, "id must be preserved");
+        assert_eq!(after.value, before.value, "value must be unchanged");
+    }
+
+    #[test]
+    fn update_value_and_data_together() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let initial_data = serde_json::json!({"x": 10});
+        let push = store
+            .push("flavor_history", "original", Some(initial_data), None)
+            .unwrap();
+
+        let patch = serde_json::json!({"x": 99});
+        store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Index(push.index),
+                Some("updated"),
+                Some(patch),
+            )
+            .unwrap();
+        let after = get_history_entry(&store, "flavor_history", push.index);
+
+        assert_eq!(after.value, "updated");
+        let data = after.data.as_ref().unwrap();
+        assert_eq!(data["x"], serde_json::json!(99));
+    }
+
+    #[test]
+    fn update_data_null_deletes_field() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let initial_data = serde_json::json!({"a": 1, "b": 2});
+        let push = store
+            .push("flavor_history", "rooibos", Some(initial_data), None)
+            .unwrap();
+
+        let patch = serde_json::json!({"b": null});
+        store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Index(push.index),
+                None,
+                Some(patch),
+            )
+            .unwrap();
+        let after = get_history_entry(&store, "flavor_history", push.index);
+
+        let data = after.data.as_ref().unwrap();
+        assert_eq!(data["a"], serde_json::json!(1), "a must remain");
+        assert!(
+            data.get("b").is_none(),
+            "b must be deleted, not set to null"
+        );
+    }
+
+    #[test]
+    fn update_data_on_entry_with_no_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let push = store
+            .push("flavor_history", "oolong", None, None)
+            .unwrap();
+
+        let patch = serde_json::json!({"a": 1});
+        store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Index(push.index),
+                None,
+                Some(patch),
+            )
+            .unwrap();
+        let after = get_history_entry(&store, "flavor_history", push.index);
+
+        let data = after.data.as_ref().expect("data must be Some after update");
+        assert_eq!(data["a"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn update_data_validation_rejects_unknown_field() {
+        let (mut store, _dir) = setup_store(test_schema_with_data());
+        let initial_data = serde_json::json!({"status": "open"});
+        let push = store
+            .push("items", "task-1", Some(initial_data), None)
+            .unwrap();
+        let before = get_history_entry(&store, "items", push.index);
+
+        let patch = serde_json::json!({"unknown_field": "bad"});
+        let err = store
+            .update_entry("items", &IdRef::Index(push.index), None, Some(patch))
+            .unwrap_err();
+
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "expected DataValidation, got {:?}",
+            err
+        );
+        let after = get_history_entry(&store, "items", push.index);
+        assert_eq!(after.data, before.data, "entry must be unchanged on failure");
+    }
+
+    #[test]
+    fn update_data_validation_rejects_type_mismatch() {
+        let (mut store, _dir) = setup_store(test_schema_with_data());
+        let initial_data = serde_json::json!({"status": "open"});
+        let push = store
+            .push("items", "task-2", Some(initial_data), None)
+            .unwrap();
+        let before = get_history_entry(&store, "items", push.index);
+
+        // count is type=number; passing a string triggers type mismatch
+        let patch = serde_json::json!({"count": "not-a-number"});
+        let err = store
+            .update_entry("items", &IdRef::Index(push.index), None, Some(patch))
+            .unwrap_err();
+
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "expected DataValidation, got {:?}",
+            err
+        );
+        let after = get_history_entry(&store, "items", push.index);
+        assert_eq!(after.data, before.data, "entry must be unchanged on failure");
+    }
+
+    #[test]
+    fn update_data_validation_keeps_required_field_via_merge() {
+        let (mut store, _dir) = setup_store(test_schema_with_data());
+        // Push with status (required) and count (optional)
+        let initial_data = serde_json::json!({"status": "open", "count": 1});
+        let push = store
+            .push("items", "task-3", Some(initial_data), None)
+            .unwrap();
+
+        // Patch only updates count — status is not in patch but is satisfied by existing data
+        let patch = serde_json::json!({"count": 2});
+        store
+            .update_entry("items", &IdRef::Index(push.index), None, Some(patch))
+            .unwrap();
+        let after = get_history_entry(&store, "items", push.index);
+
+        let data = after.data.as_ref().unwrap();
+        assert_eq!(data["status"], serde_json::json!("open"), "required field preserved in merge");
+        assert_eq!(data["count"], serde_json::json!(2), "count updated");
+    }
+
+    #[test]
+    fn update_entry_not_found_by_index() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "darjeeling", None, None).unwrap();
+
+        let err = store
+            .update_entry("flavor_history", &IdRef::Index(999), Some("new"), None)
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::EntryNotFound { .. }),
+            "expected EntryNotFound, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn update_entry_not_found_by_id_prefix() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "sencha", None, None).unwrap();
+
+        let err = store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Id("nonexistentprefix".to_string()),
+                Some("new"),
+                None,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::EntryNotFound { .. }),
+            "expected EntryNotFound, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn update_ambiguous_id_prefix() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let r1 = store.push("flavor_history", "a1", None, None).unwrap();
+        let r2 = store.push("flavor_history", "a2", None, None).unwrap();
+
+        // Find a prefix that matches both IDs
+        let id1 = &r1.id;
+        let id2 = &r2.id;
+        let prefix_len = id1
+            .chars()
+            .zip(id2.chars())
+            .take_while(|(c1, c2)| c1 == c2)
+            .count();
+
+        // If no shared prefix, use a single character that appears in both (worst case: use one char)
+        let shared_prefix = if prefix_len > 0 {
+            id1[..prefix_len].to_string()
+        } else {
+            // IDs differ from first char — use an artificial common prefix by
+            // testing with both id substrings that we know exist
+            // Instead, just use an empty-ish prefix that matches any 2-char start
+            id1.chars().next().unwrap().to_string()
+        };
+
+        // Only test ambiguous if the prefix actually matches both
+        let matches_both = id1.starts_with(&shared_prefix) && id2.starts_with(&shared_prefix);
+        if !matches_both {
+            // Different first chars — construct the test differently:
+            // Push two entries with known IDs by checking if id1[0] == id2[0]
+            // Since we can't control IDs, skip the prefix ambiguity and just verify
+            // ambiguous detection works with a known-matching prefix scenario.
+            // This is a test environment limitation — note and skip gracefully.
+            return;
+        }
+
+        let err = store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Id(shared_prefix),
+                Some("new"),
+                None,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::AmbiguousId { count: 2, .. }),
+            "expected AmbiguousId with count 2, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn update_wrong_key_type_counter() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let err = store
+            .update_entry("warmth", &IdRef::Index(0), Some("5"), None)
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::TypeMismatch { .. }),
+            "expected TypeMismatch, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn update_id_lookup_by_prefix_unique() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let push = store
+            .push("flavor_history", "gyokuro", None, None)
+            .unwrap();
+
+        // Take first 4 chars of id as prefix
+        let prefix = push.id[..4.min(push.id.len())].to_string();
+
+        let result = store
+            .update_entry(
+                "flavor_history",
+                &IdRef::Id(prefix),
+                Some("gyokuro-updated"),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(result.index, push.index);
+        assert_eq!(result.id, push.id);
+        let after = get_history_entry(&store, "flavor_history", push.index);
+        assert_eq!(after.value, "gyokuro-updated");
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -535,6 +535,178 @@ pub enum IdRef {
 }
 
 // ---------------------------------------------------------------------------
+// Entry-lookup helpers shared by History and List arms
+// ---------------------------------------------------------------------------
+
+/// `HistoryEntry` and `ListEntry` are structurally identical — same fields,
+/// same role in `update_entry`. They exist as separate types because the
+/// outer `DataValue` variant distinguishes append-only history semantics from
+/// mutable list semantics, but at the entry level there's no difference.
+/// This trait acknowledges that and lets the update path be written once.
+///
+/// Shared interface for `HistoryEntry` and `ListEntry` so generic helpers
+/// can operate over both types without duplicating the logic.
+trait EntryFields {
+    fn entry_index(&self) -> u64;
+    fn entry_id(&self) -> &str;
+    fn entry_data(&self) -> &Option<serde_json::Value>;
+    fn entry_id_str(&self) -> String;
+    fn set_value(&mut self, v: &str);
+    fn set_data(&mut self, d: Option<serde_json::Value>);
+}
+
+impl EntryFields for HistoryEntry {
+    fn entry_index(&self) -> u64 { self.index }
+    fn entry_id(&self) -> &str { &self.id }
+    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
+    fn entry_id_str(&self) -> String { self.id.clone() }
+    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
+    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+}
+
+impl EntryFields for ListEntry {
+    fn entry_index(&self) -> u64 { self.index }
+    fn entry_id(&self) -> &str { &self.id }
+    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
+    fn entry_id_str(&self) -> String { self.id.clone() }
+    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
+    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+}
+
+/// Return the Vec position of the entry identified by `id`, or an error.
+///
+/// Uses `position()` so the caller can index the slice directly (`&mut v[pos]`)
+/// — no second search pass and no `.unwrap()`.
+fn find_entry_idx<E: EntryFields>(
+    entries: &[E],
+    id: &IdRef,
+    key: &str,
+) -> Result<usize, KvError> {
+    match id {
+        IdRef::Index(n) => entries
+            .iter()
+            .position(|e| e.entry_index() == *n)
+            .ok_or_else(|| KvError::EntryNotFound {
+                key: key.to_string(),
+                id: format!("{:?}", id),
+            }),
+        IdRef::Id(h) => {
+            let positions: Vec<usize> = entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| e.entry_id().starts_with(h.as_str()))
+                .map(|(i, _)| i)
+                .collect();
+            match positions.len() {
+                0 => Err(KvError::EntryNotFound {
+                    key: key.to_string(),
+                    id: format!("{:?}", id),
+                }),
+                1 => Ok(positions[0]),
+                n => Err(KvError::AmbiguousId {
+                    prefix: h.clone(),
+                    count: n,
+                }),
+            }
+        }
+    }
+}
+
+/// Perform the validated update on `entries[idx]` and return an `UpdateResult`.
+///
+/// Extracted so the `History` and `List` arms of `update_entry` share a single
+/// code path instead of duplicating ~30 lines each.
+fn apply_entry_update<E: EntryFields>(
+    entries: &mut Vec<E>,
+    id: &IdRef,
+    key: &str,
+    def: &KeyDef,
+    new_value: Option<&str>,
+    new_data: Option<&serde_json::Value>,
+) -> Result<UpdateResult, KvError> {
+    let idx = find_entry_idx(entries, id, key)?;
+
+    // Compute merged data from the read-only borrow first.
+    let merged_data = {
+        let entry_data = entries[idx].entry_data();
+        let merged = merge_entry_data(entry_data, new_data, key)?;
+        def.validate_data(key, &merged)?;
+        merged
+    };
+
+    // Commit — safe to index directly because `idx` was verified above.
+    let entry = &mut entries[idx];
+    if let Some(v) = new_value {
+        entry.set_value(v);
+    }
+    entry.set_data(merged_data);
+    Ok(UpdateResult {
+        index: entry.entry_index(),
+        id: entry.entry_id_str(),
+    })
+}
+
+/// Merge `new_data` (a JSON-object patch) into `existing`.
+///
+/// - `None` patch → return existing unchanged.
+/// - Non-null patch fields overwrite / insert; null patch fields delete.
+/// - Empty result → `None`.
+fn merge_entry_data(
+    existing: &Option<serde_json::Value>,
+    patch: Option<&serde_json::Value>,
+    key: &str,
+) -> Result<Option<serde_json::Value>, KvError> {
+    let patch = match patch {
+        None => return Ok(existing.clone()),
+        Some(p) => p,
+    };
+
+    match existing {
+        None => {
+            let patch_obj = patch.as_object().ok_or_else(|| KvError::DataValidation {
+                message: format!("key '{}': --data must be a JSON object", key),
+            })?;
+            let obj: serde_json::Map<_, _> = patch_obj
+                .iter()
+                .filter(|(_, v)| !v.is_null())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            Ok(if obj.is_empty() {
+                None
+            } else {
+                Some(serde_json::Value::Object(obj))
+            })
+        }
+        Some(existing_val) => {
+            let mut merged_obj = existing_val
+                .as_object()
+                .ok_or_else(|| {
+                    KvError::Other(anyhow::anyhow!(
+                        "Data corruption: key '{}' entry has non-object data",
+                        key
+                    ))
+                })?
+                .clone();
+            let patch_obj = patch.as_object().ok_or_else(|| KvError::DataValidation {
+                message: format!("key '{}': --data must be a JSON object", key),
+            })?;
+            for (k, v) in patch_obj {
+                if v.is_null() {
+                    merged_obj.remove(k);
+                } else {
+                    merged_obj.insert(k.clone(), v.clone());
+                }
+            }
+            Ok(if merged_obj.is_empty() {
+                None
+            } else {
+                Some(serde_json::Value::Object(merged_obj))
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Data field validation
 // ---------------------------------------------------------------------------
 
@@ -2259,181 +2431,66 @@ impl KvStore {
         new_value: Option<&str>,
         new_data: Option<serde_json::Value>,
     ) -> Result<UpdateResult, KvError> {
+        // Item 4: reject empty-object data with no value — nothing to update.
+        // Engine-level guard so library consumers get it, not just CLI callers.
+        if new_value.is_none()
+            && new_data.as_ref().is_some_and(|d| d.as_object().is_some_and(|o| o.is_empty()))
+        {
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "key '{}': --data is an empty object and no value was given — nothing to update",
+                    key
+                ),
+            });
+        }
+
         let def = self.key_def(key)?.clone();
+
+        // Guard: key must be a History or List — anything else is a type error.
         match def.value_type {
             ValueType::History | ValueType::List => {}
-            _ => {
+            ValueType::Counter | ValueType::String => {
                 return Err(KvError::TypeMismatch {
                     key: key.to_string(),
-                    expected: "history or list".to_string(),
+                    expected: "update not supported for this entry type".to_string(),
                     got: def.value_type.to_string(),
+                });
+            }
+            ValueType::State => {
+                return Err(KvError::TypeMismatch {
+                    key: key.to_string(),
+                    expected: "history or list (state fields are set with 'mx kv set')".to_string(),
+                    got: "state".to_string(),
                 });
             }
         }
 
-        // Compute merged data on a clone so we can validate before mutating.
-        // This closure captures what we need from the entry without a mutable borrow.
-        let compute_merged =
-            |entry_data: &Option<serde_json::Value>| -> Result<Option<serde_json::Value>, KvError> {
-                match (entry_data, &new_data) {
-                    (_, None) => Ok(entry_data.clone()),
-                    (None, Some(patch)) => {
-                        if !patch.is_object() {
-                            return Err(KvError::DataValidation {
-                                message: format!("key '{}': --data must be a JSON object", key),
-                            });
-                        }
-                        let mut obj = serde_json::Map::new();
-                        for (k, v) in patch.as_object().unwrap() {
-                            if !v.is_null() {
-                                obj.insert(k.clone(), v.clone());
-                            }
-                        }
-                        Ok(if obj.is_empty() {
-                            None
-                        } else {
-                            Some(serde_json::Value::Object(obj))
-                        })
-                    }
-                    (Some(existing), Some(patch)) => {
-                        let mut merged_obj = match existing.as_object() {
-                            Some(o) => o.clone(),
-                            None => {
-                                return Err(KvError::Other(anyhow::anyhow!(
-                                    "Data corruption: key '{}' entry has non-object data",
-                                    key
-                                )));
-                            }
-                        };
-                        let patch_obj = match patch.as_object() {
-                            Some(p) => p,
-                            None => {
-                                return Err(KvError::DataValidation {
-                                    message: format!("key '{}': --data must be a JSON object", key),
-                                });
-                            }
-                        };
-                        for (k, v) in patch_obj {
-                            if v.is_null() {
-                                merged_obj.remove(k);
-                            } else {
-                                merged_obj.insert(k.clone(), v.clone());
-                            }
-                        }
-                        Ok(if merged_obj.is_empty() {
-                            None
-                        } else {
-                            Some(serde_json::Value::Object(merged_obj))
-                        })
-                    }
-                }
-            };
+        let patch = new_data.as_ref();
 
         match self.data.entries.get_mut(key) {
             Some(DataValue::History { entries, .. }) => {
-                // First pass: read-only to compute merged_data and validate.
-                let merged_data = {
-                    let entry = match id {
-                        IdRef::Index(n) => entries.iter().find(|e| e.index == *n),
-                        IdRef::Id(h) => {
-                            let matches: Vec<_> = entries
-                                .iter()
-                                .filter(|e| e.id.starts_with(h.as_str()))
-                                .collect();
-                            match matches.len() {
-                                0 => None,
-                                1 => entries.iter().find(|e| e.id.starts_with(h.as_str())),
-                                n => {
-                                    return Err(KvError::AmbiguousId {
-                                        prefix: h.clone(),
-                                        count: n,
-                                    });
-                                }
-                            }
-                        }
-                    };
-                    let entry = match entry {
-                        Some(e) => e,
-                        None => {
-                            return Err(KvError::EntryNotFound {
-                                key: key.to_string(),
-                                id: format!("{:?}", id),
-                            });
-                        }
-                    };
-                    let merged = compute_merged(&entry.data)?;
-                    def.validate_data(key, &merged)?;
-                    merged
-                };
-                // Second pass: mutable to commit the write.
-                let entry = match id {
-                    IdRef::Index(n) => entries.iter_mut().find(|e| e.index == *n),
-                    IdRef::Id(h) => entries.iter_mut().find(|e| e.id.starts_with(h.as_str())),
-                };
-                let entry = entry.unwrap(); // safe: existence confirmed above
-                if let Some(v) = new_value {
-                    entry.value = v.to_string();
-                }
-                entry.data = merged_data;
-                Ok(UpdateResult {
-                    index: entry.index,
-                    id: entry.id.clone(),
-                })
+                apply_entry_update(entries, id, key, &def, new_value, patch)
             }
             Some(DataValue::List { items, .. }) => {
-                // First pass: read-only to compute merged_data and validate.
-                let merged_data = {
-                    let entry = match id {
-                        IdRef::Index(n) => items.iter().find(|e| e.index == *n),
-                        IdRef::Id(h) => {
-                            let matches: Vec<_> = items
-                                .iter()
-                                .filter(|e| e.id.starts_with(h.as_str()))
-                                .collect();
-                            match matches.len() {
-                                0 => None,
-                                1 => items.iter().find(|e| e.id.starts_with(h.as_str())),
-                                n => {
-                                    return Err(KvError::AmbiguousId {
-                                        prefix: h.clone(),
-                                        count: n,
-                                    });
-                                }
-                            }
-                        }
-                    };
-                    let entry = match entry {
-                        Some(e) => e,
-                        None => {
-                            return Err(KvError::EntryNotFound {
-                                key: key.to_string(),
-                                id: format!("{:?}", id),
-                            });
-                        }
-                    };
-                    let merged = compute_merged(&entry.data)?;
-                    def.validate_data(key, &merged)?;
-                    merged
-                };
-                // Second pass: mutable to commit the write.
-                let entry = match id {
-                    IdRef::Index(n) => items.iter_mut().find(|e| e.index == *n),
-                    IdRef::Id(h) => items.iter_mut().find(|e| e.id.starts_with(h.as_str())),
-                };
-                let entry = entry.unwrap(); // safe: existence confirmed above
-                if let Some(v) = new_value {
-                    entry.value = v.to_string();
-                }
-                entry.data = merged_data;
-                Ok(UpdateResult {
-                    index: entry.index,
-                    id: entry.id.clone(),
-                })
+                apply_entry_update(items, id, key, &def, new_value, patch)
             }
-            _ => Err(KvError::EntryNotFound {
+            None => Err(KvError::EntryNotFound {
                 key: key.to_string(),
-                id: format!("{:?}", id),
+                id: "no entries found".to_string(),
             }),
+            // Schema says history/list (filtered by the type guard above) but the
+            // data file disagrees — this is data corruption, not a user error.
+            // Return `Other` rather than panicking so the engine never aborts.
+            Some(DataValue::Counter { .. }) | Some(DataValue::String { .. }) => {
+                Err(KvError::Other(anyhow::anyhow!(
+                    "data corruption: key '{}' schema is history/list but stored value is a scalar",
+                    key
+                )))
+            }
+            Some(DataValue::State { .. }) => Err(KvError::Other(anyhow::anyhow!(
+                "data corruption: key '{}' schema is history/list but stored value is a state map",
+                key
+            ))),
         }
     }
 

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -7917,53 +7917,20 @@ count = { type = "number" }
 
     #[test]
     fn update_ambiguous_id_prefix() {
-        let (mut store, _dir) = setup_store(test_schema());
-        let r1 = store.push("flavor_history", "a1", None, None).unwrap();
-        let r2 = store.push("flavor_history", "a2", None, None).unwrap();
-
-        // Find a prefix that matches both IDs
-        let id1 = &r1.id;
-        let id2 = &r2.id;
-        let prefix_len = id1
-            .chars()
-            .zip(id2.chars())
-            .take_while(|(c1, c2)| c1 == c2)
-            .count();
-
-        // If no shared prefix, use a single character that appears in both (worst case: use one char)
-        let shared_prefix = if prefix_len > 0 {
-            id1[..prefix_len].to_string()
-        } else {
-            // IDs differ from first char — use an artificial common prefix by
-            // testing with both id substrings that we know exist
-            // Instead, just use an empty-ish prefix that matches any 2-char start
-            id1.chars().next().unwrap().to_string()
-        };
-
-        // Only test ambiguous if the prefix actually matches both
-        let matches_both = id1.starts_with(&shared_prefix) && id2.starts_with(&shared_prefix);
-        if !matches_both {
-            // Different first chars — construct the test differently:
-            // Push two entries with known IDs by checking if id1[0] == id2[0]
-            // Since we can't control IDs, skip the prefix ambiguity and just verify
-            // ambiguous detection works with a known-matching prefix scenario.
-            // This is a test environment limitation — note and skip gracefully.
-            return;
+        let (mut store, _tmp) = setup_store(test_schema());
+        store.push("tags", "alpha", None, None).unwrap();
+        store.push("tags", "beta", None, None).unwrap();
+        // Empty prefix matches every entry — always ambiguous when there are 2+.
+        let err = store.update_entry(
+            "tags",
+            &IdRef::Id("".to_string()),
+            Some("beta-updated"),
+            None,
+        ).unwrap_err();
+        match err {
+            KvError::AmbiguousId { count, .. } => assert_eq!(count, 2),
+            other => panic!("expected AmbiguousId, got {:?}", other),
         }
-
-        let err = store
-            .update_entry(
-                "flavor_history",
-                &IdRef::Id(shared_prefix),
-                Some("new"),
-                None,
-            )
-            .unwrap_err();
-        assert!(
-            matches!(err, KvError::AmbiguousId { count: 2, .. }),
-            "expected AmbiguousId with count 2, got {:?}",
-            err
-        );
     }
 
     #[test]

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -538,50 +538,62 @@ pub enum IdRef {
 // Entry-lookup helpers shared by History and List arms
 // ---------------------------------------------------------------------------
 
-/// `HistoryEntry` and `ListEntry` are structurally identical — same fields,
-/// same role in `update_entry`. They exist as separate types because the
-/// outer `DataValue` variant distinguishes append-only history semantics from
-/// mutable list semantics, but at the entry level there's no difference.
-/// This trait acknowledges that and lets the update path be written once.
+/// Shared access to the field set used by `update_entry`.
 ///
-/// Shared interface for `HistoryEntry` and `ListEntry` so generic helpers
-/// can operate over both types without duplicating the logic.
+/// `HistoryEntry` and `ListEntry` are structurally identical — same fields,
+/// same role here. They exist as separate types because the outer `DataValue`
+/// variant distinguishes append-only history semantics from mutable list
+/// semantics, but at the entry level there's no difference. This trait
+/// acknowledges that and lets the update path be written once.
 trait EntryFields {
     fn entry_index(&self) -> u64;
     fn entry_id(&self) -> &str;
     fn entry_data(&self) -> &Option<serde_json::Value>;
-    fn entry_id_str(&self) -> String;
     fn set_value(&mut self, v: &str);
     fn set_data(&mut self, d: Option<serde_json::Value>);
 }
 
 impl EntryFields for HistoryEntry {
-    fn entry_index(&self) -> u64 { self.index }
-    fn entry_id(&self) -> &str { &self.id }
-    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
-    fn entry_id_str(&self) -> String { self.id.clone() }
-    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
-    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+    fn entry_index(&self) -> u64 {
+        self.index
+    }
+    fn entry_id(&self) -> &str {
+        &self.id
+    }
+    fn entry_data(&self) -> &Option<serde_json::Value> {
+        &self.data
+    }
+    fn set_value(&mut self, v: &str) {
+        self.value = v.to_string();
+    }
+    fn set_data(&mut self, d: Option<serde_json::Value>) {
+        self.data = d;
+    }
 }
 
 impl EntryFields for ListEntry {
-    fn entry_index(&self) -> u64 { self.index }
-    fn entry_id(&self) -> &str { &self.id }
-    fn entry_data(&self) -> &Option<serde_json::Value> { &self.data }
-    fn entry_id_str(&self) -> String { self.id.clone() }
-    fn set_value(&mut self, v: &str) { self.value = v.to_string(); }
-    fn set_data(&mut self, d: Option<serde_json::Value>) { self.data = d; }
+    fn entry_index(&self) -> u64 {
+        self.index
+    }
+    fn entry_id(&self) -> &str {
+        &self.id
+    }
+    fn entry_data(&self) -> &Option<serde_json::Value> {
+        &self.data
+    }
+    fn set_value(&mut self, v: &str) {
+        self.value = v.to_string();
+    }
+    fn set_data(&mut self, d: Option<serde_json::Value>) {
+        self.data = d;
+    }
 }
 
 /// Return the Vec position of the entry identified by `id`, or an error.
 ///
 /// Uses `position()` so the caller can index the slice directly (`&mut v[pos]`)
 /// — no second search pass and no `.unwrap()`.
-fn find_entry_idx<E: EntryFields>(
-    entries: &[E],
-    id: &IdRef,
-    key: &str,
-) -> Result<usize, KvError> {
+fn find_entry_idx<E: EntryFields>(entries: &[E], id: &IdRef, key: &str) -> Result<usize, KvError> {
     match id {
         IdRef::Index(n) => entries
             .iter()
@@ -617,7 +629,7 @@ fn find_entry_idx<E: EntryFields>(
 /// Extracted so the `History` and `List` arms of `update_entry` share a single
 /// code path instead of duplicating ~30 lines each.
 fn apply_entry_update<E: EntryFields>(
-    entries: &mut Vec<E>,
+    entries: &mut [E],
     id: &IdRef,
     key: &str,
     def: &KeyDef,
@@ -642,7 +654,7 @@ fn apply_entry_update<E: EntryFields>(
     entry.set_data(merged_data);
     Ok(UpdateResult {
         index: entry.entry_index(),
-        id: entry.entry_id_str(),
+        id: entry.entry_id().to_string(),
     })
 }
 
@@ -682,7 +694,7 @@ fn merge_entry_data(
                 .as_object()
                 .ok_or_else(|| {
                     KvError::Other(anyhow::anyhow!(
-                        "Data corruption: key '{}' entry has non-object data",
+                        "data corruption: key '{}' entry has non-object data",
                         key
                     ))
                 })?
@@ -2431,19 +2443,6 @@ impl KvStore {
         new_value: Option<&str>,
         new_data: Option<serde_json::Value>,
     ) -> Result<UpdateResult, KvError> {
-        // Item 4: reject empty-object data with no value — nothing to update.
-        // Engine-level guard so library consumers get it, not just CLI callers.
-        if new_value.is_none()
-            && new_data.as_ref().is_some_and(|d| d.as_object().is_some_and(|o| o.is_empty()))
-        {
-            return Err(KvError::DataValidation {
-                message: format!(
-                    "key '{}': --data is an empty object and no value was given — nothing to update",
-                    key
-                ),
-            });
-        }
-
         let def = self.key_def(key)?.clone();
 
         // Guard: key must be a History or List — anything else is a type error.
@@ -2452,7 +2451,7 @@ impl KvStore {
             ValueType::Counter | ValueType::String => {
                 return Err(KvError::TypeMismatch {
                     key: key.to_string(),
-                    expected: "update not supported for this entry type".to_string(),
+                    expected: "history or list".to_string(),
                     got: def.value_type.to_string(),
                 });
             }
@@ -2463,6 +2462,22 @@ impl KvStore {
                     got: "state".to_string(),
                 });
             }
+        }
+
+        // Item 4: reject empty-object data with no value — nothing to update.
+        // Engine-level guard so library consumers get it, not just CLI callers.
+        // Runs after key_def and type guard so schema errors take precedence.
+        if new_value.is_none()
+            && new_data
+                .as_ref()
+                .is_some_and(|d| d.as_object().is_some_and(|o| o.is_empty()))
+        {
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "key '{}': --data is an empty object and no value was given — nothing to update",
+                    key
+                ),
+            });
         }
 
         let patch = new_data.as_ref();
@@ -2476,7 +2491,7 @@ impl KvStore {
             }
             None => Err(KvError::EntryNotFound {
                 key: key.to_string(),
-                id: "no entries found".to_string(),
+                id: "(no entries pushed)".to_string(),
             }),
             // Schema says history/list (filtered by the type guard above) but the
             // data file disagrees — this is data corruption, not a user error.

--- a/tests/update_pressure.rs
+++ b/tests/update_pressure.rs
@@ -1,0 +1,801 @@
+/// Adversarial tests for `mx kv update` / `KvStore::update_entry`.
+///
+/// These run via `cargo test` as integration-style tests against the binary.
+/// They test paths the 15 unit tests in kv.rs do not cover.
+
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+const MX: &str = env!("CARGO_BIN_EXE_mx");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup(schema_toml: &str) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("schema.toml"), schema_toml).unwrap();
+    // Do NOT write data.json — KvStore::load treats missing file as DataFile::default()
+    dir
+}
+
+fn mx(dir: &TempDir, args: &[&str]) -> std::process::Output {
+    Command::new(MX)
+        .args(args)
+        .env("MX_KV_SCHEMA", dir.path().join("schema.toml"))
+        .env("MX_KV_DATA", dir.path().join("data.json"))
+        .output()
+        .expect("failed to run mx")
+}
+
+fn push(dir: &TempDir, key: &str, value: &str) -> String {
+    let out = mx(dir, &["kv", "push", key, value]);
+    assert!(
+        out.status.success(),
+        "push failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Output is like: kv-<id> (<index>)
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn push_with_data(dir: &TempDir, key: &str, value: &str, data: &str) -> String {
+    let out = mx(dir, &["kv", "push", key, value, "--data", data]);
+    assert!(
+        out.status.success(),
+        "push --data failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Extract the numeric index from "kv-<id> (<index>)" push output.
+fn index_from_push(push_out: &str) -> String {
+    // Format: "kv-<hash> (<index>)"
+    let inner = push_out
+        .trim_end_matches(')')
+        .rsplit('(')
+        .next()
+        .unwrap()
+        .trim()
+        .to_string();
+    inner
+}
+
+/// Extract the kv-<hash> prefix from push output for use in --id.
+fn id_from_push(push_out: &str) -> String {
+    push_out
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Basic schema used throughout
+// ---------------------------------------------------------------------------
+
+const BASIC_SCHEMA: &str = r#"
+[keys.log]
+type = "history"
+
+[keys.items]
+type = "list"
+
+[keys.counter]
+type = "counter"
+default = "0"
+"#;
+
+const VALIDATED_SCHEMA: &str = r#"
+[keys.tasks]
+type = "history"
+
+[keys.tasks.data]
+status = { type = "string", required = true }
+priority = { type = "number" }
+"#;
+
+// ---------------------------------------------------------------------------
+// P1: Empty patch `--data '{}'`
+// ---------------------------------------------------------------------------
+
+/// Empty patch object with no value: the handler now rejects `--data '{}'`
+/// when no value is supplied, because nothing would be updated (exit 4).
+/// Previously this was a silent no-op; the fix makes it an explicit error.
+#[test]
+fn empty_patch_is_accepted_but_changes_nothing() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "hello");
+    let idx = index_from_push(&pushed);
+
+    // Update with empty patch and no value — must now be rejected (exit 4)
+    let out = mx(&dir, &["kv", "update", "log", "--id", &idx, "--data", "{}"]);
+    assert!(
+        !out.status.success(),
+        "empty --data {{}} with no value must be rejected, got exit {:?}",
+        out.status.code()
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected EXIT_INVALID_INPUT (4) for empty patch with no value"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        stderr.contains("empty object") || stderr.contains("nothing to update"),
+        "stderr must explain the rejection: {}",
+        stderr
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P2: Patch with only nulls against an entry that doesn't have those fields
+// ---------------------------------------------------------------------------
+
+/// Patch is `{"foo": null}` on entry with no `data` field.
+/// Spec says null-as-delete: deleting a field that doesn't exist should be a no-op.
+/// Result: merged object is empty -> stored as None (no data).
+#[test]
+fn patch_all_nulls_on_entry_without_data_yields_none() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "world");
+    let idx = index_from_push(&pushed);
+
+    // Patch with only nulls against an entry with no data
+    let out = mx(
+        &dir,
+        &[
+            "kv", "update", "log", "--id", &idx, "--data",
+            r#"{"foo": null, "bar": null}"#,
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "null-only patch on entry with no data should succeed, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Data should still be absent (no phantom null keys stored)
+    let get = mx(&dir, &["kv", "get", "log", "--json"]);
+    let out_str = String::from_utf8_lossy(&get.stdout).to_string();
+    // data field should not contain "foo" or "bar"
+    assert!(
+        !out_str.contains("\"foo\"") && !out_str.contains("\"bar\""),
+        "null-deleted fields must not appear in output: {}",
+        out_str
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P3: Update value to empty string
+// ---------------------------------------------------------------------------
+
+/// Updating value to an empty string. The spec says value is `Option<&str>`.
+/// An empty string is a valid Rust string — it should be accepted.
+/// No schema constraint prevents empty values on unvalidated keys.
+#[test]
+fn update_value_to_empty_string_is_accepted() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "non-empty");
+    let idx = index_from_push(&pushed);
+
+    let out = mx(&dir, &["kv", "update", "log", "--id", &idx, ""]);
+    assert!(
+        out.status.success(),
+        "empty string value update should succeed, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Confirm the value was actually set to empty
+    let get = mx(&dir, &["kv", "get", "log", "--json"]);
+    let get_str = String::from_utf8_lossy(&get.stdout).to_string();
+    // The value field should be empty string
+    assert!(
+        get_str.contains("\"value\":\"\"") || get_str.contains("\"value\": \"\""),
+        "value should be empty string after update, got: {}",
+        get_str
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P4: Update on nonexistent key returns correct error (KeyNotFound, not EntryNotFound)
+// ---------------------------------------------------------------------------
+
+/// BUG CANDIDATE: When the key IS in the schema but NO data has been pushed yet,
+/// `data.entries.get_mut(key)` returns None. The `_ =>` arm at kv.rs:2418 fires
+/// and returns `KvError::EntryNotFound`. But the correct error here is
+/// `KvError::EntryNotFound` (entry 0 doesn't exist) — actually that's fine.
+/// BUT: when the key is NOT in the schema at all, `key_def` returns `KeyNotFound`.
+/// This test verifies the correct error code is returned for a completely unknown key.
+#[test]
+fn update_nonexistent_key_returns_key_not_found_exit_code() {
+    let dir = setup(BASIC_SCHEMA);
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "does_not_exist", "--id", "0", "newval"],
+    );
+    assert!(
+        !out.status.success(),
+        "update on nonexistent key must fail"
+    );
+    // EXIT_KEY_NOT_FOUND = 1
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "expected exit code 1 (KEY_NOT_FOUND), got {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P5: Update on empty history (key exists in schema, but no entries pushed)
+// ---------------------------------------------------------------------------
+
+/// Key is in schema as history/list but has never had anything pushed.
+/// The `_ =>` arm (line 2418) returns EntryNotFound, but this is the WRONG
+/// error: it should be EntryNotFound (with the right message), not KeyNotFound.
+/// The `_ =>` arm also fires for DataValue::Counter/String/State — which means
+/// if somehow the schema says history but the stored data is a counter (corrupt
+/// file), the error would be misleading.
+///
+/// More importantly: what exit code does EntryNotFound produce here?
+/// The spec says: EntryNotFound -> EXIT_INVALID_INPUT (4) via handle_kv_err.
+#[test]
+fn update_on_empty_history_returns_entry_not_found() {
+    let dir = setup(BASIC_SCHEMA);
+    // Do NOT push anything
+
+    let out = mx(&dir, &["kv", "update", "log", "--id", "0", "newval"]);
+    assert!(!out.status.success(), "update on empty history must fail");
+
+    // Should be EXIT_INVALID_INPUT (4) — EntryNotFound maps to that
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected exit code 4 (INVALID_INPUT/EntryNotFound), got {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P6: Ambiguous hash prefix — exact longer match still works
+// ---------------------------------------------------------------------------
+
+/// Push one entry, look it up by a prefix that is identical to its full ID.
+/// Should succeed — full ID is unambiguous (only 1 match).
+#[test]
+fn update_by_full_id_string_succeeds() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "exact");
+    let full_id = id_from_push(&pushed); // "kv-<full-hash>"
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "log", "--id", &full_id, "exact-updated"],
+    );
+    assert!(
+        out.status.success(),
+        "update by full ID must succeed, got: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let get = mx(&dir, &["kv", "get", "log"]);
+    assert!(
+        String::from_utf8_lossy(&get.stdout).contains("exact-updated"),
+        "entry value must be updated"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P7: Multiple sequential updates on same entry — ts/id preserved across all
+// ---------------------------------------------------------------------------
+
+/// Push once; update three times. The ts and id must remain identical across
+/// all updates. Only value and data change.
+#[test]
+fn multiple_sequential_updates_preserve_ts_and_id() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "v1");
+    let idx = index_from_push(&pushed);
+
+    // First update
+    let out1 = mx(&dir, &["kv", "update", "log", "--id", &idx, "v2"]);
+    assert!(out1.status.success(), "update 1 must succeed");
+
+    // Second update
+    let out2 = mx(&dir, &["kv", "update", "log", "--id", &idx, "v3"]);
+    assert!(out2.status.success(), "update 2 must succeed");
+
+    // Third update
+    let out3 = mx(&dir, &["kv", "update", "log", "--id", &idx, "v4"]);
+    assert!(out3.status.success(), "update 3 must succeed");
+
+    // Verify via get --json: entry should still have same index
+    let get = mx(&dir, &["kv", "get", "log", "--json"]);
+    let json_str = String::from_utf8_lossy(&get.stdout).to_string();
+
+    // Value must be v4
+    assert!(
+        json_str.contains("v4"),
+        "final value should be v4, got: {}",
+        json_str
+    );
+
+    // Only one entry should exist (not duplicated by updates)
+    let value_count = json_str.matches("\"value\"").count();
+    assert_eq!(
+        value_count, 1,
+        "should have exactly one entry after 3 updates, got {} value fields in: {}",
+        value_count, json_str
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P8: Counter key returns TypeMismatch, not some other error
+// ---------------------------------------------------------------------------
+
+/// Confirms the counter type gate exit code matches spec.
+/// EXIT_TYPE_MISMATCH = 2.
+#[test]
+fn update_counter_key_returns_type_mismatch_exit_code() {
+    let dir = setup(BASIC_SCHEMA);
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "counter", "--id", "0", "99"],
+    );
+    assert!(!out.status.success(), "update on counter must fail");
+
+    // EXIT_TYPE_MISMATCH = 2
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected exit code 2 (TYPE_MISMATCH), got {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P9: --data as non-object (string, array, number, null, bool) all rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn data_as_string_is_rejected() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "entry");
+    let idx = index_from_push(&pushed);
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "log", "--id", &idx, "--data", "\"hello\""],
+    );
+    assert!(!out.status.success(), "string --data must be rejected");
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected exit 4 for non-object data"
+    );
+}
+
+#[test]
+fn data_as_array_is_rejected() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "entry");
+    let idx = index_from_push(&pushed);
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "log", "--id", &idx, "--data", "[1,2,3]"],
+    );
+    assert!(!out.status.success(), "array --data must be rejected");
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected exit 4 for array data"
+    );
+}
+
+#[test]
+fn data_as_null_is_rejected() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "entry");
+    let idx = index_from_push(&pushed);
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "log", "--id", &idx, "--data", "null"],
+    );
+    assert!(!out.status.success(), "null --data must be rejected");
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected exit 4 for null data"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P10: No value AND --data '{}' — is this rejected?
+// ---------------------------------------------------------------------------
+
+/// Empty patch `{}` with no value is now explicitly rejected (exit 4).
+/// The handler detects that --data is an empty object and no value was given,
+/// which means nothing would be updated, and returns EXIT_INVALID_INPUT.
+#[test]
+fn data_empty_object_bypasses_noop_guard() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "noop-test");
+    let idx = index_from_push(&pushed);
+
+    // No positional value, --data '{}' — must now be rejected
+    let out = mx(
+        &dir,
+        &["kv", "update", "log", "--id", &idx, "--data", "{}"],
+    );
+    assert!(
+        !out.status.success(),
+        "empty --data {{}} with no value must be rejected"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected EXIT_INVALID_INPUT (4), got {:?}",
+        out.status.code()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P11: Validate that --data null-delete actually removes field from JSON output
+// ---------------------------------------------------------------------------
+
+/// Push with data `{"a": 1, "b": 2}`, update with `{"b": null}`.
+/// GET --json output must not contain key "b" at all.
+/// This is the spec-required null-as-delete behavior tested end-to-end via CLI.
+#[test]
+fn null_as_delete_removes_field_from_json_output() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push_with_data(&dir, "log", "entry", r#"{"a": 1, "b": 2}"#);
+    let idx = index_from_push(&pushed);
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "log", "--id", &idx, "--data", r#"{"b": null}"#],
+    );
+    assert!(
+        out.status.success(),
+        "null-delete update must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let get = mx(&dir, &["kv", "get", "log", "--json"]);
+    let json_str = String::from_utf8_lossy(&get.stdout).to_string();
+
+    assert!(
+        json_str.contains("\"a\""),
+        "field a must remain after null-delete of b: {}",
+        json_str
+    );
+    assert!(
+        !json_str.contains("\"b\""),
+        "field b must be gone after null-delete, got: {}",
+        json_str
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P12: Required field: null-delete a required field — must fail validation
+// ---------------------------------------------------------------------------
+
+/// Schema declares `status` as required. Push with `{"status": "open"}`.
+/// Patch with `{"status": null}` attempts to delete a required field.
+/// After merge, the object has no `status` field -> validate_data must reject.
+/// Entry must be unchanged.
+#[test]
+fn null_delete_required_field_fails_validation() {
+    let dir = setup(VALIDATED_SCHEMA);
+    let pushed = push_with_data(&dir, "tasks", "task-x", r#"{"status": "open"}"#);
+    let idx = index_from_push(&pushed);
+
+    let out = mx(
+        &dir,
+        &[
+            "kv", "update", "tasks", "--id", &idx, "--data",
+            r#"{"status": null}"#,
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "deleting a required field via null must fail"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected EXIT_INVALID_INPUT (4) for validation failure, got {:?}",
+        out.status.code()
+    );
+
+    // Entry must be unchanged
+    let get = mx(&dir, &["kv", "get", "tasks", "--json"]);
+    let json_str = String::from_utf8_lossy(&get.stdout).to_string();
+    assert!(
+        json_str.contains("\"status\""),
+        "status field must still exist after rejected update: {}",
+        json_str
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P13: Update by --id kv- with no suffix should be rejected
+// ---------------------------------------------------------------------------
+
+/// parse_single_id checks that the suffix after "kv-" is non-empty.
+/// Passing `--id kv-` (bare prefix only) should return an error.
+#[test]
+fn update_with_bare_kv_prefix_is_rejected() {
+    let dir = setup(BASIC_SCHEMA);
+    push(&dir, "log", "entry");
+
+    let out = mx(&dir, &["kv", "update", "log", "--id", "kv-", "newval"]);
+    assert!(
+        !out.status.success(),
+        "bare 'kv-' ID must be rejected, got exit {:?}",
+        out.status.code()
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected EXIT_INVALID_INPUT (4) for empty kv- ID"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P14: Update output format test — "Updated entry N (kv-<id>)"
+// ---------------------------------------------------------------------------
+
+/// The spec says output is: "Updated entry {index} (kv-{id})".
+/// Verify the actual output format matches what scripts would parse.
+#[test]
+fn update_output_format_matches_spec() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "check-format");
+    let idx = index_from_push(&pushed);
+    let kv_id = id_from_push(&pushed); // "kv-<hash>"
+
+    let out = mx(&dir, &["kv", "update", "log", "--id", &idx, "updated"]);
+    assert!(out.status.success(), "update must succeed");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    // Must contain "Updated entry N (kv-<hash>)"
+    assert!(
+        stdout.contains("Updated entry"),
+        "output must start with 'Updated entry': {}",
+        stdout
+    );
+    assert!(
+        stdout.contains(&kv_id),
+        "output must contain the kv-<id>: {}",
+        stdout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P15: Update when no-op (no value, no data) returns error
+// ---------------------------------------------------------------------------
+
+/// The spec requires the no-op case to be rejected at the handler level.
+/// mx kv update log --id 0  (no value, no --data) must fail with exit 4.
+#[test]
+fn update_with_no_value_and_no_data_is_rejected() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "entry");
+    let idx = index_from_push(&pushed);
+
+    let out = mx(&dir, &["kv", "update", "log", "--id", &idx]);
+    assert!(
+        !out.status.success(),
+        "no-op update must be rejected, got exit {:?}",
+        out.status.code()
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "expected EXIT_INVALID_INPUT (4) for no-op update"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P16: List type — update works same as history
+// ---------------------------------------------------------------------------
+
+#[test]
+fn update_list_entry_by_index_works() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "items", "list-item-1");
+    let idx = index_from_push(&pushed);
+
+    let out = mx(
+        &dir,
+        &["kv", "update", "items", "--id", &idx, "list-item-1-updated"],
+    );
+    assert!(
+        out.status.success(),
+        "update on list must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let get = mx(&dir, &["kv", "get", "items"]);
+    assert!(
+        String::from_utf8_lossy(&get.stdout).contains("list-item-1-updated"),
+        "list entry value must be updated"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P17: Wrong type for priority field fails with validation error, entry unchanged
+// ---------------------------------------------------------------------------
+
+#[test]
+fn patch_wrong_type_for_validated_field_fails_entry_unchanged() {
+    let dir = setup(VALIDATED_SCHEMA);
+    let pushed = push_with_data(&dir, "tasks", "work", r#"{"status": "open", "priority": 3}"#);
+    let idx = index_from_push(&pushed);
+
+    // priority must be a number; patch with a string
+    let out = mx(
+        &dir,
+        &[
+            "kv", "update", "tasks", "--id", &idx, "--data",
+            r#"{"priority": "high"}"#,
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "wrong type for validated field must fail"
+    );
+    assert_eq!(out.status.code(), Some(4));
+
+    // Entry must still have priority = 3
+    let get = mx(&dir, &["kv", "get", "tasks", "--json"]);
+    let json_str = String::from_utf8_lossy(&get.stdout).to_string();
+    assert!(
+        json_str.contains("\"priority\":3") || json_str.contains("\"priority\": 3"),
+        "priority must remain 3 after rejected update: {}",
+        json_str
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P18: Merge empty object -> data becomes None (not `{}`)
+// ---------------------------------------------------------------------------
+
+/// When the only existing field is deleted via null-patch, merged_obj is empty.
+/// The code normalizes this to None (not Some({})).
+/// Verify that no `{}` appears in serialized JSON output.
+#[test]
+fn merge_resulting_in_empty_object_stored_as_none() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push_with_data(&dir, "log", "alone", r#"{"x": 1}"#);
+    let idx = index_from_push(&pushed);
+
+    // Delete the only field via null-patch
+    let out = mx(
+        &dir,
+        &["kv", "update", "log", "--id", &idx, "--data", r#"{"x": null}"#],
+    );
+    assert!(
+        out.status.success(),
+        "null-delete of sole field must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let get = mx(&dir, &["kv", "get", "log", "--json"]);
+    let json_str = String::from_utf8_lossy(&get.stdout).to_string();
+
+    // data should not be an empty object; it should be absent or null
+    assert!(
+        !json_str.contains("\"data\":{}") && !json_str.contains("\"data\": {}"),
+        "empty merged object must be stored as None, not {{}}: {}",
+        json_str
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P19: Update invalid JSON for --data
+// ---------------------------------------------------------------------------
+
+#[test]
+fn invalid_json_for_data_returns_error() {
+    let dir = setup(BASIC_SCHEMA);
+    let pushed = push(&dir, "log", "entry");
+    let idx = index_from_push(&pushed);
+
+    let out = mx(
+        &dir,
+        &[
+            "kv", "update", "log", "--id", &idx, "--data",
+            "{not valid json",
+        ],
+    );
+    assert!(!out.status.success(), "invalid JSON must be rejected");
+    assert_eq!(out.status.code(), Some(4));
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(
+        stderr.contains("invalid JSON"),
+        "error message must mention invalid JSON: {}",
+        stderr
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P20: Ambiguous ID prefix — handler returns correct exit code
+// ---------------------------------------------------------------------------
+
+/// When two entries share a common prefix, update with that prefix must fail
+/// with AmbiguousId -> EXIT_INVALID_INPUT (4).
+/// Note: IDs are hashes and may not share prefixes reliably, so we construct
+/// a long prefix that could match multiple entries by using a known shared prefix.
+/// This test uses index-based lookup as a workaround if hash collision is unlikely,
+/// but tests the ambiguity detection at the engine boundary via unit-test helpers.
+/// For the CLI path, we rely on the prefix being actually ambiguous.
+///
+/// We push 50 entries and then use a 1-character prefix — the chance that
+/// two entries share a 1-char prefix from a hash alphabet is high enough to
+/// test this path. But since we can't guarantee it in a pure test environment,
+/// we run this as a probabilistic check with proper assertions only if ambiguous.
+#[test]
+fn ambiguous_prefix_returns_exit_code_4() {
+    let dir = setup(BASIC_SCHEMA);
+
+    // Collect IDs to find one that shares a prefix with another
+    let mut ids = Vec::new();
+    for i in 0..20 {
+        let pushed = push(&dir, "log", &format!("entry-{}", i));
+        ids.push(id_from_push(&pushed));
+    }
+
+    // Find any 1-char prefix that appears in at least 2 IDs (after stripping "kv-")
+    let hashes: Vec<&str> = ids.iter().map(|id| &id[3..]).collect(); // strip "kv-"
+    let mut ambiguous_prefix = None;
+    'outer: for prefix_len in 1..6 {
+        let mut seen = std::collections::HashMap::new();
+        for hash in &hashes {
+            if hash.len() < prefix_len {
+                continue;
+            }
+            let pfx = &hash[..prefix_len];
+            let cnt = seen.entry(pfx).or_insert(0usize);
+            *cnt += 1;
+            if *cnt >= 2 {
+                ambiguous_prefix = Some(format!("kv-{}", pfx));
+                break 'outer;
+            }
+        }
+    }
+
+    if let Some(prefix) = ambiguous_prefix {
+        let out = mx(&dir, &["kv", "update", "log", "--id", &prefix, "newval"]);
+        assert!(
+            !out.status.success(),
+            "ambiguous prefix must fail, got exit {:?}",
+            out.status.code()
+        );
+        assert_eq!(
+            out.status.code(),
+            Some(4),
+            "AmbiguousId must return exit 4, got {:?}",
+            out.status.code()
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+        assert!(
+            stderr.to_lowercase().contains("ambiguous") || stderr.contains("matches"),
+            "stderr must mention ambiguity: {}",
+            stderr
+        );
+    }
+    // If no shared prefix found in 20 entries (very unlikely), test passes vacuously
+}

--- a/tests/update_pressure.rs
+++ b/tests/update_pressure.rs
@@ -1,7 +1,7 @@
-/// Adversarial tests for `mx kv update` / `KvStore::update_entry`.
-///
-/// These run via `cargo test` as integration-style tests against the binary.
-/// They test paths the 15 unit tests in kv.rs do not cover.
+//! Adversarial tests for `mx kv update` / `KvStore::update_entry`.
+//!
+//! These run via `cargo test` as integration-style tests against the binary.
+//! They test paths the 15 unit tests in kv.rs do not cover.
 
 use std::fs;
 use std::process::Command;
@@ -53,23 +53,18 @@ fn push_with_data(dir: &TempDir, key: &str, value: &str, data: &str) -> String {
 /// Extract the numeric index from "kv-<id> (<index>)" push output.
 fn index_from_push(push_out: &str) -> String {
     // Format: "kv-<hash> (<index>)"
-    let inner = push_out
+    push_out
         .trim_end_matches(')')
         .rsplit('(')
         .next()
         .unwrap()
         .trim()
-        .to_string();
-    inner
+        .to_string()
 }
 
 /// Extract the kv-<hash> prefix from push output for use in --id.
 fn id_from_push(push_out: &str) -> String {
-    push_out
-        .split_whitespace()
-        .next()
-        .unwrap()
-        .to_string()
+    push_out.split_whitespace().next().unwrap().to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -147,7 +142,12 @@ fn patch_all_nulls_on_entry_without_data_yields_none() {
     let out = mx(
         &dir,
         &[
-            "kv", "update", "log", "--id", &idx, "--data",
+            "kv",
+            "update",
+            "log",
+            "--id",
+            &idx,
+            "--data",
             r#"{"foo": null, "bar": null}"#,
         ],
     );
@@ -217,10 +217,7 @@ fn update_nonexistent_key_returns_key_not_found_exit_code() {
         &dir,
         &["kv", "update", "does_not_exist", "--id", "0", "newval"],
     );
-    assert!(
-        !out.status.success(),
-        "update on nonexistent key must fail"
-    );
+    assert!(!out.status.success(), "update on nonexistent key must fail");
     // EXIT_KEY_NOT_FOUND = 1
     assert_eq!(
         out.status.code(),
@@ -345,10 +342,7 @@ fn multiple_sequential_updates_preserve_ts_and_id() {
 fn update_counter_key_returns_type_mismatch_exit_code() {
     let dir = setup(BASIC_SCHEMA);
 
-    let out = mx(
-        &dir,
-        &["kv", "update", "counter", "--id", "0", "99"],
-    );
+    let out = mx(&dir, &["kv", "update", "counter", "--id", "0", "99"]);
     assert!(!out.status.success(), "update on counter must fail");
 
     // EXIT_TYPE_MISMATCH = 2
@@ -394,11 +388,7 @@ fn data_as_array_is_rejected() {
         &["kv", "update", "log", "--id", &idx, "--data", "[1,2,3]"],
     );
     assert!(!out.status.success(), "array --data must be rejected");
-    assert_eq!(
-        out.status.code(),
-        Some(4),
-        "expected exit 4 for array data"
-    );
+    assert_eq!(out.status.code(), Some(4), "expected exit 4 for array data");
 }
 
 #[test]
@@ -412,11 +402,7 @@ fn data_as_null_is_rejected() {
         &["kv", "update", "log", "--id", &idx, "--data", "null"],
     );
     assert!(!out.status.success(), "null --data must be rejected");
-    assert_eq!(
-        out.status.code(),
-        Some(4),
-        "expected exit 4 for null data"
-    );
+    assert_eq!(out.status.code(), Some(4), "expected exit 4 for null data");
 }
 
 // ---------------------------------------------------------------------------
@@ -433,10 +419,7 @@ fn data_empty_object_bypasses_noop_guard() {
     let idx = index_from_push(&pushed);
 
     // No positional value, --data '{}' — must now be rejected
-    let out = mx(
-        &dir,
-        &["kv", "update", "log", "--id", &idx, "--data", "{}"],
-    );
+    let out = mx(&dir, &["kv", "update", "log", "--id", &idx, "--data", "{}"]);
     assert!(
         !out.status.success(),
         "empty --data {{}} with no value must be rejected"
@@ -464,7 +447,15 @@ fn null_as_delete_removes_field_from_json_output() {
 
     let out = mx(
         &dir,
-        &["kv", "update", "log", "--id", &idx, "--data", r#"{"b": null}"#],
+        &[
+            "kv",
+            "update",
+            "log",
+            "--id",
+            &idx,
+            "--data",
+            r#"{"b": null}"#,
+        ],
     );
     assert!(
         out.status.success(),
@@ -504,7 +495,12 @@ fn null_delete_required_field_fails_validation() {
     let out = mx(
         &dir,
         &[
-            "kv", "update", "tasks", "--id", &idx, "--data",
+            "kv",
+            "update",
+            "tasks",
+            "--id",
+            &idx,
+            "--data",
             r#"{"status": null}"#,
         ],
     );
@@ -642,14 +638,24 @@ fn update_list_entry_by_index_works() {
 #[test]
 fn patch_wrong_type_for_validated_field_fails_entry_unchanged() {
     let dir = setup(VALIDATED_SCHEMA);
-    let pushed = push_with_data(&dir, "tasks", "work", r#"{"status": "open", "priority": 3}"#);
+    let pushed = push_with_data(
+        &dir,
+        "tasks",
+        "work",
+        r#"{"status": "open", "priority": 3}"#,
+    );
     let idx = index_from_push(&pushed);
 
     // priority must be a number; patch with a string
     let out = mx(
         &dir,
         &[
-            "kv", "update", "tasks", "--id", &idx, "--data",
+            "kv",
+            "update",
+            "tasks",
+            "--id",
+            &idx,
+            "--data",
             r#"{"priority": "high"}"#,
         ],
     );
@@ -685,7 +691,15 @@ fn merge_resulting_in_empty_object_stored_as_none() {
     // Delete the only field via null-patch
     let out = mx(
         &dir,
-        &["kv", "update", "log", "--id", &idx, "--data", r#"{"x": null}"#],
+        &[
+            "kv",
+            "update",
+            "log",
+            "--id",
+            &idx,
+            "--data",
+            r#"{"x": null}"#,
+        ],
     );
     assert!(
         out.status.success(),
@@ -717,7 +731,12 @@ fn invalid_json_for_data_returns_error() {
     let out = mx(
         &dir,
         &[
-            "kv", "update", "log", "--id", &idx, "--data",
+            "kv",
+            "update",
+            "log",
+            "--id",
+            &idx,
+            "--data",
             "{not valid json",
         ],
     );

--- a/tests/update_pressure.rs
+++ b/tests/update_pressure.rs
@@ -23,6 +23,7 @@ fn setup(schema_toml: &str) -> TempDir {
 fn mx(dir: &TempDir, args: &[&str]) -> std::process::Output {
     Command::new(MX)
         .args(args)
+        .env("MX_CURRENT_AGENT", "test")
         .env("MX_KV_SCHEMA", dir.path().join("schema.toml"))
         .env("MX_KV_DATA", dir.path().join("data.json"))
         .output()


### PR DESCRIPTION
## 🦝 From the Dumpster, With Love

Cory left review on PR #322. Four items. We released six raccoons into the codebase with the same task and watched them diverge. Then I read every trace, picked the parts that didn't smell, and stitched the result on top of garbaggio's decomposition. Two reviewers ran the dumpster-dive afterward — Lil Grabby pressure-tested with 10 adversarial cases, Roach reviewed with the production lens — and we patched seven more things they found before this PR opened.

The four asks:
1. `update_entry` did a read pass to find the entry, then a mutable re-find with `.unwrap()` because "safe: existence confirmed above" (a comment is not a contract). Now it captures `usize` from the first scan and writes via `entries[idx]`.
2. ~60 lines of near-identical History/List code. Now: one `EntryFields` trait, two trivial impls, three free fns (`find_entry_idx`, `apply_entry_update`, `merge_entry_data`). `update_entry` shrinks from ~170 lines to ~55.
3. The catch-all `_ => EntryNotFound` swallowed everything — Counter/String/State, None, data corruption. Now: explicit `Counter | String → TypeMismatch` (early guard, grammatical message), `State → TypeMismatch` with a hint to use `mx kv set`, inner `Counter|String|State` arms return `KvError::Other("data corruption: ...")` (compiler-enforced exhaustive so a new `DataValue` variant won't fall through silently), `None → EntryNotFound { id: "(no entries pushed)" }`.
4. The `--data '{}'` rejection lived in the CLI handler, so a library caller passing `update_entry(key, id, None, Some({}))` programmatically got nothing. Moved into `update_entry` as a `DataValidation` early return — same exit code (`EXIT_INVALID_INPUT`) preserved.

## Who Built What

| Raccoon | Contribution |
|---------|-------------|
| 🦝 **garbaggio** | Cleanest decomposition: `find_entry_idx` + `apply_entry_update` + `merge_entry_data`. THIS is what the structural decomposer is supposed to do — code, not just trace. Base of the merge. |
| 🦝 **trashboat** | Spotted that HistoryEntry and ListEntry are structurally identical (same fields, same role) and that the duplication is a symptom of a deeper redundancy. The trait doc comment credits this insight. Also: corruption-safe explicit arms (`KvError::Other`) instead of a panicking `unreachable!()`. |
| 🦝 **lil-grabby** | Best edge-case audit table going in. Best wording for the empty-data guard message (`"key '{key}': --data is an empty object and no value was given — nothing to update"`). Then came back as pressure-tester and found a real bug: the Counter/String error message rendered as `"is counter, not update not supported for this entry type"` — gibberish through the Display template. Saved the user from a confusing error. |
| 🦝 **roach** | Code reviewer. Caught the `clippy::ptr_arg` warning (`&mut Vec<E>` → `&mut [E]`) that would have become a CI failure the moment anyone added `-D warnings`. Flagged the stilted `id: "no entries found"` rendering and the guard-order suggestion. Verified `mx kv set` actually exists before letting the error message claim it does. Inward lens working. |
| 🦝 **el-notario** | The drift watch was on this run — Item 2 is exactly the "structural decomposer becoming documenter" trap. Verdict: code-side, the helper was real (`update_entry_in_vec`) but garbaggio's was tighter, so el-notario shipped the assembly instead. Contract table in the trace was the best of the six. |
| 🦝 **one-ply** | Opinion mandate landed: trace finally had a paragraph defending the design call, not just sparse code. Implementation was tight (`KvEntryMut` trait + `find_and_update_vec`) but used `DataValidation` for Counter/String/State, which is the wrong error category. The trace was the win. |

## DJ's Take

Six raccoons, one task. Convergence was high — everyone reached for a trait + generic helper for Item 2. Garbaggio won assembly because his factoring extracted `merge_entry_data` too (the others kept the merge logic as an inline closure), and because his `update_entry` body collapsed to ~55 lines of straight-line code with single-line History/List arms. Trashboat's contribution was structural insight: he diagnosed that the deeper fix is merging HistoryEntry and ListEntry into one struct (out of scope here — touches serialization and tests). El-notario built a strong assembly but garbaggio's was tighter. Roach incomplete-deduped (only the mutable commit — read pass still inline). Lil-grabby used closures instead of a trait, which is more idiomatic Rust in some ways but loses readability at the call site. One-ply was the smallest delta but picked the wrong error variants for Item 3.

The Item 3 question — "what error do you return when the catch-all fires?" — broke the swarm into three camps. Two raccoons (el-notario, lil-grabby) returned `TypeMismatch { got: def.value_type.to_string() }`, which has a real bug: by the time you reach the inner match, `def.value_type` IS History or List (the early guard filtered everything else), so the rendered message reads "expected history or list, got history". Trashboat alone returned `KvError::Other("data corruption: ...")` — semantically correct because if Counter/String/State data is sitting under a History/List schema, that IS corruption. I took trashboat's reading, layered it on garbaggio's base, kept garbaggio's early-guard messages for the normal user-error case, and replaced his `unreachable!()` with explicit corruption arms (so the engine never panics on disk drift).

The review loop caught seven more things across two reviewers. Lil-grabby's grammatical-error test exposed that "expected: 'update not supported for this entry type'" plugged into the Display template as `"is counter, not update not supported for this entry type"` — gibberish. Fix: switch to noun-phrase wording (`"history or list"`) that the template was designed for. Roach caught the ptr_arg clippy warning under `-D warnings`. Both agreed the empty-data guard should run AFTER the key lookup so typo'd keys don't get hidden behind "empty data" errors. All fixed in iter 1, both reviewers said ship in iter 2.

## Test Results

- **341/341 GREEN.** 309 lib unit tests + 22 `update_pressure.rs` integration tests + 10 adversarial pressure tests written by Lil Grabby during the review loop (NOT committed — diagnostic only).
- `cargo build` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- Existing tests asserting `TypeMismatch` for Counter keys still pass — the early guard catches them with friendly messages before the inner match.

## Known Issues

- `find_entry_idx` collects all prefix matches into `Vec<usize>` for the ambiguity check. On a 100k-entry list with a one-char prefix, that's a 100k allocation. Both reviewers flagged it. Skipped because (a) no regression vs the PR #322 base — the same shape existed there, and (b) a `take(2)` short-circuit would lose the exact `AmbiguousId.count` payload, which is informative. If anyone ever cares, separate ticket.
- `EntryFields::set_value(&mut self, v: &str)` allocates internally via `to_string()`. Fine today (CLI passes `&str`). If a future caller passes `&String`, they allocate twice. Skipped because no measurable cost today.
- The deeper structural redundancy trashboat surfaced — HistoryEntry and ListEntry are structurally identical — would be solved cleanly by merging the structs and giving the outer `DataValue` variants the semantic distinction. Out of scope: touches serialization, public API, and test fixtures.

## Stats

- Run: `2026-05-21-112051`
- Mode: compete (6 raccoons, same task)
- Crew: trashboat · el-notario · roach · lil-grabby · garbaggio · one-ply
- Assembler: el-notario (lieutenant)
- Reviewers: lil-grabby (pressure-test) + roach (review)
- Iterations: 2
- Branch: `scrapyard/2026-05-21-112051` (built on `scrapyard/2026-05-19-175308`, PR #322's branch)
- Commits in this branch: 2 (assembly + iter-1 fix)
- Lines: `src/kv.rs` +228 −162 net (`update_entry` body alone dropped from ~170 to ~55 lines), `src/handlers/kv.rs` −6
- Notable firsts: first time DJ ran the review loop with mid-run grammatical-error bug found by adversarial pressure-tests.

---

*— DJ & the Trash Pandas* 🦝🔥

*Six raccoons, one match arm, four bugs, two reviewers, zero panics. The Display template was the bug; the test suite never read its own error messages out loud.*