### PR TITLE
docs(kv): add documentation for update and migrate subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ mx kv random shipped --count 5
 mx kv random ideas --count 1
 mx kv random shipped --count 3 --since 30d
 
+# Update an entry's value or structured data in-place
+mx kv update projects "palmtop DSI fix (v2)" --id kv-A3fB
+mx kv update projects --id 42 --data '{"status":"done"}'
+mx kv update projects --id 42 --data '{"obsolete_field":null}'
+
+# Migrate entries to match current schema data definitions
+mx kv migrate projects --dry-run
+mx kv migrate projects --prune
+
 # Per-entry memory links (bridge KV entries to the knowledge graph)
 mx kv push decisions "adopted memory links" --memory kn-abc123
 mx kv set decisions --id 17 --memory kn-abc123

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ mx kv count shipped --json | jq '.count'
 
 Every entry gets a stable entry ID (e.g. `kv-A3fB`) alongside its numeric index. Push prints both: `kv-A3fB (42)`. Anywhere a numeric index works, an entry ID also works -- `--id kv-A3fB`, mixed comma lists, remove. Ranges remain numeric only. Old data files are back-filled on first load.
 
-Entries can carry structured JSON data via `--data` on push. Query entries by data fields with `--where key=value` (available on `search`, `last`, `random`, `count`). Multiple `--where` flags are ANDed. Supports exact string match, array-contains, and numeric/boolean comparison on top-level fields.
+Entries can carry structured JSON data via `--data` on push or update. Query entries by data fields with `--where key=value` (available on `search`, `last`, `random`, `count`). Multiple `--where` flags are ANDed. Supports exact string match, array-contains, and numeric/boolean comparison on top-level fields.
 
 Individual entries can link to the memory graph via `--memory kn-xxx` on `push` (at creation) or `set --id --memory` (on existing entries). Per-entry memory wins over key-level fallback. Pass `--memory` on read commands (`get`, `last`, `since`, `search`, `random`, `dump`) to resolve linked knowledge entries.
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -587,8 +587,8 @@ Supported types:
   table.header([*Type*], [*Behavior*]),
   [`counter`], [Integer with optional `min`/`max` bounds. Supports `inc`, `dec`, `set`, `get`],
   [`string`], [Simple string value. Supports `set`, `get`],
-  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`. Each entry gets a numeric index and a stable base58 entry ID (`kv-` prefix). Entries can carry optional structured JSON data (`--data` on push, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
-  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`. Each entry gets a numeric index and a stable base58 entry ID. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
+  [`history`], [Timestamped append-only log with optional `max_entries` cap. Supports `push`, `last`, `since`, `search`, `count`, `random`, `update`, `migrate`. Each entry gets a numeric index and a stable base58 entry ID (`kv-` prefix). Entries can carry optional structured JSON data (`--data` on push/update, `--where` on queries). The `last`, `search`, `count`, and `random` commands accept time-range flags (`--day`, `--month`, `--week`, `--since`, `--from`/`--to`) for date filtering.],
+  [`list`], [Ordered list with timestamps. Supports `push`, `pop`, `remove`, `search`, `count`, `random`, `update`, `migrate`. Each entry gets a numeric index and a stable base58 entry ID. Entries can carry optional structured JSON data. The `last`, `search`, `count`, and `random` commands accept the same time-range flags as history.],
   [`state`], [Named fields (like a struct). Supports single-field set (`set <key> <field> <value>`), batch set (`set <key> field=value ...` or `set <key> --json '{...}'`), tensor positional set (`set <key> --json '[...]'`), and `get`. Batch operations validate all fields against the schema before writing.],
 )
 

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -162,6 +162,14 @@ mx kv push projects "palmtop DSI fix" \
 mx kv search projects --where status=active
 mx kv search projects "DSI" --where tags=palmtop
 
+# Update an existing entry's value or data in-place
+mx kv update projects "palmtop DSI fix (v2)" --id kv-A3fB
+mx kv update projects --id 42 --data '{"status":"done"}'
+
+# Migrate entries to match current schema data definitions
+mx kv migrate projects --dry-run
+mx kv migrate projects --prune
+
 # JSON output for scripting and jq piping
 mx kv last projects --count 5 --json | jq '.[].data.status'
 mx kv count shipped --json | jq '.count'

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -261,10 +261,11 @@ stable entry ID (a base58 string prefixed with `kv-`, e.g. `kv-A3fB`). Both
 can be used anywhere an ID is accepted. See #link(<entry-ids>)[Entry IDs] for
 details.
 
-Both types support `push`, `last`, `search`, `count`, `random`, `remove`, and
-entry lookup by ID via `get --id`. Both support structured data on entries
-(`--data` on push) and structured data filtering (`--where` on queries).
-Only lists support `pop`. Only history supports `since` (time-based queries).
+Both types support `push`, `last`, `search`, `count`, `random`, `remove`,
+`update`, and entry lookup by ID via `get --id`. Both support structured data
+on entries (`--data` on push, `--data` on update) and structured data filtering
+(`--where` on queries). Only lists support `pop`. Only history supports `since`
+(time-based queries).
 
 === push <push>
 
