### PR TITLE
feat(memory): auto-anchor re-evaluation and --no-auto-anchor flag (#199)

### DIFF
--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -69,6 +69,7 @@ similarity, and surfaced through keyword or semantic search.
     ([`--type`],       [`string`], [Fact type for ephemeral knowledge: `decision`, `insight`, `person`, `quote`, `thread_opened`, `commitment`, `thread_closed`. Auto-routes category and sets `resonance_type=ephemeral`.]),
     ([`--session`],    [`string`], [Session to link fact to via EXTRACTED_FROM relationship. Requires `--type`.]),
     ([`--thread-id`],  [`string`], [Thread ID for `thread_closed` operations. Requires `--type`.]),
+    ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
     ([`--json`],       [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -223,6 +224,7 @@ to have embeddings generated via `mx memory embed`.]
     ([`--owner`],         [`string`], [Update owner (only valid when visibility is private).]),
     ([`--session-id`],    [`string`], [Update session ID (for retrofitting entries with wrong or missing session linkage).]),
     ([`--force`],         [`flag`],   [Force dangerous visibility changes (e.g., making blooms public).]),
+    ([`--no-auto-anchor`], [`flag`],  [Skip automatic anchor generation.]),
     ([`--json`],          [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -243,6 +245,7 @@ to have embeddings generated via `mx memory embed`.]
     ([`--replace`],     [`string`], [Replacement text. Also accepts `--new`.]),
     ([`--replace-all`], [`flag`],   [Replace all occurrences (default: error if multiple matches).]),
     ([`--nth`],         [`int`],    [Replace only the Nth occurrence (1-indexed).]),
+    ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
     ([`--json`],        [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -258,6 +261,7 @@ to have embeddings generated via `mx memory embed`.]
   flags: (
     ([`--content`], [`string`], [Content to append (omit to read from stdin).]),
     ([`-f, --file`], [`path`],  [Read content from file. Also accepts `--content-file`.]),
+    ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
     ([`--json`],    [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -273,6 +277,7 @@ to have embeddings generated via `mx memory embed`.]
   flags: (
     ([`--content`], [`string`], [Content to prepend (omit to read from stdin).]),
     ([`-f, --file`], [`path`],  [Read content from file. Also accepts `--content-file`.]),
+    ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
     ([`--json`],    [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -286,6 +291,7 @@ to have embeddings generated via `mx memory embed`.]
   before restoring.],
   flags: (
     ([`--list`], [`flag`], [List available backups instead of restoring.]),
+    ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
     ([`--json`], [`flag`], [Output as JSON.]),
   ),
   examples: (
@@ -408,7 +414,12 @@ Anchors are connections between entries discovered via embedding similarity.
 #command(
   "mx memory auto-anchor",
   [Automatically add anchors between entries based on embedding similarity.
-  Processes a single entry or all entries that have embeddings.],
+  Processes a single entry or all entries that have embeddings.
+
+  Also re-evaluates existing anchors: any anchor whose cosine similarity has
+  fallen below the threshold (default 0.75) or risen above the near-duplicate
+  ceiling (0.95) is pruned. This keeps the anchor graph self-cleaning --
+  anchors that made sense once but no longer do are removed automatically.],
   flags: (
     ([`--threshold`],   [`float`], [Minimum cosine similarity (0.0--1.0). Default: `0.75`.]),
     ([`--max-anchors`], [`int`],   [Maximum anchors to add per entry. Default: `5`.]),
@@ -425,6 +436,13 @@ Anchors are connections between entries discovered via embedding similarity.
 #tip[A typical workflow: run `mx memory embed --all` to generate embeddings,
 then `mx memory auto-anchor --dry-run --verbose` to preview anchor
 candidates, then `mx memory auto-anchor` to write them.]
+
+#note[Anchors are also maintained automatically on every write operation
+(`add`, `update`, `edit`, `append`, `prepend`, `restore`). After each write,
+mx re-evaluates anchors and prunes stale ones using the same similarity
+thresholds. Pass `--no-auto-anchor` on any of these commands to skip this
+step -- useful for bulk operations or cleanup scripts where the overhead is
+unwanted.]
 
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -425,11 +425,13 @@ Anchors are connections between entries discovered via embedding similarity.
     ([`--max-anchors`], [`int`],   [Maximum anchors to add per entry. Default: `5`.]),
     ([`--dry-run`],     [`flag`],  [Preview changes without writing.]),
     ([`--verbose`],     [`flag`],  [Show similarity scores in output.]),
+    ([`--fill`],        [`flag`],  [Only process entries with zero existing anchors. Fills gaps in the graph without touching already-anchored entries.]),
   ),
   examples: (
     "mx memory auto-anchor",
     "mx memory auto-anchor kn-abc123 --threshold 0.8 --max-anchors 3",
     "mx memory auto-anchor --dry-run --verbose",
+    "mx memory auto-anchor --fill",
   ),
 )
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -605,6 +605,10 @@ pub enum MemoryCommands {
         /// Thread ID for thread_closed operations (requires --type=thread_closed)
         #[arg(long, requires = "type")]
         thread_id: Option<String>,
+
+        /// Skip automatic anchor generation
+        #[arg(long)]
+        no_auto_anchor: bool,
     },
 
     /// Update an existing entry in the database
@@ -740,6 +744,10 @@ pub enum MemoryCommands {
         #[arg(long)]
         force: bool,
 
+        /// Skip automatic anchor generation
+        #[arg(long)]
+        no_auto_anchor: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -766,6 +774,10 @@ pub enum MemoryCommands {
         #[arg(long, conflicts_with = "replace_all")]
         nth: Option<usize>,
 
+        /// Skip automatic anchor generation
+        #[arg(long)]
+        no_auto_anchor: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -788,6 +800,10 @@ pub enum MemoryCommands {
             conflicts_with = "content"
         )]
         file: Option<String>,
+
+        /// Skip automatic anchor generation
+        #[arg(long)]
+        no_auto_anchor: bool,
 
         /// Output as JSON
         #[arg(long)]
@@ -812,6 +828,10 @@ pub enum MemoryCommands {
         )]
         file: Option<String>,
 
+        /// Skip automatic anchor generation
+        #[arg(long)]
+        no_auto_anchor: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -825,6 +845,10 @@ pub enum MemoryCommands {
         /// List available backups instead of restoring
         #[arg(long)]
         list: bool,
+
+        /// Skip automatic anchor generation
+        #[arg(long)]
+        no_auto_anchor: bool,
 
         /// Output as JSON
         #[arg(long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -871,6 +871,9 @@ pub enum MemoryCommands {
     /// Also re-evaluates existing anchors: any anchor whose similarity has
     /// fallen below the threshold or risen above the near-duplicate ceiling
     /// (0.95) is pruned. This keeps the anchor graph self-cleaning.
+    ///
+    /// Use --fill to only process entries that have zero existing anchors,
+    /// filling the gaps without touching already-anchored entries.
     AutoAnchor {
         /// Entry ID to process (omit to process all entries with embeddings)
         id: Option<String>,
@@ -890,6 +893,10 @@ pub enum MemoryCommands {
         /// Show similarity scores in output
         #[arg(long)]
         verbose: bool,
+
+        /// Only process entries with no existing anchors
+        #[arg(long)]
+        fill: bool,
     },
 
     /// Manage agents registry

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -866,7 +866,11 @@ pub enum MemoryCommands {
         all: bool,
     },
 
-    /// Automatically add anchors based on embedding similarity
+    /// Automatically add anchors based on embedding similarity.
+    ///
+    /// Also re-evaluates existing anchors: any anchor whose similarity has
+    /// fallen below the threshold or risen above the near-duplicate ceiling
+    /// (0.95) is pruned. This keeps the anchor graph self-cleaning.
     AutoAnchor {
         /// Entry ID to process (omit to process all entries with embeddings)
         id: Option<String>,

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1772,6 +1772,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                             entry.title,
                             entry.anchors.len()
                         );
+                    } else {
+                        eprintln!("Entry {} already has anchors, skipping (--fill)", entry.id);
                     }
                     continue;
                 }
@@ -1905,12 +1907,12 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     "\n✓ Added {} total anchors, pruned {} stale across {} entries",
                     total_added, total_pruned, entries_count
                 );
-                if fill && total_skipped > 0 {
-                    println!(
-                        "  Skipped {} entries that already had anchors (--fill)",
-                        total_skipped
-                    );
-                }
+            }
+            if fill && total_skipped > 0 {
+                println!(
+                    "  Skipped {} entries that already had anchors (--fill)",
+                    total_skipped
+                );
             }
         }
         MemoryCommands::Agents { command } => handle_agents(command, &config)?,

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1704,6 +1704,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             max_anchors,
             dry_run,
             verbose,
+            fill,
         } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
 
