### PR TITLE
refactor: rename command-specific --verbose to --detailed (#152)

### DIFF
--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1138,6 +1138,7 @@ the category and generates a title from content).
   `--type`                `string`   Fact type for ephemeral knowledge: `decision`, `insight`, `person`, `quote`, `thread_opened`, `commitment`, `thread_closed`. Auto-routes category and sets `resonance_type=ephemeral`.
   `--session`             `string`   Session to link fact to via EXTRACTED_FROM relationship. Requires `--type`.
   `--thread-id`           `string`   Thread ID for `thread_closed` operations. Requires `--type`.
+  `--no-auto-anchor`      `flag`     Skip automatic anchor generation.
   `--json`                `flag`     Output as JSON.
 
 ### Examples
@@ -1345,6 +1346,7 @@ field. Content mutation modes are mutually exclusive.
   `--owner`                `string`   Update owner (only valid when visibility is private).
   `--session-id`           `string`   Update session ID (for retrofitting entries with wrong or missing session linkage).
   `--force`                `flag`     Force dangerous visibility changes (e.g., making blooms public).
+  `--no-auto-anchor`       `flag`     Skip automatic anchor generation.
   `--json`                 `flag`     Output as JSON.
 
 ### Examples
@@ -1377,13 +1379,14 @@ interface.
 
 ### Flags
 
-  **Flag**          **Type**   **Description**
-  ----------------- ---------- ---------------------------------------------------------------
-  `--find`          `string`   Text to find in content. Also accepts `--old`.
-  `--replace`       `string`   Replacement text. Also accepts `--new`.
-  `--replace-all`   `flag`     Replace all occurrences (default: error if multiple matches).
-  `--nth`           `int`      Replace only the Nth occurrence (1-indexed).
-  `--json`          `flag`     Output as JSON.
+  **Flag**             **Type**   **Description**
+  -------------------- ---------- ---------------------------------------------------------------
+  `--find`             `string`   Text to find in content. Also accepts `--old`.
+  `--replace`          `string`   Replacement text. Also accepts `--new`.
+  `--replace-all`      `flag`     Replace all occurrences (default: error if multiple matches).
+  `--nth`              `int`      Replace only the Nth occurrence (1-indexed).
+  `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--json`             `flag`     Output as JSON.
 
 ### Examples
 
@@ -1402,11 +1405,12 @@ Append content to the end of an entry's body. Shortcut for
 
 ### Flags
 
-  **Flag**       **Type**   **Description**
-  -------------- ---------- --------------------------------------------------------
-  `--content`    `string`   Content to append (omit to read from stdin).
-  `-f, --file`   `path`     Read content from file. Also accepts `--content-file`.
-  `--json`       `flag`     Output as JSON.
+  **Flag**             **Type**   **Description**
+  -------------------- ---------- --------------------------------------------------------
+  `--content`          `string`   Content to append (omit to read from stdin).
+  `-f, --file`         `path`     Read content from file. Also accepts `--content-file`.
+  `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--json`             `flag`     Output as JSON.
 
 ### Examples
 
@@ -1425,11 +1429,12 @@ Prepend content to the start of an entry's body. Shortcut for
 
 ### Flags
 
-  **Flag**       **Type**   **Description**
-  -------------- ---------- --------------------------------------------------------
-  `--content`    `string`   Content to prepend (omit to read from stdin).
-  `-f, --file`   `path`     Read content from file. Also accepts `--content-file`.
-  `--json`       `flag`     Output as JSON.
+  **Flag**             **Type**   **Description**
+  -------------------- ---------- --------------------------------------------------------
+  `--content`          `string`   Content to prepend (omit to read from stdin).
+  `-f, --file`         `path`     Read content from file. Also accepts `--content-file`.
+  `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--json`             `flag`     Output as JSON.
 
 ### Examples
 
@@ -1444,10 +1449,11 @@ backups before restoring.
 
 ### Flags
 
-  **Flag**   **Type**   **Description**
-  ---------- ---------- ----------------------------------------------
-  `--list`   `flag`     List available backups instead of restoring.
-  `--json`   `flag`     Output as JSON.
+  **Flag**             **Type**   **Description**
+  -------------------- ---------- ----------------------------------------------
+  `--list`             `flag`     List available backups instead of restoring.
+  `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--json`             `flag`     Output as JSON.
 
 ### Examples
 
@@ -1621,14 +1627,21 @@ mx memory embed --all
 Automatically add anchors between entries based on embedding similarity.
 Processes a single entry or all entries that have embeddings.
 
