### PR TITLE
feat(kv): batch multi-field set for state entries (#324)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ mx kv inc builds
 mx kv push decisions "chose Typst for docs"    # prints: kv-A3fB (1)
 mx kv last decisions --count 5
 
+# Batch set multiple state fields at once
+mx kv set context goal="done" phase="writing"
+mx kv set context --json '{"goal":"done","phase":"writing"}'
+mx kv set mytensor --json '[0.4, 0.6, 0.5]'
+echo '{"goal":"done"}' | mx kv set context --json -
+
 # Auto-create a key in the schema and push in one step
 mx kv push puns "the joke" --create history
 mx kv push ideas "wild thought" --create list --max-entries 500

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -589,7 +589,7 @@ Supported types:
   [`string`], [Simple string value. Supports `set`, `get`],
   [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. Each entry gets a numeric index and a stable base58 entry ID (`kv-` prefix). Entries can carry optional structured JSON data (`--data` on push, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
   [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. Each entry gets a numeric index and a stable base58 entry ID. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
-  [`state`], [Named fields (like a struct). Supports `set <key> <field> <value>`, `get`],
+  [`state`], [Named fields (like a struct). Supports single-field set (`set <key> <field> <value>`), batch set (`set <key> field=value ...` or `set <key> --json '{...}'`), tensor positional set (`set <key> --json '[...]'`), and `get`. Batch operations validate all fields against the schema before writing.],
 )
 
 === Data (JSON)

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -145,6 +145,12 @@ mx kv get decisions --id kv-A3fB              # look up by entry ID
 mx kv push puns "the joke" --create history
 mx kv push ideas "wild thought" --create list --max-entries 500
 
+# Batch set multiple state fields at once
+mx kv set context goal="done" phase="writing"
+mx kv set context --json '{"goal":"done","phase":"writing"}'
+mx kv set mytensor --json '[0.4, 0.6, 0.5]'
+echo '{"goal":"done"}' | mx kv set context --json -
+
 # Link entries to the memory graph
 mx kv push decisions "adopted memory links" --memory kn-abc123
 mx kv set decisions --id 17 --memory kn-abc123

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -156,17 +156,32 @@ KV commands use structured exit codes for scripting:
 )
 
 #command(
-  "mx kv set <key> <value> [field_value]",
+  "mx kv set <key> [args...] [--json <value>]",
   [Set a value for a string, counter, or state key, or link a specific
-  entry to a memory node.
+  entry to a memory node. Supports four input modes for state keys:
+  single-field, inline batch, JSON object, and JSON array (tensor).
 
   For *string* keys: `mx kv set <key> <value>` sets the value directly.
 
   For *counter* keys: `mx kv set <key> <value>` parses the value as an integer
   and clamps to min/max.
 
-  For *state* keys: `mx kv set <key> <field> <value>` sets a single field.
-  The field name must be declared in the schema.
+  For *state* keys, four input modes are available:
+
+  / Single field (legacy): `mx kv set <key> <field> <value>` -- sets one field. Backward compatible with pre-batch syntax.
+  / Inline batch: `mx kv set <key> field1=value1 field2=value2 ...` -- sets multiple fields atomically. All field names are validated against the schema before any writes. Unmentioned fields are preserved (partial update).
+  / JSON object: `mx kv set <key> --json '{"field1":"value1","field2":"value2"}'` -- sets multiple fields from a JSON object. Non-string values (numbers, booleans, null) are coerced to strings. Same atomic validation as inline batch.
+  / JSON array (tensor): `mx kv set <key> --json '[0.4, 0.6, 0.5]'` -- sets all fields by position. The number of array elements must exactly match the number of fields declared in the schema. Values are mapped to schema fields in declaration order.
+
+  The `--json` flag accepts `"-"` to read JSON from stdin:
+  `echo '{"goal":"done"}' | mx kv set context --json -`
+
+  The `--json` flag and positional arguments cannot be combined -- use one
+  or the other.
+
+  Batch operations (inline and JSON) are all-or-nothing: if any field name
+  is invalid, no fields are written. Duplicate field names in a single batch
+  are rejected. All validation errors are reported, not just the first.
 
   With `--id` and `--memory`, links an existing history or list entry to a
   memory knowledge node. The `--id` flag accepts a numeric index (`17`) or an
@@ -175,6 +190,7 @@ KV commands use structured exit codes for scripting:
   `--memory`; it cannot be used alone. Pass an empty string
   (`--memory ""`) to clear a per-entry link.],
   flags: (
+    ([`--json <value>`], [string], [JSON input: object for state batch set, array for tensor positional set. Use `"-"` to read from stdin.]),
     ([`--memory <kn-id>`], [string], [Link a memory entry (kn- ID) to this key or entry, or `""` to clear]),
     ([`--id <spec>`], [string], [Target a specific entry by numeric index or entry ID (requires `--memory`)]),
   ),
@@ -183,6 +199,11 @@ KV commands use structured exit codes for scripting:
     "mx kv set builds 0",
     "mx kv set context goal \"finish KV docs\"",
     "mx kv set context phase \"writing\"",
+    "mx kv set context goal=\"done\" phase=\"writing\"",
+    "mx kv set context goal=\"done\" phase=\"writing\" blocker=\"none\"",
+    "mx kv set context --json '{\"goal\":\"done\",\"phase\":\"writing\"}'",
+    "mx kv set mytensor --json '[0.4, 0.6, 0.5]'",
+    "echo '{\"goal\":\"done\"}' | mx kv set context --json -",
     "mx kv set decisions --memory kn-abc123",
     "mx kv set decisions --memory \"\"",
     "mx kv set decisions --id 17 --memory kn-abc123",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1723,7 +1723,7 @@ pub enum KvCommands {
         json: bool,
     },
 
-    /// Set a value (string/counter), or set a field on a state type
+    /// Set a value (string/counter), set field(s) on a state type, or batch set via --json
     Set {
         /// Key name
         key: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1724,15 +1724,20 @@ pub enum KvCommands {
     },
 
     /// Set a value (string/counter), or set a field on a state type
+    #[command(trailing_var_arg = true)]
     Set {
         /// Key name
         key: String,
 
-        /// Value to set (for string/counter), or field name (for state type)
-        value: Option<String>,
+        /// Positional arguments: value (string/counter), field value (state),
+        /// or key=value pairs (batch state set)
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
 
-        /// Field value (only for state type: mx kv set <key> <field> <value>)
-        field_value: Option<String>,
+        /// JSON value: object for state batch, array for tensor positional set.
+        /// Use "-" to read from stdin.
+        #[arg(long)]
+        json: Option<String>,
 
         /// Link a memory entry (kn- ID) to this key, or "" to clear
         #[arg(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1724,7 +1724,6 @@ pub enum KvCommands {
     },
 
     /// Set a value (string/counter), or set a field on a state type
-    #[command(trailing_var_arg = true)]
     Set {
         /// Key name
         key: String,

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -195,6 +195,152 @@ fn parse_where_clauses(clauses: &[String]) -> Result<Vec<(String, String)>, Stri
     Ok(result)
 }
 
+// ---------------------------------------------------------------------------
+// Set input parsing
+// ---------------------------------------------------------------------------
+
+/// Parsed input for the `kv set` subcommand.
+#[derive(Debug, PartialEq)]
+enum SetInput {
+    /// A single scalar value (string or counter).
+    Scalar(String),
+    /// A single field=value for a state type (legacy two-arg syntax).
+    SingleField { field: String, value: String },
+    /// Multiple field=value pairs for batch state set.
+    BatchFields(Vec<(String, String)>),
+    /// Parsed JSON object → field pairs for state batch.
+    JsonObject(Vec<(String, String)>),
+    /// Parsed JSON array → positional values for tensor set.
+    JsonArray(Vec<String>),
+    /// No input provided.
+    None,
+}
+
+/// Parse positional args into a `SetInput`.
+///
+/// Rules:
+/// - 0 args → None
+/// - 1 arg without `=` → Scalar
+/// - 1 arg with `=` → BatchFields (of 1)
+/// - 2 args, neither has `=` → SingleField (legacy backward compat)
+/// - 2 args, any has `=` → BatchFields
+/// - 3+ args → BatchFields (all must have `=`)
+fn parse_positional_args(args: &[String]) -> Result<SetInput, String> {
+    match args.len() {
+        0 => Ok(SetInput::None),
+        1 => {
+            let arg = &args[0];
+            if arg.contains('=') {
+                let (k, v) = arg.split_once('=').unwrap();
+                Ok(SetInput::BatchFields(vec![(k.to_string(), v.to_string())]))
+            } else {
+                Ok(SetInput::Scalar(arg.clone()))
+            }
+        }
+        2 => {
+            let has_eq_0 = args[0].contains('=');
+            let has_eq_1 = args[1].contains('=');
+            if !has_eq_0 && !has_eq_1 {
+                // Legacy: mx kv set <key> <field> <value>
+                Ok(SetInput::SingleField {
+                    field: args[0].clone(),
+                    value: args[1].clone(),
+                })
+            } else {
+                // Both should be key=value pairs
+                let mut pairs = Vec::with_capacity(2);
+                for arg in args {
+                    match arg.split_once('=') {
+                        Some((k, v)) => pairs.push((k.to_string(), v.to_string())),
+                        None => {
+                            return Err(format!("expected key=value pair, got '{}'", arg));
+                        }
+                    }
+                }
+                Ok(SetInput::BatchFields(pairs))
+            }
+        }
+        _ => {
+            // 3+ args: all must be key=value
+            let mut pairs = Vec::with_capacity(args.len());
+            for arg in args {
+                match arg.split_once('=') {
+                    Some((k, v)) => pairs.push((k.to_string(), v.to_string())),
+                    None => {
+                        return Err(format!("expected key=value pair, got '{}'", arg));
+                    }
+                }
+            }
+            Ok(SetInput::BatchFields(pairs))
+        }
+    }
+}
+
+/// Parse `--json` input into a `SetInput`.
+///
+/// - If the string is "-", reads from stdin.
+/// - Object → extract pairs, route to JsonObject
+/// - Array of numbers/strings → extract as strings, route to JsonArray
+/// - Other → error
+fn parse_json_input(raw: &str) -> Result<SetInput, String> {
+    let json_str = if raw == "-" {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| format!("failed to read JSON from stdin: {}", e))?;
+        buf
+    } else {
+        raw.to_string()
+    };
+
+    let value: serde_json::Value =
+        serde_json::from_str(&json_str).map_err(|e| format!("invalid JSON: {}", e))?;
+
+    match value {
+        serde_json::Value::Object(map) => {
+            let pairs: Vec<(String, String)> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let v_str = match v {
+                        serde_json::Value::String(s) => s,
+                        other => other.to_string(),
+                    };
+                    (k, v_str)
+                })
+                .collect();
+            if pairs.is_empty() {
+                return Err("JSON object is empty".to_string());
+            }
+            Ok(SetInput::JsonObject(pairs))
+        }
+        serde_json::Value::Array(arr) => {
+            if arr.is_empty() {
+                return Err("JSON array is empty".to_string());
+            }
+            let values: Vec<String> = arr
+                .into_iter()
+                .map(|v| match v {
+                    serde_json::Value::String(s) => s,
+                    serde_json::Value::Number(n) => n.to_string(),
+                    other => other.to_string(),
+                })
+                .collect();
+            Ok(SetInput::JsonArray(values))
+        }
+        _ => Err(format!(
+            "--json value must be an object or array, got {}",
+            match value {
+                serde_json::Value::String(_) => "string",
+                serde_json::Value::Number(_) => "number",
+                serde_json::Value::Bool(_) => "boolean",
+                serde_json::Value::Null => "null",
+                _ => "unknown",
+            }
+        )),
+    }
+}
+
 /// Handle all `mx kv` subcommands. Returns the exit code directly.
 pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
     let mut store = match KvStore::from_env() {
@@ -334,8 +480,8 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
 
         KvCommands::Set {
             key,
-            value,
-            field_value,
+            args,
+            json,
             memory,
             id,
         } => {
@@ -358,42 +504,96 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                 }
             }
 