@@ -557,6 +558,83 @@ Only lists support `pop`. Only history supports `since` (time-based queries).
     "mx kv remove todos --id 7",
     "mx kv remove todos --id kv-A3fB",
     "mx kv remove decisions \"typo\" --all",
+  ),
+)
+
+=== update
+
+#command(
+  "mx kv update <key> [value] --id <spec>",
+  [Update an existing entry's value and/or structured data in-place.
+  Preserves the entry's ID, position, and timestamp.
+
+  Requires `--id` to target a specific entry by numeric index or entry ID.
+  The value argument is optional -- you can update only `--data`, only the
+  value, or both.
+
+  When `--data` is provided, the JSON object is shallow-merged into the
+  entry's existing structured data. Fields in the patch overwrite existing
+  fields. Null values in the patch _delete_ that field from the merged
+  result (they do not set it to null). If the key has a `[data]` schema
+  section, validation runs on the merged result before the write commits.
+
+  At least one of a value argument or `--data` must be provided -- calling
+  update with neither is rejected.
+
+  On success, prints the updated entry's identifiers:
+
+  ```
+  Updated entry 42 (kv-A3fB)
+  ```
+
+  Works on both history and list types.],
+  flags: (
+    ([`--id <spec>`], [string], [Target entry by numeric index (`42`) or entry ID (`kv-A3fB`). Required.]),
+    ([`--data <json>`], [string], [JSON object to merge into the entry's structured data. Null field values delete that field from the merged result.]),
+  ),
+  examples: (
+    "mx kv update projects \"palmtop DSI fix (v2)\" --id kv-A3fB",
+    "mx kv update projects --id 42 --data '{\"status\":\"done\"}'",
+    "mx kv update projects \"renamed\" --id kv-A3fB --data '{\"status\":\"closed\"}'",
+    "mx kv update projects --id 42 --data '{\"obsolete_field\":null}'",
+  ),
+)
+
+=== migrate
+
+#command(
+  "mx kv migrate <key>",
+  [Migrate existing entries to match current schema data definitions.
+  Operates on all entries in a key.
+
+  Compares each entry's structured data against the `[data]` section in
+  the key's schema. Missing fields that have a default value in the schema
+  are added. Required fields without defaults produce a warning. Type
+  mismatches between existing data and schema declarations are reported as
+  warnings.
+
+  Entries without any structured data get a new data object populated from
+  schema defaults.
+
+  With `--prune`, fields present in entries but not declared in the schema
+  are removed. Without `--prune`, undeclared fields are left untouched.
+
+  With `--dry-run`, reports what would change without modifying any data.
+  The output lists each affected entry with its added and pruned fields.
+
+  If the key has no `[data]` section in the schema, nothing is migrated
+  and a warning is printed.
+
+  Works on both history and list types.],
+  flags: (
+    ([`--prune`], [flag], [Remove fields not declared in the current schema]),
+    ([`--dry-run`], [flag], [Show what would change without modifying data]),
+  ),
+  examples: (
+    "mx kv migrate projects",
+    "mx kv migrate projects --dry-run",
+    "mx kv migrate projects --prune",
+    "mx kv migrate projects --prune --dry-run",
   ),
 )
 

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -262,9 +262,9 @@ can be used anywhere an ID is accepted. See #link(<entry-ids>)[Entry IDs] for
 details.
 
 Both types support `push`, `last`, `search`, `count`, `random`, `remove`,
-`update`, and entry lookup by ID via `get --id`. Both support structured data
-on entries (`--data` on push, `--data` on update) and structured data filtering
-(`--where` on queries). Only lists support `pop`. Only history supports `since`
+`update`, `migrate`, and entry lookup by ID via `get --id`. Both support
+structured data on entries (`--data` on push/update) and structured data
+filtering (`--where` on queries). Only lists support `pop`. Only history supports `since`
 (time-based queries).
 
 === push <push>
@@ -569,6 +569,8 @@ on entries (`--data` on push, `--data` on update) and structured data filtering
   Preserves the entry's ID, position, and timestamp.
 
   Requires `--id` to target a specific entry by numeric index or entry ID.
+  ID matching is prefix-based -- if the prefix is ambiguous (matches
+  multiple entries), an error is returned asking for more characters.
   The value argument is optional -- you can update only `--data`, only the
   value, or both.
 


### PR DESCRIPTION
## Summary

- Add `kv update` and `kv migrate` command documentation to all four doc surfaces
- References: #317 (kv update), #312 (kv migrate)

### Surfaces updated

- **`docs/src/kv.typ`** -- Full `#command` blocks for both subcommands with flags, descriptions, and examples. Added `update` to the operations list in the Lists & History intro section.
- **`docs/src/architecture.typ`** -- Added `update` and `migrate` to the operations listed in the history and list type table rows.
- **`docs/src/getting-started.typ`** -- Added practical examples for both subcommands in the KV section.
- **`README.md`** -- Added examples for both subcommands in the KV Store section.

## Test plan

- [ ] Verify `kv.typ` renders correctly (command blocks, flags tables, examples)
- [ ] Verify architecture type table rows are not broken by the additions
- [ ] Verify getting-started and README examples are syntactically valid
- [ ] Spot-check that documented flags and behavior match the source in `src/cli.rs`, `src/handlers/kv.rs`, and `src/kv.rs`