### PR TITLE
feat: add kv rename command (#315)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ mx kv update projects --id 42 --data '{"obsolete_field":null}'
 mx kv migrate projects --dry-run
 mx kv migrate projects --prune
 
+# Rename a key (preserves all entries, IDs, and data)
+mx kv rename old_decisions archived_decisions
+
 # Per-entry memory links (bridge KV entries to the knowledge graph)
 mx kv push decisions "adopted memory links" --memory kn-abc123
 mx kv set decisions --id 17 --memory kn-abc123

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -299,6 +299,9 @@ mx kv update projects --id 42 --data '{"status":"done"}'
 mx kv migrate projects --dry-run
 mx kv migrate projects --prune
 
+# Rename a key (preserves all entries and data)
+mx kv rename old_decisions archived_decisions
+
 # JSON output for scripting and jq piping
 mx kv last projects --count 5 --json | jq '.[].data.status'
 mx kv count shipped --json | jq '.count'
@@ -4025,6 +4028,32 @@ mx kv reset decisions
 mx kv reset context
 ```
 
+## `mx kv rename <old-key> <new-key>`
+
+Rename a key, preserving all entries and data. The old key is removed
+from both the schema (TOML) and data (JSON) files, and all its content
+-- type definition, constraints, entries, timestamps, structured data,
+memory links -- is moved to the new key name. Entry IDs are stable and
+do not change.
+
+The new key name is validated with the same rules as `push --create`:
+alphanumeric characters, underscores, and hyphens only, maximum 128
+characters, no dots.
+
+Persistence order: the data file is written first (higher-value file),
+then the schema file. If the data write fails, in-memory state is rolled
+back and no files are modified.
+
+### Examples
+
+``` bash
+mx kv rename session_goal current_goal
+```
+
+``` bash
+mx kv rename old_decisions archived_decisions
+```
+
 ## Memory linking
 
 History, list, and state keys can be linked to a memory graph entry via
@@ -7286,6 +7315,15 @@ content, and re-parses the file to update the in-memory `Schema`. This
 is exposed through `push --create <type>` at the CLI layer, where the
 handler calls `add_key_to_schema` before the normal push path. If the
 key already exists, the method is a no-op.
+
+The `rename_key()` method moves a key from one name to another in both
+the schema and data files. It validates the new name, checks that the
+old key exists and the new key does not, then atomically swaps the
+in-memory entries before persisting. Data is written first (higher-value
+file), then schema. If the data write fails, in-memory mutations are
+rolled back. Entry IDs are stable across renames -- they were hashed
+from the original key name at creation time and are never regenerated.
+This is exposed through `mx kv rename <old> <new>` at the CLI layer.
 
 ### Per-agent keying
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -626,6 +626,15 @@ exposed through `push --create <type>` at the CLI layer, where the handler
 calls `add_key_to_schema` before the normal push path. If the key already
 exists, the method is a no-op.
 
+The `rename_key()` method moves a key from one name to another in both the
+schema and data files. It validates the new name, checks that the old key
+exists and the new key does not, then atomically swaps the in-memory
+entries before persisting. Data is written first (higher-value file), then
+schema. If the data write fails, in-memory mutations are rolled back. Entry
+IDs are stable across renames -- they were hashed from the original key
+name at creation time and are never regenerated. This is exposed through
+`mx kv rename <old> <new>` at the CLI layer.
+
 === Per-agent keying
 
 The active agent is determined by the `MX_CURRENT_AGENT` environment variable.

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -170,6 +170,9 @@ mx kv update projects --id 42 --data '{"status":"done"}'
 mx kv migrate projects --dry-run
 mx kv migrate projects --prune
 
+# Rename a key (preserves all entries and data)
+mx kv rename old_decisions archived_decisions
+
 # JSON output for scripting and jq piping
 mx kv last projects --count 5 --json | jq '.[].data.status'
 mx kv count shipped --json | jq '.count'

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -935,6 +935,27 @@ manual action is needed.
   ),
 )
 
+#command(
+  "mx kv rename <old-key> <new-key>",
+  [Rename a key, preserving all entries and data. The old key is removed
+  from both the schema (TOML) and data (JSON) files, and all its content
+  -- type definition, constraints, entries, timestamps, structured data,
+  memory links -- is moved to the new key name. Entry IDs are stable and
+  do not change.
+
+  The new key name is validated with the same rules as `push --create`:
+  alphanumeric characters, underscores, and hyphens only, maximum 128
+  characters, no dots.
+
+  Persistence order: the data file is written first (higher-value file),
+  then the schema file. If the data write fails, in-memory state is
+  rolled back and no files are modified.],
+  examples: (
+    "mx kv rename session_goal current_goal",
+    "mx kv rename old_decisions archived_decisions",
+  ),
+)
+
 == Memory linking
 
 History, list, and state keys can be linked to a memory graph entry via the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2015,6 +2015,14 @@ pub enum KvCommands {
         dry_run: bool,
     },
 
+    /// Rename a key (schema + data migration)
+    Rename {
+        /// Current key name
+        old_key: String,
+        /// New key name
+        new_key: String,
+    },
+
     /// List all defined keys with their types and descriptions
     Keys,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2015,7 +2015,7 @@ pub enum KvCommands {
         dry_run: bool,
     },
 
-    /// Rename a key (schema + data migration)
+    /// Rename a key, preserving all entries and data
     Rename {
         /// Current key name
         old_key: String,

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -1182,6 +1182,14 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             Err(e) => handle_kv_err(e),
         },
 
+        KvCommands::Rename { old_key, new_key } => match store.rename_key(&old_key, &new_key) {
+            Ok(()) => {
+                println!("Key renamed: {} \u{2192} {}", old_key, new_key);
+                Ok(kv::EXIT_OK)
+            }
+            Err(e) => handle_kv_err(e),
+        },
+
         KvCommands::Keys => {
             let keys = store.keys();
             for (name, vtype, desc) in &keys {

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -1184,7 +1184,7 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
 
         KvCommands::Rename { old_key, new_key } => match store.rename_key(&old_key, &new_key) {
             Ok(()) => {
-                println!("Key renamed: {} \u{2192} {}", old_key, new_key);
+                println!("Renamed {} to {}", old_key, new_key);
                 Ok(kv::EXIT_OK)
             }
             Err(e) => handle_kv_err(e),

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1187,8 +1187,8 @@ impl KvStore {
     /// formatting -- this matches the existing pattern established by
     /// `add_key_to_schema` which re-parses after appending.
     fn save_schema(&self) -> Result<()> {
-        let toml_str = toml::to_string_pretty(&self.schema)
-            .context("Failed to serialize schema to TOML")?;
+        let toml_str =
+            toml::to_string_pretty(&self.schema).context("Failed to serialize schema to TOML")?;
 
         // Ensure parent directory exists
         if let Some(parent) = self.schema_path.parent() {

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1087,28 +1087,33 @@ impl KvStore {
     /// and names with other special characters.
     fn validate_key_name(key: &str) -> Result<(), KvError> {
         if key.is_empty() {
-            return Err(KvError::Other(anyhow::anyhow!("key name cannot be empty")));
+            return Err(KvError::DataValidation {
+                message: "key name cannot be empty".to_string(),
+            });
         }
         if key.len() > 128 {
-            return Err(KvError::Other(anyhow::anyhow!(
-                "key name too long ({} chars, max 128)",
-                key.len()
-            )));
+            return Err(KvError::DataValidation {
+                message: format!("key name too long ({} chars, max 128)", key.len()),
+            });
         }
         if key.contains('.') {
-            return Err(KvError::Other(anyhow::anyhow!(
-                "key name '{}' cannot contain dots -- they require TOML quoting and create confusion",
-                key
-            )));
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "key name '{}' cannot contain dots -- they require TOML quoting and create confusion",
+                    key
+                ),
+            });
         }
         if !key
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
         {
-            return Err(KvError::Other(anyhow::anyhow!(
-                "key name '{}' contains invalid characters -- only alphanumeric, underscores, and hyphens are allowed",
-                key
-            )));
+            return Err(KvError::DataValidation {
+                message: format!(
+                    "key name '{}' contains invalid characters -- only alphanumeric, underscores, and hyphens are allowed",
+                    key
+                ),
+            });
         }
         Ok(())
     }
@@ -1186,6 +1191,10 @@ impl KvStore {
     /// file). Schema serialization via `toml = "0.8"` drops comments and custom
     /// formatting -- this matches the existing pattern established by
     /// `add_key_to_schema` which re-parses after appending.
+    ///
+    /// Takes `&self` rather than `&mut self` because it only serializes the
+    /// current schema to disk -- unlike `save()`, it does not update timestamps
+    /// or other mutable bookkeeping.
     fn save_schema(&self) -> Result<()> {
         let toml_str =
             toml::to_string_pretty(&self.schema).context("Failed to serialize schema to TOML")?;
@@ -1218,23 +1227,22 @@ impl KvStore {
         Ok(())
     }
 
-    /// Rename a key in both schema and data, preserving all entries.
+    /// Rename a key, preserving all entries and data.
     ///
-    /// Atomic: mutates in-memory state fully before writing either file, so
-    /// if either write fails the on-disk state is unchanged (the old data is
-    /// still there).
+    /// Mutates in-memory state fully before writing either file. Data is
+    /// persisted first (higher-value file), then schema. If the data write
+    /// fails, in-memory mutations are rolled back so the `KvStore` stays
+    /// clean. If data succeeds but the schema write fails, the on-disk data
+    /// file already contains the renamed key while the schema still
+    /// references the old name -- a narrow consistency gap that callers
+    /// should be aware of. In practice both writes target the same
+    /// directory, so a failure between them is unlikely.
     ///
     /// Entry IDs are stable -- they were hashed from the original key name at
     /// creation time and are never regenerated.
     pub fn rename_key(&mut self, old_key: &str, new_key: &str) -> Result<(), KvError> {
-        // Validate new key name (convert Other errors to DataValidation for
-        // proper exit code mapping -- validate_key_name uses Other internally)
-        Self::validate_key_name(new_key).map_err(|e| match e {
-            KvError::Other(inner) => KvError::DataValidation {
-                message: inner.to_string(),
-            },
-            other => other,
-        })?;
+        // Validate new key name
+        Self::validate_key_name(new_key)?;
 
         // old_key must exist in schema
         if !self.schema.keys.contains_key(old_key) {
@@ -1253,13 +1261,27 @@ impl KvStore {
         self.schema.keys.insert(new_key.to_string(), key_def);
 
         // Move data entry (if it exists -- key might have no data yet)
+        let had_data = self.data.entries.contains_key(old_key);
         if let Some(data_value) = self.data.entries.remove(old_key) {
             self.data.entries.insert(new_key.to_string(), data_value);
         }
 
-        // Persist both files. Schema first, then data.
+        // Persist data first (higher-value file), then schema.
+        if let Err(e) = self.save() {
+            // Rollback in-memory mutations so the KvStore stays clean.
+            let key_def = self.schema.keys.remove(new_key).expect("just inserted");
+            self.schema.keys.insert(old_key.to_string(), key_def);
+            if had_data {
+                if let Some(data_value) = self.data.entries.remove(new_key) {
+                    self.data.entries.insert(old_key.to_string(), data_value);
+                }
+            }
+            return Err(KvError::Other(e));
+        }
+
+        // Schema write -- if this fails, data is already persisted with the
+        // new key name. See doc comment for the consistency trade-off.
         self.save_schema().map_err(KvError::Other)?;
-        self.save().map_err(KvError::Other)?;
 
         Ok(())
     }
@@ -8461,5 +8483,153 @@ count = { type = "number" }
         assert_eq!(result.id, push.id);
         let after = get_history_entry(&store, "flavor_history", push.index);
         assert_eq!(after.value, "gyokuro-updated");
+    }
+
+    // -- rename_key --
+
+    #[test]
+    fn rename_key_happy_path() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        // Push some data into flavor_history so there is something to rename
+        let push1 = store
+            .push("flavor_history", "matcha", None, None)
+            .unwrap();
+        let push2 = store
+            .push("flavor_history", "hojicha", None, None)
+            .unwrap();
+        store.save().unwrap();
+
+        store
+            .rename_key("flavor_history", "tea_history")
+            .unwrap();
+
+        // Old key gone from schema and data
+        assert!(!store.schema.keys.contains_key("flavor_history"));
+        assert!(!store.data.entries.contains_key("flavor_history"));
+
+        // New key present in schema and data
+        assert!(store.schema.keys.contains_key("tea_history"));
+        assert!(store.data.entries.contains_key("tea_history"));
+
+        // Data preserved: IDs and values intact (newest entry first)
+        let entries = match store.data.entries.get("tea_history").unwrap() {
+            DataValue::History { entries, .. } => entries,
+            _ => panic!("Expected History"),
+        };
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].value, "hojicha");
+        assert_eq!(entries[0].id, push2.id);
+        assert_eq!(entries[1].value, "matcha");
+        assert_eq!(entries[1].id, push1.id);
+    }
+
+    #[test]
+    fn rename_key_old_key_not_found() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let err = store
+            .rename_key("nonexistent", "something")
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::KeyNotFound(ref k) if k == "nonexistent"),
+            "Expected KeyNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rename_key_new_key_already_exists() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        let err = store
+            .rename_key("warmth", "capped")
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "Expected DataValidation, got: {err}"
+        );
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn rename_key_invalid_new_key_name() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        // Dots are rejected
+        let err = store
+            .rename_key("warmth", "bad.name")
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "Expected DataValidation, got: {err}"
+        );
+
+        // Empty name rejected
+        let err = store.rename_key("warmth", "").unwrap_err();
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "Expected DataValidation, got: {err}"
+        );
+
+        // Special chars rejected
+        let err = store
+            .rename_key("warmth", "no spaces!")
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "Expected DataValidation, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rename_key_with_no_data_entries() {
+        // Key exists in schema but has no data entries yet
+        let (mut store, _dir) = setup_store(test_schema());
+
+        // warmth is a counter with no data pushed yet -- but counters get a
+        // default. Use a fresh history key via add_key_to_schema instead.
+        store
+            .add_key_to_schema("empty_history", "history", None)
+            .unwrap();
+        assert!(!store.data.entries.contains_key("empty_history"));
+
+        store
+            .rename_key("empty_history", "renamed_history")
+            .unwrap();
+
+        assert!(!store.schema.keys.contains_key("empty_history"));
+        assert!(store.schema.keys.contains_key("renamed_history"));
+        // No crash, no data entry created out of thin air
+        assert!(!store.data.entries.contains_key("empty_history"));
+    }
+
+    #[test]
+    fn rename_key_data_preservation() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        // Push entries with data payloads
+        let data_json = serde_json::json!({"mood": "calm"});
+        store
+            .push("flavor_history", "sencha", Some(data_json.clone()), None)
+            .unwrap();
+        store.save().unwrap();
+
+        // Serialize before rename
+        let before = serde_json::to_string(
+            store.data.entries.get("flavor_history").unwrap(),
+        )
+        .unwrap();
+
+        store
+            .rename_key("flavor_history", "tea_log")
+            .unwrap();
+
+        // Serialize after rename -- should be identical
+        let after = serde_json::to_string(
+            store.data.entries.get("tea_log").unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(before, after, "Serialized data should be identical after rename");
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1271,10 +1271,10 @@ impl KvStore {
             // Rollback in-memory mutations so the KvStore stays clean.
             let key_def = self.schema.keys.remove(new_key).expect("just inserted");
             self.schema.keys.insert(old_key.to_string(), key_def);
-            if had_data {
-                if let Some(data_value) = self.data.entries.remove(new_key) {
-                    self.data.entries.insert(old_key.to_string(), data_value);
-                }
+            if had_data
+                && let Some(data_value) = self.data.entries.remove(new_key)
+            {
+                self.data.entries.insert(old_key.to_string(), data_value);
             }
             return Err(KvError::Other(e));
         }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1271,9 +1271,7 @@ impl KvStore {
             // Rollback in-memory mutations so the KvStore stays clean.
             let key_def = self.schema.keys.remove(new_key).expect("just inserted");
             self.schema.keys.insert(old_key.to_string(), key_def);
-            if had_data
-                && let Some(data_value) = self.data.entries.remove(new_key)
-            {
+            if had_data && let Some(data_value) = self.data.entries.remove(new_key) {
                 self.data.entries.insert(old_key.to_string(), data_value);
             }
             return Err(KvError::Other(e));

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -8492,17 +8492,11 @@ count = { type = "number" }
         let (mut store, _dir) = setup_store(test_schema());
 
         // Push some data into flavor_history so there is something to rename
-        let push1 = store
-            .push("flavor_history", "matcha", None, None)
-            .unwrap();
-        let push2 = store
-            .push("flavor_history", "hojicha", None, None)
-            .unwrap();
+        let push1 = store.push("flavor_history", "matcha", None, None).unwrap();
+        let push2 = store.push("flavor_history", "hojicha", None, None).unwrap();
         store.save().unwrap();
 
-        store
-            .rename_key("flavor_history", "tea_history")
-            .unwrap();
+        store.rename_key("flavor_history", "tea_history").unwrap();
 
         // Old key gone from schema and data
         assert!(!store.schema.keys.contains_key("flavor_history"));
@@ -8528,9 +8522,7 @@ count = { type = "number" }
     fn rename_key_old_key_not_found() {
         let (mut store, _dir) = setup_store(test_schema());
 
-        let err = store
-            .rename_key("nonexistent", "something")
-            .unwrap_err();
+        let err = store.rename_key("nonexistent", "something").unwrap_err();
         assert!(
             matches!(err, KvError::KeyNotFound(ref k) if k == "nonexistent"),
             "Expected KeyNotFound, got: {err}"
@@ -8541,9 +8533,7 @@ count = { type = "number" }
     fn rename_key_new_key_already_exists() {
         let (mut store, _dir) = setup_store(test_schema());
 
-        let err = store
-            .rename_key("warmth", "capped")
-            .unwrap_err();
+        let err = store.rename_key("warmth", "capped").unwrap_err();
         assert!(
             matches!(err, KvError::DataValidation { .. }),
             "Expected DataValidation, got: {err}"
@@ -8556,9 +8546,7 @@ count = { type = "number" }
         let (mut store, _dir) = setup_store(test_schema());
 
         // Dots are rejected
-        let err = store
-            .rename_key("warmth", "bad.name")
-            .unwrap_err();
+        let err = store.rename_key("warmth", "bad.name").unwrap_err();
         assert!(
             matches!(err, KvError::DataValidation { .. }),
             "Expected DataValidation, got: {err}"
@@ -8572,9 +8560,7 @@ count = { type = "number" }
         );
 
         // Special chars rejected
-        let err = store
-            .rename_key("warmth", "no spaces!")
-            .unwrap_err();
+        let err = store.rename_key("warmth", "no spaces!").unwrap_err();
         assert!(
             matches!(err, KvError::DataValidation { .. }),
             "Expected DataValidation, got: {err}"
@@ -8615,21 +8601,17 @@ count = { type = "number" }
         store.save().unwrap();
 
         // Serialize before rename
-        let before = serde_json::to_string(
-            store.data.entries.get("flavor_history").unwrap(),
-        )
-        .unwrap();
+        let before =
+            serde_json::to_string(store.data.entries.get("flavor_history").unwrap()).unwrap();
 
-        store
-            .rename_key("flavor_history", "tea_log")
-            .unwrap();
+        store.rename_key("flavor_history", "tea_log").unwrap();
 
         // Serialize after rename -- should be identical
-        let after = serde_json::to_string(
-            store.data.entries.get("tea_log").unwrap(),
-        )
-        .unwrap();
+        let after = serde_json::to_string(store.data.entries.get("tea_log").unwrap()).unwrap();
 
-        assert_eq!(before, after, "Serialized data should be identical after rename");
+        assert_eq!(
+            before, after,
+            "Serialized data should be identical after rename"
+        );
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -178,13 +178,13 @@ impl From<anyhow::Error> for KvError {
 // ---------------------------------------------------------------------------
 
 /// Top-level schema definition.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Schema {
     pub keys: BTreeMap<String, KeyDef>,
 }
 
 /// Definition of a single key in the schema.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct KeyDef {
     #[serde(rename = "type")]
     pub value_type: ValueType,
@@ -215,7 +215,7 @@ pub struct KeyDef {
 }
 
 /// The type of a data field in a schema's `[keys.X.data]` section.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DataFieldType {
     String,
@@ -238,7 +238,7 @@ impl std::fmt::Display for DataFieldType {
 }
 
 /// Definition of a single data field within a key's `[keys.X.data]` section.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DataFieldDef {
     #[serde(rename = "type")]
     pub field_type: DataFieldType,
@@ -251,7 +251,7 @@ pub struct DataFieldDef {
     pub default: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ValueType {
     Counter,
@@ -1176,6 +1176,90 @@ impl KvStore {
             ))
         })?;
         self.schema = schema;
+
+        Ok(())
+    }
+
+    /// Atomic write of the schema file: serialize to TOML, write to tmp, fsync, rename.
+    ///
+    /// This is the schema counterpart of `save()` (which persists only the data
+    /// file). Schema serialization via `toml = "0.8"` drops comments and custom
+    /// formatting -- this matches the existing pattern established by
+    /// `add_key_to_schema` which re-parses after appending.
+    fn save_schema(&self) -> Result<()> {
+        let toml_str = toml::to_string_pretty(&self.schema)
+            .context("Failed to serialize schema to TOML")?;
+
+        // Ensure parent directory exists
+        if let Some(parent) = self.schema_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+
+        let tmp_path = self
+            .schema_path
+            .with_extension(format!("tmp.{}", std::process::id()));
+
+        {
+            let mut f = fs::File::create(&tmp_path)
+                .with_context(|| format!("Failed to create temp file: {}", tmp_path.display()))?;
+            f.write_all(toml_str.as_bytes())?;
+            f.sync_all()?;
+        }
+
+        fs::rename(&tmp_path, &self.schema_path).with_context(|| {
+            format!(
+                "Failed to rename {} -> {}",
+                tmp_path.display(),
+                self.schema_path.display()
+            )
+        })?;
+
+        Ok(())
+    }
+
+    /// Rename a key in both schema and data, preserving all entries.
+    ///
+    /// Atomic: mutates in-memory state fully before writing either file, so
+    /// if either write fails the on-disk state is unchanged (the old data is
+    /// still there).
+    ///
+    /// Entry IDs are stable -- they were hashed from the original key name at
+    /// creation time and are never regenerated.
+    pub fn rename_key(&mut self, old_key: &str, new_key: &str) -> Result<(), KvError> {
+        // Validate new key name (convert Other errors to DataValidation for
+        // proper exit code mapping -- validate_key_name uses Other internally)
+        Self::validate_key_name(new_key).map_err(|e| match e {
+            KvError::Other(inner) => KvError::DataValidation {
+                message: inner.to_string(),
+            },
+            other => other,
+        })?;
+
+        // old_key must exist in schema
+        if !self.schema.keys.contains_key(old_key) {
+            return Err(KvError::KeyNotFound(old_key.to_string()));
+        }
+
+        // new_key must not already exist
+        if self.schema.keys.contains_key(new_key) {
+            return Err(KvError::DataValidation {
+                message: format!("Key already exists: {}", new_key),
+            });
+        }
+
+        // Move schema entry: remove old, insert new
+        let key_def = self.schema.keys.remove(old_key).expect("checked above");
+        self.schema.keys.insert(new_key.to_string(), key_def);
+
+        // Move data entry (if it exists -- key might have no data yet)
+        if let Some(data_value) = self.data.entries.remove(old_key) {
+            self.data.entries.insert(new_key.to_string(), data_value);
+        }
+
+        // Persist both files. Schema first, then data.
+        self.save_schema().map_err(KvError::Other)?;
+        self.save().map_err(KvError::Other)?;
 
         Ok(())
     }


### PR DESCRIPTION
Closes #315

## Summary
- Adds `mx kv rename <old-key> <new-key>` command
- Renames key in both schema (.toml) and data (.json), preserving all entries (IDs, timestamps, data)
- Atomic: mutates in-memory state fully before persisting; schema save uses tmp+fsync+rename

## Files Changed
- `src/kv.rs` — `rename_key()` method, `save_schema()` helper, added `Serialize` derives
- `src/cli.rs` — `Rename` variant on `KvCommands`
- `src/handlers/kv.rs` — handler wiring

## Exit Codes
- 0: success
- 1: old key not found
- 4: new key name invalid or already exists

## Test Plan
- [x] `cargo build` passes
- [x] `cargo test` passes (1028 tests)
- [ ] Manual: `mx kv rename` with valid keys
- [ ] Manual: `mx kv rename` with nonexistent old key (exit 1)
- [ ] Manual: `mx kv rename` to existing key name (exit 4)