@@ -1743,6 +1744,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 return Ok(());
             }
 
+            if fill {
+                println!("Fill mode: only processing entries with no existing anchors");
+            }
             println!("Processing {} entries...", entries.len());
 
             // Get ALL entries with embeddings for similarity comparison
@@ -1754,9 +1758,24 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             let mut total_added = 0;
             let mut total_pruned = 0;
+            let mut total_skipped = 0;
             let entries_count = entries.len();
 
             for entry in entries {
+                // In fill mode, skip entries that already have anchors
+                if fill && !entry.anchors.is_empty() {
+                    total_skipped += 1;
+                    if verbose {
+                        println!(
+                            "  {} \"{}\" - Skipped (has {} anchors)",
+                            entry.id,
+                            entry.title,
+                            entry.anchors.len()
+                        );
+                    }
+                    continue;
+                }
+
                 let entry_embedding = entry.embedding.as_ref().unwrap();
 
                 // Calculate similarities
@@ -1886,6 +1905,12 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     "\n✓ Added {} total anchors, pruned {} stale across {} entries",
                     total_added, total_pruned, entries_count
                 );
+                if fill && total_skipped > 0 {
+                    println!(
+                        "  Skipped {} entries that already had anchors (--fill)",
+                        total_skipped
+                    );
+                }
             }
         }
         MemoryCommands::Agents { command } => handle_agents(command, &config)?,

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1753,6 +1753,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 .collect();
 
             let mut total_added = 0;