+Also re-evaluates existing anchors: any anchor whose cosine similarity
+has fallen below the threshold (default 0.75) or risen above the
+near-duplicate ceiling (0.95) is pruned. This keeps the anchor graph
+self-cleaning -- anchors that made sense once but no longer do are
+removed automatically.
+
 ### Flags
 
   **Flag**          **Type**   **Description**
-  ----------------- ---------- --------------------------------------------------------
+  ----------------- ---------- ---------------------------------------------------------------------------------------------------------------------
   `--threshold`     `float`    Minimum cosine similarity (0.0--1.0). Default: `0.75`.
   `--max-anchors`   `int`      Maximum anchors to add per entry. Default: `5`.
   `--dry-run`       `flag`     Preview changes without writing.
-  `--verbose`       `flag`     Show similarity scores in output.
+  `--detailed`      `flag`     Show similarity scores in output.
+  `--fill`          `flag`     Only process entries with zero existing anchors. Fills gaps in the graph without touching already-anchored entries.
 
 ### Examples
 
@@ -1641,13 +1654,26 @@ mx memory auto-anchor kn-abc123 --threshold 0.8 --max-anchors 3
 ```
 
 ``` bash
-mx memory auto-anchor --dry-run --verbose
+mx memory auto-anchor --dry-run --detailed
+```
+
+``` bash
+mx memory auto-anchor --fill
 ```
 
 ::: {.admonition .tip}
 **TIP:** A typical workflow: run `mx memory embed --all` to generate
-embeddings, then `mx memory auto-anchor --dry-run --verbose` to preview
+embeddings, then `mx memory auto-anchor --dry-run --detailed` to preview
 anchor candidates, then `mx memory auto-anchor` to write them.
+:::
+
+::: {.admonition .note}
+**NOTE:** Anchors are also maintained automatically on every write
+operation (`add`, `update`, `edit`, `append`, `prepend`, `restore`).
+After each write, mx re-evaluates anchors and prunes stale ones using
+the same similarity thresholds. Pass `--no-auto-anchor` on any of these
+commands to skip this step -- useful for bulk operations or cleanup
+scripts where the overhead is unwanted.
 :::
 
 ## Relationships
@@ -2562,7 +2588,7 @@ before clean mode existed.
   **Flag**             **Type**   **Description**
   -------------------- ---------- -----------------------------------------------------------------------------------
   `--dry-run`          flag       Show what would be migrated without making changes.
-  `--verbose`          flag       Show detailed progress for each archive.
+  `--detailed`         flag       Show detailed progress for each archive.
   `--clean`            flag       Generate `conversation.md` for archives missing a clean transcript.
   `--include-agents`   flag       Include sub-agent transcripts in generated clean transcripts. Requires `--clean`.
 
@@ -2573,7 +2599,7 @@ mx codex migrate --dry-run
 ```
 
 ``` bash
-mx codex migrate --verbose
+mx codex migrate --detailed
 ```
 
 ``` bash
@@ -2581,7 +2607,7 @@ mx codex migrate --clean
 ```
 
 ``` bash
-mx codex migrate --clean --include-agents --verbose
+mx codex migrate --clean --include-agents --detailed
 ```
 
 ## Deprecated alias
@@ -2694,6 +2720,7 @@ type = "list"
 [keys.todos]
 type = "list"
 max_entries = 20
+description = "Pending work items"
 
 [keys.context]
 type = "state"
@@ -2722,6 +2749,11 @@ Schema fields:
 
 :   Optional. Maximum entries for history and list types. Oldest entries
     are dropped when exceeded. Omit to allow unbounded growth.
+
+`description`
+
+:   Optional. Human-readable description of the key's purpose. Displayed
+    as a third column by `mx kv keys`.
 
 `fields`
 
@@ -2989,7 +3021,8 @@ mx kv set decisions --id 17 --memory ""
 ## `mx kv keys`
 
 List all keys defined in the schema with their types. Output is two
-columns: key name (left-aligned, 30 chars) and type.
+columns: key name (left-aligned, 30 chars) and type. When a key has a
+`description` in the schema, it is shown as a third column.
 
 ### Examples
 
@@ -7157,6 +7190,7 @@ default = ""
 
 [keys.focus_areas]
 type = "list"
+description = "Areas of active focus"
 
 [keys.session_state]
 type = "state"

