### PR TITLE
fix: tract-onnx embeddings perf regression (truncation + one-time optimization)

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -84,9 +84,7 @@ impl TractProvider {
                 .with_context(|| format!("Failed to set input fact for input {}", i))?;
         }
 
-        let model = model
-            .into_optimized()
-            .context("Failed to optimize model")?;
+        let model = model.into_optimized().context("Failed to optimize model")?;
         let plan = model
             .into_runnable()
             .context("Failed to make model runnable")?;

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -2,13 +2,16 @@ use anyhow::{Context, Result};
 use tokenizers::Tokenizer;
 use tract_onnx::prelude::*;
 
+/// Maximum sequence length for BGE-Base-EN-v1.5 (matches max_position_embeddings).
+const MAX_SEQ_LEN: usize = 512;
+
 /// Trait for embedding providers
 pub trait EmbeddingProvider: Send + Sync {
     /// Generate embedding for a single text
-    fn embed(&mut self, text: &str) -> Result<Vec<f32>>;
+    fn embed(&self, text: &str) -> Result<Vec<f32>>;
 
     /// Generate embeddings for multiple texts
-    fn embed_batch(&mut self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>>;
 
     /// Get the dimension of embeddings
     fn dimensions(&self) -> usize;
@@ -18,8 +21,13 @@ pub trait EmbeddingProvider: Send + Sync {
 }
 
 /// Tract-ONNX provider using BGE-Base-EN-v1.5 (pure Rust, no C++ ONNX Runtime)
+///
+/// The model is optimized once at construction time with a fixed input shape
+/// of [1, 512]. Inputs shorter than 512 tokens are zero-padded; inputs longer
+/// than 512 tokens are truncated by the tokenizer. This avoids the enormous
+/// cost of cloning + re-optimizing the model graph on every embed() call.
 pub struct TractProvider {
-    model: InferenceModel,
+    plan: TypedRunnableModel<TypedModel>,
     tokenizer: Tokenizer,
     model_id: String,
     dimensions: usize,
@@ -48,17 +56,43 @@ impl TractProvider {
             .get("tokenizer.json")
             .context("Failed to fetch tokenizer from HF Hub")?;
 
-        // Load ONNX model (unoptimized -- optimized per-input in embed())
-        let model = tract_onnx::onnx()
+        // Load ONNX model
+        let mut model = tract_onnx::onnx()
             .model_for_path(&model_path)
             .context("Failed to load ONNX model with tract")?;
 
-        // Load tokenizer
-        let tokenizer = Tokenizer::from_file(&tokenizer_path)
+        // Load tokenizer with truncation enabled (max 512 tokens, matching model limit).
+        // Without this, inputs exceeding 512 tokens cause into_optimized() to hang.
+        let mut tokenizer = Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
 
+        tokenizer
+            .with_truncation(Some(tokenizers::TruncationParams::default()))
+            .map_err(|e| anyhow::anyhow!("Failed to configure truncation: {}", e))?;
+
+        // Optimize the model ONCE with fixed input shape [1, MAX_SEQ_LEN].
+        // Inputs are padded to MAX_SEQ_LEN at inference time. This avoids
+        // cloning + re-optimizing the graph on every embed() call (the
+        // previous approach used ~10GB RAM per call).
+        let input_fact = InferenceFact::dt_shape(
+            i64::datum_type(),
+            tvec![1_usize.to_dim(), MAX_SEQ_LEN.to_dim()],
+        );
+        for i in 0..3 {
+            model
+                .set_input_fact(i, input_fact.clone())
+                .with_context(|| format!("Failed to set input fact for input {}", i))?;
+        }
+
+        let model = model
+            .into_optimized()
+            .context("Failed to optimize model")?;
+        let plan = model
+            .into_runnable()
+            .context("Failed to make model runnable")?;
+
         Ok(Self {
-            model,
+            plan,
             tokenizer,
             model_id: "BAAI/bge-base-en-v1.5".to_string(),
             dimensions: 768,
@@ -66,9 +100,17 @@ impl TractProvider {
     }
 }
 
+/// Pad a token vector to `MAX_SEQ_LEN` with the given pad value.
+fn pad_to_max(tokens: &[i64], pad_value: i64) -> Vec<i64> {
+    let mut padded = vec![pad_value; MAX_SEQ_LEN];
+    let copy_len = tokens.len().min(MAX_SEQ_LEN);
+    padded[..copy_len].copy_from_slice(&tokens[..copy_len]);
+    padded
+}
+
 impl EmbeddingProvider for TractProvider {
-    fn embed(&mut self, text: &str) -> Result<Vec<f32>> {
-        // Tokenize
+    fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        // Tokenize (truncation to 512 tokens is handled by the tokenizer)
         let encoding = self
             .tokenizer
             .encode(text, true)
@@ -81,33 +123,22 @@ impl EmbeddingProvider for TractProvider {
             .map(|&x| x as i64)
             .collect();
         let token_type_ids: Vec<i64> = encoding.get_type_ids().iter().map(|&x| x as i64).collect();
-        let seq_len = input_ids.len();
-        let batch = 1_usize;
 
-        // Clone model and set input facts for this sequence length
-        let mut model = self.model.clone();
-        let input_fact =
-            InferenceFact::dt_shape(i64::datum_type(), tvec![batch.to_dim(), seq_len.to_dim()]);
+        // Pad to fixed MAX_SEQ_LEN (the model was optimized for this shape).
+        // input_ids: pad with 0 (PAD token)
+        // attention_mask: pad with 0 (ignore padded positions)
+        // token_type_ids: pad with 0
+        let input_ids = pad_to_max(&input_ids, 0);
+        let attention_mask = pad_to_max(&attention_mask, 0);
+        let token_type_ids = pad_to_max(&token_type_ids, 0);
 
-        // Set input shapes for all 3 model inputs: input_ids, attention_mask, token_type_ids
-        for i in 0..3 {
-            model
-                .set_input_fact(i, input_fact.clone())
-                .with_context(|| format!("Failed to set input fact for input {}", i))?;
-        }
-
-        let model = model.into_optimized().context("Failed to optimize model")?;
-        let model = model
-            .into_runnable()
-            .context("Failed to make model runnable")?;
-
-        // Build input tensors
+        // Build input tensors with fixed shape [1, MAX_SEQ_LEN]
         let input_ids_tensor =
-            tract_ndarray::Array2::from_shape_vec((batch, seq_len), input_ids)?.into_tensor();
+            tract_ndarray::Array2::from_shape_vec((1, MAX_SEQ_LEN), input_ids)?.into_tensor();
         let attention_mask_tensor =
-            tract_ndarray::Array2::from_shape_vec((batch, seq_len), attention_mask)?.into_tensor();
+            tract_ndarray::Array2::from_shape_vec((1, MAX_SEQ_LEN), attention_mask)?.into_tensor();
         let token_type_ids_tensor =
-            tract_ndarray::Array2::from_shape_vec((batch, seq_len), token_type_ids)?.into_tensor();
+            tract_ndarray::Array2::from_shape_vec((1, MAX_SEQ_LEN), token_type_ids)?.into_tensor();
 
         let inputs = tvec![
             input_ids_tensor.into(),
@@ -115,8 +146,8 @@ impl EmbeddingProvider for TractProvider {
             token_type_ids_tensor.into(),
         ];
 
-        // Run inference
-        let outputs = model.run(inputs).context("Failed to run inference")?;
+        // Run inference (no clone, no re-optimization -- just run the pre-built plan)
+        let outputs = self.plan.run(inputs).context("Failed to run inference")?;
 
         // Output shape: [batch, seq_len, hidden_size]
         let output_tensor = outputs[0]
@@ -137,10 +168,9 @@ impl EmbeddingProvider for TractProvider {
         Ok(cls_pooled)
     }
 
-    fn embed_batch(&mut self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
-        // Simple loop: each text gets compiled at its actual sequence length.
-        // This is correct and avoids padding complexity.
-        texts.iter().map(|t| self.embed(t)).collect()
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        // Simple loop: each call is now cheap (no model clone or re-optimization).
+        texts.iter().map(|t| self.embed(t.as_str())).collect()
     }
 
     fn dimensions(&self) -> usize {
@@ -160,7 +190,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_embed_single() -> Result<()> {
-        let mut provider = TractProvider::new()?;
+        let provider = TractProvider::new()?;
         let embedding = provider.embed("Hello, world!")?;
         assert_eq!(embedding.len(), 768);
         Ok(())
@@ -169,7 +199,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_embed_batch() -> Result<()> {
-        let mut provider = TractProvider::new()?;
+        let provider = TractProvider::new()?;
         let texts = vec!["First text".to_string(), "Second text".to_string()];
         let embeddings = provider.embed_batch(&texts)?;
         assert_eq!(embeddings.len(), 2);
@@ -183,6 +213,32 @@ mod tests {
     fn test_dimensions() -> Result<()> {
         let provider = TractProvider::new()?;
         assert_eq!(provider.dimensions(), 768);
+        Ok(())
+    }
+
+    /// Regression test: long inputs (>512 tokens) must be truncated by the
+    /// tokenizer and produce a valid 768-dim embedding without hanging.
+    /// Before the fix, inputs exceeding max_position_embeddings (512) caused
+    /// tract's into_optimized() to hang with 100% CPU and unbounded RAM.
+    #[test]
+    #[serial]
+    fn test_embed_long_input_truncation() -> Result<()> {
+        let provider = TractProvider::new()?;
+        // ~2000 words, well beyond the 512-token limit
+        let long_text = "the quick brown fox jumps over the lazy dog ".repeat(250);
+        let embedding = provider.embed(&long_text)?;
+        assert_eq!(
+            embedding.len(),
+            768,
+            "Long input should produce 768-dim embedding after truncation"
+        );
+        // Verify it's a valid normalized vector (L2 norm ~= 1.0)
+        let l2: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (l2 - 1.0).abs() < 1e-4,
+            "Embedding should be L2-normalized, got norm {}",
+            l2
+        );
         Ok(())
     }
 }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -60,7 +60,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 use crate::embeddings::{EmbeddingProvider, TractProvider};
 
                 eprintln!("Initializing semantic search...");
-                let mut provider = TractProvider::new()?;
+                let provider = TractProvider::new()?;
                 let query_embedding = provider.embed(&query)?;
 
                 // When --tags is present the in-memory filter will thin the DB results,
@@ -1626,7 +1626,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Initialize embedding provider once
             println!("Initializing embedding model...");
-            let mut provider = TractProvider::new()?;
+            let provider = TractProvider::new()?;
 
             if all {
                 // Embed ALL entries

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -214,7 +214,7 @@ pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Resu
     };
 
     // Initialize embedding provider
-    let mut provider = TractProvider::new()?;
+    let provider = TractProvider::new()?;
 
     // Use the entry's embedding_text method (DRY - shared with other embedding paths)
     let embedding_text = entry.embedding_text();


### PR DESCRIPTION
## Summary

Fixes two bugs introduced in the tract-onnx migration (PR #335) that caused `embed()` to hang or consume ~10GB RAM per call:

- **Missing tokenizer truncation** — BGE-Base-EN-v1.5 has `max_position_embeddings=512`, but the tokenizer was loaded without truncation configured. Inputs exceeding 512 tokens caused tract's `into_optimized()` to hang (100% CPU, unbounded RAM, never completes). Fixed by enabling `TruncationParams::default()` on the tokenizer at load time.

- **Model re-optimized on every `embed()` call** — Each call cloned the raw `InferenceModel` and ran full graph optimization, using ~10GB RAM even for short inputs. Fixed by optimizing the model once at construction with fixed shape `[1, 512]`, padding inputs to 512 tokens at inference time, and reusing the pre-built `TypedRunnableModel` plan.

Also changed `EmbeddingProvider` trait methods from `&mut self` to `&self` since the pre-optimized plan's `run()` only requires a shared reference. Callsites in `src/helpers.rs` and `src/handlers/memory.rs` updated to remove unnecessary `mut`.

Includes a regression test for long-input truncation.

## Files changed

- `src/embeddings.rs` — core fix: tokenizer truncation, one-time model optimization, pad helper, regression test
- `src/handlers/memory.rs` — remove `mut` from `TractProvider` bindings
- `src/helpers.rs` — remove `mut` from `TractProvider` binding

## Test plan

- [ ] `cargo test --lib embeddings` — all four tests pass (including new `test_embed_long_input_truncation`)
- [ ] `mx memory search "test" --semantic` — semantic search completes without hanging or OOM
- [ ] Verify RAM usage stays reasonable (~500MB vs previous ~10GB per call)