+            // Reject --json + positional args together
+            if json.is_some() && !args.is_empty() {
+                eprintln!("Error: --json and positional arguments cannot be combined");
+                return Ok(kv::EXIT_INVALID_INPUT);
+            }
+
+            // Parse input into a SetInput
+            let input = if let Some(json_str) = json {
+                match parse_json_input(&json_str) {
+                    Ok(i) => i,
+                    Err(msg) => {
+                        eprintln!("Error: {}", msg);
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
+                }
+            } else {
+                match parse_positional_args(&args) {
+                    Ok(i) => i,
+                    Err(msg) => {
+                        eprintln!("Error: {}", msg);
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
+                }
+            };
+
             let mut did_something = false;
 
-            // Handle the value set (if a value was provided)
-            if let Some(ref val) = value {
-                // For state types: mx kv set <key> <field> <value>
-                // value = field name, field_value = actual value
-                // For string/counter: mx kv set <key> <value>
-                let result = if let Some(fv) = &field_value {
-                    store.set(&key, fv, Some(val))
-                } else {
-                    store.set(&key, val, None)
-                };
-
-                match result {
-                    Ok(()) => {
-                        did_something = true;
-                    }
-                    Err(e) => {
-                        // If --memory was also provided, still try the memory set
-                        // only if the type mismatch is because it's a history/list
-                        // (set doesn't normally work on those). Otherwise, propagate error.
-                        if memory.is_none() {
-                            return handle_kv_err(e);
+            // Dispatch based on parsed input
+            match input {
+                SetInput::None => {}
+                SetInput::Scalar(val) => {
+                    let result = store.set(&key, &val, None);
+                    match result {
+                        Ok(()) => {
+                            did_something = true;
                         }
-                        // Type mismatch on history/list is expected when only --memory is provided
-                        match &e {
-                            KvError::TypeMismatch { .. } => {
-                                // Allow falling through to memory-only set
-                                eprintln!(
-                                    "Warning: value not set (type does not support set); memory pointer updated"
-                                );
+                        Err(e) => {
+                            if memory.is_none() {
+                                return handle_kv_err(e);
                             }
-                            _ => return handle_kv_err(e),
+                            match &e {
+                                KvError::TypeMismatch { .. } => {
+                                    eprintln!(
+                                        "Warning: value not set (type does not support set); memory pointer updated"
+                                    );
+                                }
+                                _ => return handle_kv_err(e),
+                            }
                         }
                     }
                 }
+                SetInput::SingleField { field, value } => {
+                    let result = store.set(&key, &value, Some(&field));
+                    match result {
+                        Ok(()) => {
+                            did_something = true;
+                        }
+                        Err(e) => {
+                            if memory.is_none() {
+                                return handle_kv_err(e);
+                            }
+                            match &e {
+                                KvError::TypeMismatch { .. } => {
+                                    eprintln!(
+                                        "Warning: value not set (type does not support set); memory pointer updated"
+                                    );
+                                }
+                                _ => return handle_kv_err(e),
+                            }
+                        }
+                    }
+                }
+                SetInput::BatchFields(pairs) => match store.set_state_batch(&key, &pairs) {
+                    Ok(()) => {
+                        did_something = true;
+                    }
+                    Err(e) => return handle_kv_err(e),
+                },
+                SetInput::JsonObject(pairs) => match store.set_state_batch(&key, &pairs) {
+                    Ok(()) => {
+                        did_something = true;
+                    }
+                    Err(e) => return handle_kv_err(e),
+                },
+                SetInput::JsonArray(values) => match store.set_tensor_batch(&key, &values) {
+                    Ok(()) => {
+                        did_something = true;
+                    }
+                    Err(e) => return handle_kv_err(e),
+                },
             }
 
             // Handle the memory pointer (if --memory was provided)
@@ -1081,5 +1281,160 @@ mod tests {
         let err = parse_where_clauses(&clauses).unwrap_err();
         assert!(err.contains("noequalssign"));
         assert!(err.contains("expected format key=value"));
+    }
+
+    // -- parse_positional_args --
+
+    #[test]
+    fn positional_empty_args() {
+        assert_eq!(parse_positional_args(&[]).unwrap(), SetInput::None,);
+    }
+
+    #[test]
+    fn positional_single_scalar() {
+        assert_eq!(
+            parse_positional_args(&["hello".to_string()]).unwrap(),
+            SetInput::Scalar("hello".to_string()),
+        );
+    }
+
+    #[test]
+    fn positional_single_key_value() {
+        assert_eq!(
+            parse_positional_args(&["goal=finish docs".to_string()]).unwrap(),
+            SetInput::BatchFields(vec![("goal".to_string(), "finish docs".to_string())]),
+        );
+    }
+
+    #[test]
+    fn positional_legacy_two_bare_args() {
+        assert_eq!(
+            parse_positional_args(&["phase".to_string(), "writing".to_string()]).unwrap(),
+            SetInput::SingleField {
+                field: "phase".to_string(),
+                value: "writing".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn positional_two_key_value_args() {
+        assert_eq!(
+            parse_positional_args(&["goal=finish docs".to_string(), "phase=writing".to_string(),])
+                .unwrap(),
+            SetInput::BatchFields(vec![
+                ("goal".to_string(), "finish docs".to_string()),
+                ("phase".to_string(), "writing".to_string()),
+            ]),
+        );
+    }
+
+    #[test]
+    fn positional_three_plus_key_value_args() {
+        assert_eq!(
+            parse_positional_args(&[
+                "goal=finish docs".to_string(),
+                "phase=writing".to_string(),
+                "blocker=none".to_string(),
+            ])
+            .unwrap(),
+            SetInput::BatchFields(vec![
+                ("goal".to_string(), "finish docs".to_string()),
+                ("phase".to_string(), "writing".to_string()),
+                ("blocker".to_string(), "none".to_string()),
+            ]),
+        );
+    }
+
+    #[test]
+    fn positional_value_containing_equals_splits_first_only() {
+        assert_eq!(
+            parse_positional_args(&["query=key=value".to_string()]).unwrap(),
+            SetInput::BatchFields(vec![("query".to_string(), "key=value".to_string())]),
+        );
+    }
+
+    #[test]
+    fn positional_mixed_two_args_one_has_eq() {
+        let result = parse_positional_args(&["goal=finish".to_string(), "writing".to_string()]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expected key=value pair"));
+    }
+
+    #[test]
+    fn positional_three_args_one_missing_eq() {
+        let result = parse_positional_args(&[
+            "goal=finish".to_string(),
+            "writing".to_string(),
+            "blocker=none".to_string(),
+        ]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expected key=value pair"));
+    }
+
+    // -- parse_json_input --
+
+    #[test]
+    fn json_object_parsing() {
+        let input = parse_json_input(r#"{"goal":"finish docs","phase":"writing"}"#).unwrap();
+        match input {
+            SetInput::JsonObject(pairs) => {
+                assert_eq!(pairs.len(), 2);
+                assert!(pairs.contains(&("goal".to_string(), "finish docs".to_string())));
+                assert!(pairs.contains(&("phase".to_string(), "writing".to_string())));
+            }
+            _ => panic!("expected JsonObject"),
+        }
+    }
+
+    #[test]
+    fn json_array_parsing() {
+        assert_eq!(
+            parse_json_input("[0.4, 0.6, 0.5]").unwrap(),
+            SetInput::JsonArray(vec![
+                "0.4".to_string(),
+                "0.6".to_string(),
+                "0.5".to_string(),
+            ]),
+        );
+    }
+
+    #[test]
+    fn json_invalid_input() {
+        let result = parse_json_input("not json at all");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid JSON"));
+    }
+
+    #[test]
+    fn json_string_rejected() {
+        let result = parse_json_input(r#""just a string""#);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be an object or array"));
+    }
+
+    #[test]
+    fn json_empty_object_rejected() {
+        let result = parse_json_input("{}");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn json_empty_array_rejected() {
+        let result = parse_json_input("[]");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    #[test]
+    fn json_object_with_numeric_value() {
+        let input = parse_json_input(r#"{"temperature":0.75}"#).unwrap();
+        match input {
+            SetInput::JsonObject(pairs) => {
+                assert_eq!(pairs, vec![("temperature".to_string(), "0.75".to_string())]);
+            }
+            _ => panic!("expected JsonObject"),
+        }
     }
 }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -290,7 +290,7 @@ fn parse_positional_args(args: &[String]) -> Result<SetInput, String> {
 /// Parse `--json` input into a `SetInput`.
 ///
 /// - If the string is "-", reads from stdin.
-/// - Object → extract pairs, route to JsonObject
+/// - Object → extract pairs, route to BatchFields
 /// - Array of numbers/strings → extract as strings, route to JsonArray
 /// - Other → error
 fn parse_json_input(raw: &str) -> Result<SetInput, String> {

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -206,10 +206,8 @@ enum SetInput {
     Scalar(String),
     /// A single field=value for a state type (legacy two-arg syntax).
     SingleField { field: String, value: String },
-    /// Multiple field=value pairs for batch state set.
+    /// Multiple field=value pairs for batch state set (from positional args or JSON object).
     BatchFields(Vec<(String, String)>),
-    /// Parsed JSON object → field pairs for state batch.
-    JsonObject(Vec<(String, String)>),
     /// Parsed JSON array → positional values for tensor set.
     JsonArray(Vec<String>),
     /// No input provided.
@@ -232,6 +230,9 @@ fn parse_positional_args(args: &[String]) -> Result<SetInput, String> {
             let arg = &args[0];
             if arg.contains('=') {
                 let (k, v) = arg.split_once('=').unwrap();
+                if k.is_empty() {
+                    return Err(format!("empty field name in '{}'", arg));
+                }
                 Ok(SetInput::BatchFields(vec![(k.to_string(), v.to_string())]))
             } else {
                 Ok(SetInput::Scalar(arg.clone()))
@@ -251,7 +252,12 @@ fn parse_positional_args(args: &[String]) -> Result<SetInput, String> {
                 let mut pairs = Vec::with_capacity(2);
                 for arg in args {
                     match arg.split_once('=') {
-                        Some((k, v)) => pairs.push((k.to_string(), v.to_string())),
+                        Some((k, v)) => {
+                            if k.is_empty() {
+                                return Err(format!("empty field name in '{}'", arg));
+                            }
+                            pairs.push((k.to_string(), v.to_string()));
+                        }
                         None => {
                             return Err(format!("expected key=value pair, got '{}'", arg));
                         }
@@ -265,7 +271,12 @@ fn parse_positional_args(args: &[String]) -> Result<SetInput, String> {
             let mut pairs = Vec::with_capacity(args.len());
             for arg in args {
                 match arg.split_once('=') {
-                    Some((k, v)) => pairs.push((k.to_string(), v.to_string())),
+                    Some((k, v)) => {
+                        if k.is_empty() {
+                            return Err(format!("empty field name in '{}'", arg));
+                        }
+                        pairs.push((k.to_string(), v.to_string()));
+                    }
                     None => {
                         return Err(format!("expected key=value pair, got '{}'", arg));
                     }
@@ -312,7 +323,7 @@ fn parse_json_input(raw: &str) -> Result<SetInput, String> {
             if pairs.is_empty() {
                 return Err("JSON object is empty".to_string());
             }
-            Ok(SetInput::JsonObject(pairs))
+            Ok(SetInput::BatchFields(pairs))
         }
         serde_json::Value::Array(arr) => {
             if arr.is_empty() {
@@ -580,19 +591,37 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
                     Ok(()) => {
                         did_something = true;
                     }
-                    Err(e) => return handle_kv_err(e),
-                },
-                SetInput::JsonObject(pairs) => match store.set_state_batch(&key, &pairs) {
-                    Ok(()) => {
-                        did_something = true;
+                    Err(e) => {
+                        if memory.is_none() {
+                            return handle_kv_err(e);
+                        }
+                        match &e {
+                            KvError::TypeMismatch { .. } => {
+                                eprintln!(
+                                    "Warning: value not set (type does not support batch set); memory pointer updated"
+                                );
+                            }
+                            _ => return handle_kv_err(e),
+                        }
                     }
-                    Err(e) => return handle_kv_err(e),
                 },
                 SetInput::JsonArray(values) => match store.set_tensor_batch(&key, &values) {
                     Ok(()) => {
                         did_something = true;
                     }
-                    Err(e) => return handle_kv_err(e),
+                    Err(e) => {
+                        if memory.is_none() {
+                            return handle_kv_err(e);
+                        }
+                        match &e {
+                            KvError::TypeMismatch { .. } => {
+                                eprintln!(
+                                    "Warning: value not set (type does not support tensor set); memory pointer updated"
+                                );
+                            }
+                            _ => return handle_kv_err(e),
+                        }
+                    }
                 },
             }
 
@@ -1378,12 +1407,12 @@ mod tests {
     fn json_object_parsing() {
         let input = parse_json_input(r#"{"goal":"finish docs","phase":"writing"}"#).unwrap();
         match input {
-            SetInput::JsonObject(pairs) => {
+            SetInput::BatchFields(pairs) => {
                 assert_eq!(pairs.len(), 2);
                 assert!(pairs.contains(&("goal".to_string(), "finish docs".to_string())));
                 assert!(pairs.contains(&("phase".to_string(), "writing".to_string())));
             }
-            _ => panic!("expected JsonObject"),
+            _ => panic!("expected BatchFields"),
         }
     }
 
@@ -1431,10 +1460,85 @@ mod tests {
     fn json_object_with_numeric_value() {
         let input = parse_json_input(r#"{"temperature":0.75}"#).unwrap();
         match input {
-            SetInput::JsonObject(pairs) => {
+            SetInput::BatchFields(pairs) => {
                 assert_eq!(pairs, vec![("temperature".to_string(), "0.75".to_string())]);
             }
-            _ => panic!("expected JsonObject"),
+            _ => panic!("expected BatchFields"),
         }
+    }
+
+    // -- S3: --json + positional mutual exclusion --
+
+    #[test]
+    fn json_and_positional_args_mutual_exclusion() {
+        // Simulate the handler guard: --json provided AND positional args non-empty
+        let json: Option<String> = Some(r#"{"goal":"test"}"#.to_string());
+        let args: Vec<String> = vec!["goal=test".to_string()];
+        assert!(
+            json.is_some() && !args.is_empty(),
+            "guard should reject --json combined with positional args"
+        );
+    }
+
+    // -- S4: JSON coercion behavior --
+
+    #[test]
+    fn json_object_with_boolean_value() {
+        let input = parse_json_input(r#"{"flag":true}"#).unwrap();
+        match input {
+            SetInput::BatchFields(pairs) => {
+                assert_eq!(pairs, vec![("flag".to_string(), "true".to_string())]);
+            }
+            _ => panic!("expected BatchFields"),
+        }
+    }
+
+    #[test]
+    fn json_object_with_null_value() {
+        let input = parse_json_input(r#"{"val":null}"#).unwrap();
+        match input {
+            SetInput::BatchFields(pairs) => {
+                assert_eq!(pairs, vec![("val".to_string(), "null".to_string())]);
+            }
+            _ => panic!("expected BatchFields"),
+        }
+    }
+
+    #[test]
+    fn json_object_with_integer_value() {
+        let input = parse_json_input(r#"{"count":42}"#).unwrap();
+        match input {
+            SetInput::BatchFields(pairs) => {
+                assert_eq!(pairs, vec![("count".to_string(), "42".to_string())]);
+            }
+            _ => panic!("expected BatchFields"),
+        }
+    }
+
+    // -- W2: empty field name rejection --
+
+    #[test]
+    fn positional_empty_field_name_rejected() {
+        let result = parse_positional_args(&["=hello".to_string()]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty field name"));
+    }
+
+    #[test]
+    fn positional_empty_field_name_in_batch_rejected() {
+        let result = parse_positional_args(&["goal=finish".to_string(), "=oops".to_string()]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty field name"));
+    }
+
+    #[test]
+    fn positional_empty_field_name_in_three_plus_rejected() {
+        let result = parse_positional_args(&[
+            "goal=finish".to_string(),
+            "phase=writing".to_string(),
+            "=bad".to_string(),
+        ]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty field name"));
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -2982,7 +2982,7 @@ max_entries = 5
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("unknown field 'bogus'"), "got: {}", msg);
         // Verify nothing was written (entire batch rejected)
-        assert!(store.data.entries.get("tensor").is_none());
+        assert!(!store.data.entries.contains_key("tensor"));
     }
 
     #[test]

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1122,7 +1122,8 @@ impl KvStore {
         Ok(())
     }
 
-    /// Set multiple fields on a state-type entry in a single atomic operation.
+    /// Set multiple fields on a state-type entry in a single validate-all-then-write-all operation.
+    /// Persistence is atomic (tmp + fsync + rename).
     ///
     /// - Validates the key is `ValueType::State`
     /// - Validates ALL field names against the schema before any writes
@@ -1218,14 +1219,6 @@ impl KvStore {
     /// Delegates to `set_state_batch` after building the field pairs.
     pub fn set_tensor_batch(&mut self, key: &str, values: &[String]) -> Result<(), KvError> {
         let def = self.key_def(key)?.clone();
-
-        if def.value_type != ValueType::State {
-            return Err(KvError::TypeMismatch {
-                key: key.to_string(),
-                expected: "state".to_string(),
-                got: def.value_type.to_string(),
-            });
-        }
 
         let schema_fields = match def.fields {
             Some(ref f) => f,
@@ -3110,7 +3103,8 @@ type = "state"
         let result = store.set_tensor_batch("warmth", &["0.5".to_string()]);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("Type mismatch"), "got: {}", msg);
+        // Counter type has no fields, so tensor set fails at the fields-exist check
+        assert!(msg.contains("no fields defined"), "got: {}", msg);
     }
 
     // -- History operations --

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1122,6 +1122,144 @@ impl KvStore {
         Ok(())
     }
 
+    /// Set multiple fields on a state-type entry in a single atomic operation.
+    ///
+    /// - Validates the key is `ValueType::State`
+    /// - Validates ALL field names against the schema before any writes
+    /// - Rejects empty `fields` vec
+    /// - Rejects duplicate field names in the batch
+    /// - Reports all validation errors, not just the first
+    /// - Preserves existing fields not mentioned in the batch (partial update)
+    pub fn set_state_batch(
+        &mut self,
+        key: &str,
+        fields: &[(String, String)],
+    ) -> Result<(), KvError> {
+        if fields.is_empty() {
+            return Err(KvError::DataValidation {
+                message: "batch set requires at least one field".to_string(),
+            });
+        }
+
+        let def = self.key_def(key)?.clone();
+
+        if def.value_type != ValueType::State {
+            return Err(KvError::TypeMismatch {
+                key: key.to_string(),
+                expected: "state".to_string(),
+                got: def.value_type.to_string(),
+            });
+        }
+
+        // Check for duplicate field names in the batch
+        let mut seen = HashSet::new();
+        let dupes: Vec<&str> = fields
+            .iter()
+            .filter(|(name, _)| !seen.insert(name.as_str()))
+            .map(|(name, _)| name.as_str())
+            .collect();
+        if !dupes.is_empty() {
+            return Err(KvError::DataValidation {
+                message: format!("duplicate field names in batch: {}", dupes.join(", ")),
+            });
+        }
+
+        // Validate all field names against schema (batch all errors)
+        if let Some(ref schema_fields) = def.fields {
+            let errors: Vec<String> = fields
+                .iter()
+                .filter(|(name, _)| !schema_fields.contains(name))
+                .map(|(name, _)| {
+                    format!(
+                        "unknown field '{}' (valid: {})",
+                        name,
+                        schema_fields.join(", ")
+                    )
+                })
+                .collect();
+            if !errors.is_empty() {
+                return Err(KvError::DataValidation {
+                    message: errors.join("; "),
+                });
+            }
+        }
+
+        // All validation passed -- apply the batch
+        let entry = self
+            .data
+            .entries
+            .entry(key.to_string())
+            .or_insert_with(|| Self::default_value(&def));
+
+        match entry {
+            DataValue::State {
+                fields: state_fields,
+                ..
+            } => {
+                for (name, value) in fields {
+                    state_fields.insert(name.clone(), value.clone());
+                }
+            }
+            _ => {
+                return Err(KvError::Other(anyhow::anyhow!(
+                    "Data corruption: key '{}' has wrong runtime type",
+                    key
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Set a state-type entry's fields from positional values (tensor-style).
+    ///
+    /// Maps each value to the corresponding schema field by position.
+    /// The number of values must match the number of schema fields exactly.
+    /// Delegates to `set_state_batch` after building the field pairs.
+    pub fn set_tensor_batch(&mut self, key: &str, values: &[String]) -> Result<(), KvError> {
+        let def = self.key_def(key)?.clone();
+
+        if def.value_type != ValueType::State {
+            return Err(KvError::TypeMismatch {
+                key: key.to_string(),
+                expected: "state".to_string(),
+                got: def.value_type.to_string(),
+            });
+        }
+
+        let schema_fields = match def.fields {
+            Some(ref f) => f,
+            None => {
+                return Err(KvError::DataValidation {
+                    message: format!(
+                        "key '{}' is state type but has no fields defined; \
+                         positional set requires a fields schema",
+                        key
+                    ),
+                });
+            }
+        };
+
+        if values.len() != schema_fields.len() {
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "expected {} values ({}), got {}",
+                    schema_fields.len(),
+                    schema_fields.join(", "),
+                    values.len()
+                ),
+            });
+        }
+
+        let pairs: Vec<(String, String)> = schema_fields
+            .iter()
+            .zip(values.iter())
+            .map(|(f, v)| (f.clone(), v.clone()))
+            .collect();
+
+        self.set_state_batch(key, &pairs)
+    }
+
     /// Increment a counter. Clamps to min/max, never errors on bounds.
     pub fn inc(&mut self, key: &str, by: i64) -> Result<i64, KvError> {
         let def = self.assert_type(key, ValueType::Counter)?.clone();
@@ -2785,6 +2923,194 @@ max_entries = 5
         let result = store.set("tensor", "0.5", None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("field name"));
+    }
+
+    // -- Batch state operations --
+
+    #[test]
+    fn batch_set_multiple_fields() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .set_state_batch(
+                "tensor",
+                &[
+                    ("temperature".to_string(), "0.8".to_string()),
+                    ("entropy".to_string(), "0.3".to_string()),
+                    ("agency".to_string(), "0.9".to_string()),
+                ],
+            )
+            .unwrap();
+        match store.get("tensor").unwrap() {
+            DataValue::State { fields, .. } => {
+                assert_eq!(fields["temperature"], "0.8");
+                assert_eq!(fields["entropy"], "0.3");
+                assert_eq!(fields["agency"], "0.9");
+            }
+            _ => panic!("Expected state"),
+        }
+    }
+
+    #[test]
+    fn batch_preserves_existing_fields() {
+        let (mut store, _dir) = setup_store(test_schema());
+        // Set one field first
+        store.set("tensor", "0.5", Some("temperature")).unwrap();
+        // Batch update only entropy
+        store
+            .set_state_batch("tensor", &[("entropy".to_string(), "0.7".to_string())])
+            .unwrap();
+        match store.get("tensor").unwrap() {
+            DataValue::State { fields, .. } => {
+                assert_eq!(fields["temperature"], "0.5"); // preserved
+                assert_eq!(fields["entropy"], "0.7"); // updated
+            }
+            _ => panic!("Expected state"),
+        }
+    }
+
+    #[test]
+    fn batch_rejects_unknown_field() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_state_batch(
+            "tensor",
+            &[
+                ("temperature".to_string(), "0.5".to_string()),
+                ("bogus".to_string(), "0.1".to_string()),
+            ],
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("unknown field 'bogus'"), "got: {}", msg);
+        // Verify nothing was written (entire batch rejected)
+        assert!(store.data.entries.get("tensor").is_none());
+    }
+
+    #[test]
+    fn batch_rejects_empty_fields() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_state_batch("tensor", &[]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("at least one field"), "got: {}", msg);
+    }
+
+    #[test]
+    fn batch_rejects_duplicate_field_names() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_state_batch(
+            "tensor",
+            &[
+                ("temperature".to_string(), "0.5".to_string()),
+                ("temperature".to_string(), "0.9".to_string()),
+            ],
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("duplicate"), "got: {}", msg);
+    }
+
+    #[test]
+    fn batch_on_wrong_type_returns_type_mismatch() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result =
+            store.set_state_batch("warmth", &[("temperature".to_string(), "0.5".to_string())]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Type mismatch"), "got: {}", msg);
+    }
+
+    #[test]
+    fn batch_overwrites_existing_field_value() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.set("tensor", "0.5", Some("temperature")).unwrap();
+        store
+            .set_state_batch("tensor", &[("temperature".to_string(), "0.9".to_string())])
+            .unwrap();
+        match store.get("tensor").unwrap() {
+            DataValue::State { fields, .. } => {
+                assert_eq!(fields["temperature"], "0.9");
+            }
+            _ => panic!("Expected state"),
+        }
+    }
+
+    #[test]
+    fn batch_reports_all_unknown_fields() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_state_batch(
+            "tensor",
+            &[
+                ("gol".to_string(), "value".to_string()),
+                ("statis".to_string(), "value".to_string()),
+            ],
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("gol"), "got: {}", msg);
+        assert!(msg.contains("statis"), "got: {}", msg);
+    }
+
+    // -- Tensor positional set --
+
+    #[test]
+    fn tensor_positional_set() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .set_tensor_batch(
+                "tensor",
+                &["0.4".to_string(), "0.6".to_string(), "0.5".to_string()],
+            )
+            .unwrap();
+        match store.get("tensor").unwrap() {
+            DataValue::State { fields, .. } => {
+                assert_eq!(fields["temperature"], "0.4");
+                assert_eq!(fields["entropy"], "0.6");
+                assert_eq!(fields["agency"], "0.5");
+            }
+            _ => panic!("Expected state"),
+        }
+    }
+
+    #[test]
+    fn tensor_wrong_count() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_tensor_batch(
+            "tensor",
+            &[
+                "0.1".to_string(),
+                "0.2".to_string(),
+                "0.3".to_string(),
+                "0.4".to_string(),
+                "0.5".to_string(),
+            ],
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("expected 3 values"), "got: {}", msg);
+        assert!(msg.contains("got 5"), "got: {}", msg);
+    }
+
+    #[test]
+    fn tensor_on_key_without_fields() {
+        // Create a state key without fields defined
+        let schema = r#"
+[keys.bare_state]
+type = "state"
+"#;
+        let (mut store, _dir) = setup_store(schema);
+        let result = store.set_tensor_batch("bare_state", &["0.1".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("no fields defined"), "got: {}", msg);
+    }
+
+    #[test]
+    fn tensor_on_wrong_type() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let result = store.set_tensor_batch("warmth", &["0.5".to_string()]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Type mismatch"), "got: {}", msg);
     }
 
     // -- History operations --


### PR DESCRIPTION
## Summary

Two new input modes for `mx kv set` on state-type entries:

- **Inline `key=value` pairs** — trailing varargs after the entry name (e.g. `mx kv set mystate foo=bar baz=42`)
- **`--json` flag** — accepts a JSON object for state entries or a JSON array for tensor entries

Both modes are atomic (all-or-nothing), support partial updates (unmentioned fields are preserved), and are schema-validated against the entry's declared schema.

## What changed

- **Engine** (`kv.rs`): 2 new methods — `set_state_fields` for batch field writes and `set_json` for JSON-based input
- **CLI** (`cli.rs`): trailing varargs support + `--json` flag on `kv set`
- **Handler** (`kv_handler.rs`): `SetInput` enum with parsing logic to disambiguate legacy single-field, inline multi-field, and JSON input modes

## Backward compatibility

Legacy `mx kv set <key> <field> <value>` syntax continues to work unchanged.

## Test coverage

25 new tests (12 engine, 13 handler) — 968 total passing.

Closes #324