--- a/docs/src/codex.typ
+++ b/docs/src/codex.typ
@@ -285,15 +285,15 @@ The remaining tokens (`subagents`, `mcp`, `tool-output`, `history`, `all`,
   existed.],
   flags: (
     ([`--dry-run`], [flag], [Show what would be migrated without making changes.]),
-    ([`--verbose`], [flag], [Show detailed progress for each archive.]),
+    ([`--detailed`], [flag], [Show detailed progress for each archive.]),
     ([`--clean`], [flag], [Generate `conversation.md` for archives missing a clean transcript.]),
     ([`--include-agents`], [flag], [Include sub-agent transcripts in generated clean transcripts. Requires `--clean`.]),
   ),
   examples: (
     "mx codex migrate --dry-run",
-    "mx codex migrate --verbose",
+    "mx codex migrate --detailed",
     "mx codex migrate --clean",
-    "mx codex migrate --clean --include-agents --verbose",
+    "mx codex migrate --clean --include-agents --detailed",
   ),
 )
 

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -424,19 +424,19 @@ Anchors are connections between entries discovered via embedding similarity.
     ([`--threshold`],   [`float`], [Minimum cosine similarity (0.0--1.0). Default: `0.75`.]),
     ([`--max-anchors`], [`int`],   [Maximum anchors to add per entry. Default: `5`.]),
     ([`--dry-run`],     [`flag`],  [Preview changes without writing.]),
-    ([`--verbose`],     [`flag`],  [Show similarity scores in output.]),
+    ([`--detailed`],    [`flag`],  [Show similarity scores in output.]),
     ([`--fill`],        [`flag`],  [Only process entries with zero existing anchors. Fills gaps in the graph without touching already-anchored entries.]),
   ),
   examples: (
     "mx memory auto-anchor",
     "mx memory auto-anchor kn-abc123 --threshold 0.8 --max-anchors 3",
-    "mx memory auto-anchor --dry-run --verbose",
+    "mx memory auto-anchor --dry-run --detailed",
     "mx memory auto-anchor --fill",
   ),
 )
 
 #tip[A typical workflow: run `mx memory embed --all` to generate embeddings,