+            let mut total_pruned = 0;
             let entries_count = entries.len();
 
             for entry in entries {
@@ -1772,7 +1773,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     if entry.anchors.contains(&candidate.id) {
                         let candidate_embedding = candidate.embedding.as_ref().unwrap();
                         let similarity = cosine_similarity(entry_embedding, candidate_embedding);
-                        if similarity < threshold || similarity > 0.95 {
+                        if similarity < threshold || similarity > NEAR_DUPLICATE_CEILING {
                             stale_anchors.push(candidate.id.clone());
                         }
                         continue; // don't consider existing anchors as new candidates
@@ -1797,7 +1798,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     let similarity = cosine_similarity(entry_embedding, candidate_embedding);
 
                     // Filter by threshold, skip near-duplicates
-                    if similarity >= threshold && similarity <= 0.95 {
+                    if similarity >= threshold && similarity <= NEAR_DUPLICATE_CEILING {
                         similarities.push((
                             candidate.id.clone(),
                             candidate.title.clone(),
@@ -1832,9 +1833,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 for (match_id, match_title, score) in &top_matches {
                     if verbose {
-                        println!("  + {} \"{}\" ({:.2})", match_id, match_title, score);
+                        println!("  → {} \"{}\" ({:.2})", match_id, match_title, score);
                     } else {
-                        println!("  + {} \"{}\"", match_id, match_title);
+                        println!("  → {} \"{}\"", match_id, match_title);
                     }
                 }
 
@@ -1874,6 +1875,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         stale_anchors.len()
                     );
                     total_added += top_matches.len();
+                    total_pruned += stale_anchors.len();
                 }
             }
 
@@ -1881,8 +1883,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 println!("\n[DRY RUN] Complete. No changes written.");
             } else {
                 println!(
-                    "\n✓ Added {} total anchors across {} entries",
-                    total_added, entries_count
+                    "\n✓ Added {} total anchors, pruned {} stale across {} entries",
+                    total_added, total_pruned, entries_count
                 );
             }
         }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -369,6 +369,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             r#type,
             session,
             thread_id,
+            no_auto_anchor,
         } => {
             use anyhow::Context;
             use std::fs;
@@ -728,7 +729,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            auto_anchor(&id, db.as_ref(), None)?;
+            if !no_auto_anchor {
+                auto_anchor(&id, db.as_ref(), None)?;
+            } else {
+                eprintln!("  (auto-anchor skipped)");
+            }
 
             if json {
                 println!(
@@ -811,6 +816,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             owner,
             session_id,
             force,
+            no_auto_anchor,
             json,
         } => {
             use anyhow::Context;
@@ -1245,7 +1251,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             } else {
                 Some(explicitly_removed_anchors.as_slice())
             };
-            auto_anchor(&id, db.as_ref(), removed)?;
+            if !no_auto_anchor {
+                auto_anchor(&id, db.as_ref(), removed)?;
+            } else {
+                eprintln!("  (auto-anchor skipped)");
+            }
 
             if json {
                 println!(
@@ -1273,6 +1283,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             replace,
             replace_all,
             nth,
+            no_auto_anchor,
             json,
         } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
@@ -1300,7 +1311,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            auto_anchor(&id, db.as_ref(), None)?;
+            if !no_auto_anchor {
+                auto_anchor(&id, db.as_ref(), None)?;
+            } else {
+                eprintln!("  (auto-anchor skipped)");
+            }
 
             if json {
                 println!(
@@ -1324,6 +1339,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             id,
             content,
             file,
+            no_auto_anchor,
             json,
         } => {
             use std::io::{self, Read};
@@ -1371,7 +1387,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            auto_anchor(&id, db.as_ref(), None)?;
+            if !no_auto_anchor {
+                auto_anchor(&id, db.as_ref(), None)?;
+            } else {
+                eprintln!("  (auto-anchor skipped)");
+            }
 
             if json {
                 println!(
@@ -1391,6 +1411,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             id,
             content,
             file,
+            no_auto_anchor,
             json,
         } => {
             use std::io::{self, Read};
@@ -1438,7 +1459,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            auto_anchor(&id, db.as_ref(), None)?;
+            if !no_auto_anchor {
+                auto_anchor(&id, db.as_ref(), None)?;
+            } else {
+                eprintln!("  (auto-anchor skipped)");
+            }
 
             if json {
                 println!(
@@ -1454,7 +1479,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             }
         }
 
-        MemoryCommands::Restore { id, list, json } => {
+        MemoryCommands::Restore { id, list, no_auto_anchor, json } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
             let id = normalize_id(&id);
 
@@ -1538,7 +1563,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 // #3: update embeddings and anchors like all other mutation paths
                 auto_embed(&id, db.as_ref())?;
-                auto_anchor(&id, db.as_ref(), None)?;
+                if !no_auto_anchor {
+                    auto_anchor(&id, db.as_ref(), None)?;
+                } else {
+                    eprintln!("  (auto-anchor skipped)");
+                }
 
                 if json {
                     println!(
@@ -1726,6 +1755,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 // Calculate similarities
                 let mut similarities: Vec<(String, String, f32)> = Vec::new();
+                let mut stale_anchors: Vec<String> = Vec::new();
 
                 for candidate in &candidates {
                     // Skip self
@@ -1733,9 +1763,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         continue;
                     }
 
-                    // Skip if already an anchor
+                    // Re-evaluate existing anchors for staleness
                     if entry.anchors.contains(&candidate.id) {
-                        continue;
+                        let candidate_embedding = candidate.embedding.as_ref().unwrap();
+                        let similarity = cosine_similarity(entry_embedding, candidate_embedding);
+                        if similarity < threshold || similarity > 0.95 {
+                            stale_anchors.push(candidate.id.clone());
+                        }
+                        continue; // don't consider existing anchors as new candidates
                     }
 
                     // Privacy check
@@ -1771,7 +1806,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     .sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
                 let top_matches: Vec<_> = similarities.into_iter().take(max_anchors).collect();
 
-                if top_matches.is_empty() {
+                if top_matches.is_empty() && stale_anchors.is_empty() {
                     if verbose {
                         println!(
                             "  {} \"{}\" - No similar entries found",
@@ -1783,27 +1818,37 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 println!("Processing {} \"{}\"...", entry.id, entry.title);
 
+                if !stale_anchors.is_empty() {
+                    println!("  Pruning {} stale anchor(s)", stale_anchors.len());
+                    for stale_id in &stale_anchors {
+                        println!("  x {}", stale_id);
+                    }
+                }
+
                 for (match_id, match_title, score) in &top_matches {
                     if verbose {
-                        println!("  → {} \"{}\" ({:.2})", match_id, match_title, score);
+                        println!("  + {} \"{}\" ({:.2})", match_id, match_title, score);
                     } else {
-                        println!("  → {} \"{}\"", match_id, match_title);
+                        println!("  + {} \"{}\"", match_id, match_title);
                     }
                 }
 
                 if dry_run {
                     println!(
-                        "[DRY RUN] Would add {} anchors to {}",
+                        "[DRY RUN] Would add {} anchors and prune {} stale anchors on {}",
                         top_matches.len(),
+                        stale_anchors.len(),
                         entry.id
                     );
                 } else {
-                    // Update the entry with new anchors
+                    // Update the entry with new anchors, filtering out stale ones
                     let new_anchor_ids: Vec<String> =
                         top_matches.iter().map(|(id, _, _)| id.clone()).collect();
 
-                    // Merge with existing anchors
-                    let mut updated_anchors = entry.anchors.clone();
+                    let mut updated_anchors: Vec<String> = entry.anchors.clone()
+                        .into_iter()
+                        .filter(|a| !stale_anchors.contains(a))
+                        .collect();
                     updated_anchors.extend(new_anchor_ids);
                     updated_anchors.sort();
                     updated_anchors.dedup();
@@ -1816,7 +1861,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     // Save to database
                     db.upsert_knowledge(&updated_entry)?;
 
-                    println!("Added {} anchors", top_matches.len());
+                    println!("Added {} anchors, pruned {} stale", top_matches.len(), stale_anchors.len());
                     total_added += top_matches.len();
                 }
             }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1479,7 +1479,12 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             }
         }
 
-        MemoryCommands::Restore { id, list, no_auto_anchor, json } => {
+        MemoryCommands::Restore {
+            id,
+            list,
+            no_auto_anchor,
+            json,
+        } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
             let id = normalize_id(&id);
 
@@ -1845,7 +1850,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     let new_anchor_ids: Vec<String> =
                         top_matches.iter().map(|(id, _, _)| id.clone()).collect();
 
-                    let mut updated_anchors: Vec<String> = entry.anchors.clone()
+                    let mut updated_anchors: Vec<String> = entry
+                        .anchors
+                        .clone()
                         .into_iter()
                         .filter(|a| !stale_anchors.contains(a))
                         .collect();
@@ -1861,7 +1868,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     // Save to database
                     db.upsert_knowledge(&updated_entry)?;
 
-                    println!("Added {} anchors, pruned {} stale", top_matches.len(), stale_anchors.len());
+                    println!(
+                        "Added {} anchors, pruned {} stale",
+                        top_matches.len(),
+                        stale_anchors.len()
+                    );
                     total_added += top_matches.len();
                 }
             }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -330,7 +330,9 @@ pub(crate) fn auto_anchor(
         .collect();
 
     // Update the entry with new anchors, filtering out stale ones
-    let mut updated_anchors: Vec<String> = entry.anchors.clone()
+    let mut updated_anchors: Vec<String> = entry
+        .anchors
+        .clone()
         .into_iter()
         .filter(|a| !stale_anchors.contains(a))
         .collect();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -168,6 +168,14 @@ pub(crate) fn resolve_agent_context(mine: bool, include_private: bool) -> store:
     }
 }
 
+/// Similarity threshold above which two entries are considered near-duplicates
+/// and should NOT be anchored together. Used in both the batch `AutoAnchor`
+/// handler and the per-entry `auto_anchor` helper.
+pub(crate) const NEAR_DUPLICATE_CEILING: f32 = 0.95;
+
+/// Default minimum similarity for two entries to be considered anchor-worthy.
+pub(crate) const DEFAULT_ANCHOR_THRESHOLD: f32 = 0.75;
+
 /// Calculate cosine similarity between two vectors
 ///
 /// Returns a value between -1.0 and 1.0 (typically 0.0 to 1.0 for normalized embeddings)
@@ -262,7 +270,7 @@ pub(crate) fn auto_anchor(
         .collect();
 
     // Calculate similarities
-    let threshold = 0.75;
+    let threshold = DEFAULT_ANCHOR_THRESHOLD;
     let max_anchors = 5;
     let mut similarities: Vec<(String, f32)> = Vec::new();
     let mut stale_anchors: Vec<String> = Vec::new();
@@ -277,7 +285,7 @@ pub(crate) fn auto_anchor(
         if entry.anchors.contains(&candidate.id) {
             let candidate_embedding = candidate.embedding.as_ref().unwrap();
             let similarity = cosine_similarity(entry_embedding, candidate_embedding);
-            if similarity < threshold || similarity > 0.95 {
+            if similarity < threshold || similarity > NEAR_DUPLICATE_CEILING {
                 stale_anchors.push(candidate.id.clone());
             }
             continue; // don't consider existing anchors as new candidates
@@ -286,6 +294,11 @@ pub(crate) fn auto_anchor(
         // Skip anchors that the user explicitly removed via --anchors replacement.
         // auto_anchor is a safety net for missed connections, not an override of
         // explicit user intent.
+        //
+        // Defensive: current callers (Add, Update) already strip explicitly-removed
+        // anchors before reaching this loop, but future call sites might not. This
+        // guard ensures auto_anchor never re-adds an anchor the user chose to remove,
+        // regardless of how the caller is wired.
         if let Some(removed) = explicitly_removed
             && removed.contains(&candidate.id)
         {
@@ -311,7 +324,7 @@ pub(crate) fn auto_anchor(
         let similarity = cosine_similarity(entry_embedding, candidate_embedding);
 
         // Filter by threshold, skip near-duplicates
-        if similarity >= threshold && similarity <= 0.95 {
+        if similarity >= threshold && similarity <= NEAR_DUPLICATE_CEILING {
             similarities.push((candidate.id.clone(), similarity));
         }
     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -265,6 +265,7 @@ pub(crate) fn auto_anchor(
     let threshold = 0.75;
     let max_anchors = 5;
     let mut similarities: Vec<(String, f32)> = Vec::new();
+    let mut stale_anchors: Vec<String> = Vec::new();
 
     for candidate in &candidates {
         // Skip self
@@ -272,9 +273,14 @@ pub(crate) fn auto_anchor(
             continue;
         }
 
-        // Skip if already an anchor
+        // Re-evaluate existing anchors for staleness
         if entry.anchors.contains(&candidate.id) {
-            continue;
+            let candidate_embedding = candidate.embedding.as_ref().unwrap();
+            let similarity = cosine_similarity(entry_embedding, candidate_embedding);
+            if similarity < threshold || similarity > 0.95 {
+                stale_anchors.push(candidate.id.clone());
+            }
+            continue; // don't consider existing anchors as new candidates
         }
 
         // Skip anchors that the user explicitly removed via --anchors replacement.
@@ -310,8 +316,8 @@ pub(crate) fn auto_anchor(
         }
     }
 
-    // No similar entries found
-    if similarities.is_empty() {
+    // No similar entries found and no stale anchors to prune
+    if stale_anchors.is_empty() && similarities.is_empty() {
         return Ok(());
     }
 
@@ -323,8 +329,16 @@ pub(crate) fn auto_anchor(
         .map(|(id, _)| id)
         .collect();
 
-    // Update the entry with new anchors
-    let mut updated_anchors = entry.anchors.clone();
+    // Update the entry with new anchors, filtering out stale ones
+    let mut updated_anchors: Vec<String> = entry.anchors.clone()
+        .into_iter()
+        .filter(|a| !stale_anchors.contains(a))
+        .collect();
+
+    if let Some(removed) = explicitly_removed {
+        updated_anchors.retain(|a| !removed.contains(a));
+    }
+
     updated_anchors.extend(top_matches);
     updated_anchors.sort();
     updated_anchors.dedup();


### PR DESCRIPTION
## Summary

- **Stale anchor pruning**: `auto_anchor` (in `helpers.rs`) and the `AutoAnchor` batch command (in `handlers/memory.rs`) now re-evaluate existing anchors. Anchors whose cosine similarity has drifted below the threshold (0.75) or above the near-duplicate ceiling (0.95) are pruned from the entry's anchor list.
- **`--no-auto-anchor` flag**: Added to six mutation subcommands (Add, Update, Edit, Append, Prepend, Restore) in `cli.rs`. When set, skips the automatic anchor generation step and prints `(auto-anchor skipped)` to stderr. Does NOT skip `auto_embed` -- only anchoring is affected.
- **Batch visibility**: The `AutoAnchor` batch command now reports stale anchor pruning counts alongside new anchor additions, with `x` prefix for removals and `+` prefix for additions.

## Files changed

- `src/cli.rs` -- `no_auto_anchor: bool` field added to six subcommand structs
- `src/helpers.rs` -- `auto_anchor()` restructured: stale anchor detection, combined early-return guard, filtered anchor rebuild with `explicitly_removed` integration
- `src/handlers/memory.rs` -- Six handler destructuring patterns updated; `auto_anchor` calls wrapped in `if !no_auto_anchor`; batch `AutoAnchor` command gets same stale-pruning logic

## Test results

- `cargo clippy`: zero warnings
- `cargo test`: 1004 unit + 22 integration tests pass, 0 failures

Closes #199