-then `mx memory auto-anchor --dry-run --verbose` to preview anchor
+then `mx memory auto-anchor --dry-run --detailed` to preview anchor
 candidates, then `mx memory auto-anchor` to write them.]
 
 #note[Anchors are also maintained automatically on every write operation

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -892,7 +892,7 @@ pub enum MemoryCommands {
 
         /// Show similarity scores in output
         #[arg(long)]
-        verbose: bool,
+        detailed: bool,
 
         /// Only process entries with no existing anchors
         #[arg(long)]
@@ -1419,7 +1419,7 @@ pub enum CodexCommands {
 
         /// Show detailed progress
         #[arg(long)]
-        verbose: bool,
+        detailed: bool,
 
         /// Generate conversation.md for archives that have session.jsonl but no clean transcript
         #[arg(long)]

--- a/src/codex/migrate.rs
+++ b/src/codex/migrate.rs
@@ -28,7 +28,7 @@ use super::archive::{collect_archives, get_codex_dir};
 /// `None` counts.
 pub(crate) fn migrate_archives(
     dry_run: bool,
-    verbose: bool,
+    detailed: bool,
     clean: bool,
     include_agents: bool,
 ) -> Result<()> {
@@ -48,7 +48,7 @@ pub(crate) fn migrate_archives(
 
     // --clean mode: generate conversation.md for archives that have session.jsonl but no transcript
     if clean {
-        return migrate_clean_transcripts(&codex_dir, archives, dry_run, verbose, include_agents);
+        return migrate_clean_transcripts(&codex_dir, archives, dry_run, detailed, include_agents);
     }
 
     // Split archives into two buckets:
@@ -98,7 +98,7 @@ pub(crate) fn migrate_archives(
             continue;
         }
 
-        if verbose {
+        if detailed {
             println!("Migrating archive: {}", archive.short_id);
         }
 
@@ -127,7 +127,7 @@ pub(crate) fn migrate_archives(
                     let path = entry.path();
 
                     if path.extension().and_then(|s| s.to_str()) == Some("jsonl") {
-                        if verbose {
+                        if detailed {
                             println!(
                                 "  Processing agent file: {}",
                                 path.file_name().unwrap().to_string_lossy()
@@ -174,7 +174,7 @@ pub(crate) fn migrate_archives(
             let image_count = all_images.len();
             total_images += image_count;
 
-            if verbose || image_count > 0 {
+            if detailed || image_count > 0 {
                 println!(
                     "  ✓ Migrated {}: {} images extracted, {} KB saved",
                     archive.short_id,
@@ -205,7 +205,7 @@ pub(crate) fn migrate_archives(
 
             total_images += total_archive_images;
 
-            if verbose || total_archive_images > 0 {
+            if detailed || total_archive_images > 0 {
                 println!(
                     "  Would migrate {}: {} images found",
                     archive.short_id, total_archive_images
@@ -223,7 +223,7 @@ pub(crate) fn migrate_archives(
     let mut metadata_bumped = 0;
     for archive in metadata_only_bumps {
         let archive_dir = codex_dir.join(&archive.dir_name);
-        if verbose {
+        if detailed {
             println!(
                 "Metadata bump: {} (v{} -> v{})",
                 archive.short_id, archive.manifest.version, MANIFEST_WRITE_VERSION

--- a/src/codex/transcript.rs
+++ b/src/codex/transcript.rs
@@ -253,7 +253,7 @@ pub(super) fn migrate_clean_transcripts(
     codex_dir: &Path,
     archives: Vec<ArchiveEntry>,
     dry_run: bool,
-    verbose: bool,
+    detailed: bool,
     include_agents: bool,
 ) -> Result<()> {
     let mut needs_transcript = Vec::new();
@@ -265,7 +265,7 @@ pub(super) fn migrate_clean_transcripts(
 
         if transcript_file.exists() {
             // Already has a clean transcript — skip
-            if verbose {
+            if detailed {
                 println!(
                     "  Skipping {} (already has conversation.md)",
                     archive.short_id
@@ -276,7 +276,7 @@ pub(super) fn migrate_clean_transcripts(
 
         if !session_file.exists() {
             // Clean-only archive or missing JSONL — can't generate
-            if verbose {
+            if detailed {
                 println!(
                     "  Skipping {} (no session.jsonl to generate from)",
                     archive.short_id
@@ -359,7 +359,7 @@ pub(super) fn migrate_clean_transcripts(
             }
         }
 
-        if verbose {
+        if detailed {
             println!("  Generated conversation.md for {}", archive.short_id);
         }
 

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1703,7 +1703,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             threshold,
             max_anchors,
             dry_run,
-            verbose,
+            detailed,
             fill,
         } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
@@ -1765,7 +1765,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 // In fill mode, skip entries that already have anchors
                 if fill && !entry.anchors.is_empty() {
                     total_skipped += 1;
-                    if verbose {
+                    if detailed {
                         println!(
                             "  {} \"{}\" - Skipped (has {} anchors)",
                             entry.id,
@@ -1834,7 +1834,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 let top_matches: Vec<_> = similarities.into_iter().take(max_anchors).collect();
 
                 if top_matches.is_empty() && stale_anchors.is_empty() {
-                    if verbose {
+                    if detailed {
                         println!(
                             "  {} \"{}\" - No similar entries found",
                             entry.id, entry.title
@@ -1853,7 +1853,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
 
                 for (match_id, match_title, score) in &top_matches {
-                    if verbose {
+                    if detailed {
                         println!("  → {} \"{}\" ({:.2})", match_id, match_title, score);
                     } else {
                         println!("  → {} \"{}\"", match_id, match_title);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -153,11 +153,11 @@ pub(crate) fn handle_codex(cmd: CodexCommands) -> Result<()> {
         }
         CodexCommands::Migrate {
             dry_run,
-            verbose,
+            detailed,
             clean,
             include_agents,
         } => {
-            codex::migrate_archives(dry_run, verbose, clean, include_agents)?;
+            codex::migrate_archives(dry_run, detailed, clean, include_agents)?;
             Ok(())
         }
     }


### PR DESCRIPTION
## Summary

- Renamed `--verbose` to `--detailed` on the `auto-anchor` and `codex migrate` subcommands
- The global `-v/--verbose` flag (connection logs) is unchanged
- Fixes the shadowing bug where the command-specific `--verbose` was accidentally passed to `create_store_with_verbose` in the auto-anchor handler instead of the global verbose flag

## Files changed

- `src/cli.rs` — field renames in `AutoAnchor` and `CodexCommands::Migrate`
- `src/handlers/memory.rs` — destructure + usage renames in the AutoAnchor handler
- `src/handlers/mod.rs` — destructure + passthrough in the codex Migrate handler
- `src/codex/migrate.rs` — parameter + usage renames
- `src/codex/transcript.rs` — parameter + usage renames (called by migrate)

## Test plan

- [x] `cargo clippy` passes clean
- [x] `cargo test` — 1004 + 22 tests pass, 0 failures

Closes #152