### PR TITLE
feat: chunked embedding for long memory entries (#346)

### DIFF
--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1617,10 +1617,62 @@ Each entry can have a vector embedding generated from its title and
 content. Anchors are connections between entries discovered via
 embedding similarity.
 
+### Chunked embeddings
+
+Entries longer than 400 tokens are automatically split into overlapping
+chunks before embedding. This ensures semantic search covers the full
+content of long entries, not just the first 400 tokens.
+
+**How it works:**
+
+1.  The entry's embedding text (title + body/summary + tags) is
+    tokenized using the BGE-Base-EN-v1.5 tokenizer.
+
+2.  If the text fits within 400 tokens, a single embedding is generated
+    and stored on the entry --- exactly as before. No chunks are
+    created.
+
+3.  If the text exceeds 400 tokens, it is split into overlapping chunks
+    with a sliding window: 400 tokens per chunk, 100-token overlap
+    (stride 300).
+
+4.  Each chunk is embedded separately and stored in the
+    `embedding_chunk` table.
+
+5.  A normalized mean vector of all chunk embeddings is stored on the
+    entry's `embedding` field for `auto-anchor` compatibility.
+
+6.  The entry's `chunk_count` field records how many chunks were created
+    (0 for unchunked entries).
+
+**Semantic search with chunks:**
+
+When `mx memory search --semantic` runs, it queries both unchunked entry
+embeddings and chunk embeddings in parallel. Results are merged by
+taking the maximum similarity score per entry --- if a chunk from entry
+X scores 0.92 and the entry's mean vector scores 0.85, the entry's final
+score is 0.92. This ensures long entries surface when any section is
+relevant, not just when the overall average is relevant.
+
+::: {.admonition .tip}
+**TIP:** Short entries (≤400 tokens) behave exactly as before --- single
+embedding, no chunks, no behavior change. Chunking only activates for
+entries that exceed the 400-token threshold.
+:::
+
+::: {.admonition .note}
+**NOTE:** The `embedding_text()` method on entries no longer truncates
+body content. The chunker handles length management, ensuring no content
+is lost during embedding.
+:::
+
 ## `mx memory embed`
 
 Generate a vector embedding for one or all entries. Embeddings power
 semantic search (`--semantic` flag on `search`) and automatic anchoring.
+Long entries (\>400 tokens) are automatically split into overlapping
+chunks, with each chunk embedded separately. Short entries get a single
+embedding.
 
 ### Flags
 
@@ -6770,6 +6822,7 @@ All source lives under `src/`. The top-level modules declared in
        read.rs          # list, read, search operations
        migrate.rs       # v1->v2 archive migration
        notices.rs       # vault-present warnings
+     chunking.rs        # token-aware text chunking for embeddings
      embeddings.rs      # EmbeddingProvider trait, TractProvider
      kv.rs              # KV store engine (schema TOML + data JSON)
      types.rs           # shared domain types (Agent, Category, Project, etc.)
@@ -7102,9 +7155,15 @@ entry with the following field groups:
 **Embeddings:**
 
 - `embedding` (optional array\<float\>) -- 768-dim vector
-  (BGE-Base-EN-v1.5)
+  (BGE-Base-EN-v1.5). For chunked entries, this holds a normalized mean
+  vector of all chunk embeddings (used by `auto-anchor`).
 
 - `embedding_model` (optional string), `embedded_at` (optional datetime)
+
+- `chunk_count` (int, default 0) -- number of embedding chunks. Zero
+  means the entry is unchunked (single embedding). A positive value
+  means the entry was split into overlapping chunks stored in the
+  `embedding_chunk` table.
 
 ### Graph relations
 
@@ -7148,6 +7207,67 @@ vectors or 100ms query latency.
 The `EmbeddingProvider` trait in `embeddings.rs` abstracts the embedding
 backend. `TractProvider` is the sole implementation. The model cache
 location is controlled by `paths::model_cache_dir()`.
+
+#### Two-phase semantic search {#two-phase-search}
+
+Semantic search uses a two-phase strategy to cover both unchunked
+entries and chunked entries:
+
+1.  **Phase 1a**: Query unchunked entries (those with `chunk_count <= 0`
+    or absent) by cosine similarity against their `embedding` field.
+    Returns up to `limit` results.
+
+2.  **Phase 1b**: Query the `embedding_chunk` table by cosine
+    similarity. Returns up to `limit * 3` results (over-fetching for
+    deduplication).
+
+Both queries run in a single SurrealDB request (chained statements).
+
+1.  **Phase 2 (merge)**: Chunk results are deduplicated by `entry_id`,
+    keeping the maximum similarity score per entry. For each unique
+    chunk entry, the full `knowledge` record is fetched (with
+    visibility, category, and resonance filters applied). The unchunked
+    and chunk results are merged into a single scored map: if an entry
+    appears in both result sets, the higher score wins. The final list
+    is sorted by score descending and truncated to `limit`.
+
+This design means a long entry surfaces in search results if *any*
+400-token section is semantically relevant, rather than only when the
+mean vector (which averages over all sections) happens to score well.
+
+### Embedding chunks
+
+The `embedding_chunk` table stores per-chunk embeddings for long entries
+(those exceeding 400 tokens). Each row represents one chunk of a chunked
+entry:
+
+- `entry_id` (string) -- the `kn-` prefixed ID of the parent knowledge
+  entry
+
+- `chunk_index` (int) -- zero-based position within the entry's chunk
+  sequence
+
+- `chunk_text` (string) -- the decoded text of this chunk
+
+- `token_offset` (int) -- token offset from the start of the original
+  text
+
+- `token_count` (int) -- number of tokens in this chunk
+
+- `embedding` (array\<float\>) -- 768-dim vector for this chunk
+
+- `embedding_model` (string) -- model ID that generated the embedding
+
+- `created_at` (datetime)
+
+The table is indexed on `entry_id` (for bulk deletion) and uniquely
+indexed on `(entry_id, chunk_index)` (for upsert). Chunks are deleted
+and re-created on every re-embed of the parent entry. When a knowledge
+entry is deleted, its chunks are cleaned up on a best-effort basis.
+
+Chunking parameters: 400 tokens per chunk, 100-token overlap (stride
+300). These are defined in `ChunkConfig::default()` in
+`src/chunking.rs`.
 
 ### Backups
 

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1676,9 +1676,10 @@ embedding.
 
 ### Flags
 
-  **Flag**      **Type**   **Description**
-  ------------- ---------- -------------------------------------------------------
-  `-a, --all`   `flag`     Embed all knowledge entries (instead of a single ID).
+  **Flag**        **Type**   **Description**
+  --------------- ---------- --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  `-a, --all`     `flag`     Embed all knowledge entries (instead of a single ID).
+  `--long-only`   `int`      Only re-embed entries whose `embedding_text()` exceeds this many tokens. Entries at or below the threshold are skipped entirely. Use with `--all`. Useful for selectively re-embedding long entries that were previously truncated at a smaller token limit (e.g., 512).
 
 ### Examples
 
@@ -1688,6 +1689,11 @@ mx memory embed kn-abc123
 
 ``` bash
 mx memory embed --all
+```
+
+``` bash
+# Re-embed only entries that exceed 512 tokens
+mx memory embed --all --long-only 512
 ```
 
 ## `mx memory auto-anchor`

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -106,6 +106,7 @@ src/
    read.rs          # list, read, search operations
    migrate.rs       # v1->v2 archive migration
    notices.rs       # vault-present warnings
+ chunking.rs        # token-aware text chunking for embeddings
  embeddings.rs      # EmbeddingProvider trait, TractProvider
  kv.rs              # KV store engine (schema TOML + data JSON)
  types.rs           # shared domain types (Agent, Category, Project, etc.)
@@ -413,8 +414,13 @@ the following field groups:
 - `wake_order` (optional int) -- custom sequence position
 
 *Embeddings:*
-- `embedding` (optional array\<float\>) -- 768-dim vector (BGE-Base-EN-v1.5)
+- `embedding` (optional array\<float\>) -- 768-dim vector (BGE-Base-EN-v1.5).
+  For chunked entries, this holds a normalized mean vector of all chunk
+  embeddings (used by `auto-anchor`).
 - `embedding_model` (optional string), `embedded_at` (optional datetime)
+- `chunk_count` (int, default 0) -- number of embedding chunks. Zero means the
+  entry is unchunked (single embedding). A positive value means the entry was
+  split into overlapping chunks stored in the `embedding_chunk` table.
 
 === Graph relations
 
@@ -460,6 +466,53 @@ schema comment notes to reconsider when the store exceeds 50K vectors or
 The `EmbeddingProvider` trait in `embeddings.rs` abstracts the embedding
 backend. `TractProvider` is the sole implementation. The model cache
 location is controlled by `paths::model_cache_dir()`.
+
+==== Two-phase semantic search <two-phase-search>
+
+Semantic search uses a two-phase strategy to cover both unchunked entries and
+chunked entries:
+
++ *Phase 1a*: Query unchunked entries (those with `chunk_count <= 0` or absent)
+  by cosine similarity against their `embedding` field. Returns up to `limit`
+  results.
++ *Phase 1b*: Query the `embedding_chunk` table by cosine similarity. Returns
+  up to `limit * 3` results (over-fetching for deduplication).
+
+Both queries run in a single SurrealDB request (chained statements).
+
++ *Phase 2 (merge)*: Chunk results are deduplicated by `entry_id`, keeping the
+  maximum similarity score per entry. For each unique chunk entry, the full
+  `knowledge` record is fetched (with visibility, category, and resonance
+  filters applied). The unchunked and chunk results are merged into a single
+  scored map: if an entry appears in both result sets, the higher score wins.
+  The final list is sorted by score descending and truncated to `limit`.
+
+This design means a long entry surfaces in search results if _any_ 400-token
+section is semantically relevant, rather than only when the mean vector (which
+averages over all sections) happens to score well.
+
+=== Embedding chunks
+
+The `embedding_chunk` table stores per-chunk embeddings for long entries
+(those exceeding 400 tokens). Each row represents one chunk of a chunked
+entry:
+
+- `entry_id` (string) -- the `kn-` prefixed ID of the parent knowledge entry
+- `chunk_index` (int) -- zero-based position within the entry's chunk sequence
+- `chunk_text` (string) -- the decoded text of this chunk
+- `token_offset` (int) -- token offset from the start of the original text
+- `token_count` (int) -- number of tokens in this chunk
+- `embedding` (array\<float\>) -- 768-dim vector for this chunk
+- `embedding_model` (string) -- model ID that generated the embedding
+- `created_at` (datetime)
+
+The table is indexed on `entry_id` (for bulk deletion) and uniquely indexed on
+`(entry_id, chunk_index)` (for upsert). Chunks are deleted and re-created on
+every re-embed of the parent entry. When a knowledge entry is deleted, its
+chunks are cleaned up on a best-effort basis.
+
+Chunking parameters: 400 tokens per chunk, 100-token overlap (stride 300).
+These are defined in `ChunkConfig::default()` in `src/chunking.rs`.
 
 === Backups
 

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -404,10 +404,49 @@ Embeddings enable semantic search and automatic relationship discovery.
 Each entry can have a vector embedding generated from its title and content.
 Anchors are connections between entries discovered via embedding similarity.
 
+=== Chunked embeddings <chunked-embeddings>
+
+Entries longer than 400 tokens are automatically split into overlapping chunks
+before embedding. This ensures semantic search covers the full content of long
+entries, not just the first 400 tokens.
+
+*How it works:*
+
++ The entry's embedding text (title + body/summary + tags) is tokenized using
+  the BGE-Base-EN-v1.5 tokenizer.
++ If the text fits within 400 tokens, a single embedding is generated and
+  stored on the entry --- exactly as before. No chunks are created.
++ If the text exceeds 400 tokens, it is split into overlapping chunks with a
+  sliding window: 400 tokens per chunk, 100-token overlap (stride 300).
++ Each chunk is embedded separately and stored in the `embedding_chunk` table.
++ A normalized mean vector of all chunk embeddings is stored on the entry's
+  `embedding` field for `auto-anchor` compatibility.
++ The entry's `chunk_count` field records how many chunks were created (0 for
+  unchunked entries).
+
+*Semantic search with chunks:*
+
+When `mx memory search --semantic` runs, it queries both unchunked entry
+embeddings and chunk embeddings in parallel. Results are merged by taking the
+maximum similarity score per entry --- if a chunk from entry X scores 0.92 and
+the entry's mean vector scores 0.85, the entry's final score is 0.92. This
+ensures long entries surface when any section is relevant, not just when the
+overall average is relevant.
+
+#tip[Short entries (≤400 tokens) behave exactly as before --- single embedding,
+no chunks, no behavior change. Chunking only activates for entries that exceed
+the 400-token threshold.]
+
+#note[The `embedding_text()` method on entries no longer truncates body content.
+The chunker handles length management, ensuring no content is lost during
+embedding.]
+
 #command(
   "mx memory embed",
   [Generate a vector embedding for one or all entries. Embeddings power
-  semantic search (`--semantic` flag on `search`) and automatic anchoring.],
+  semantic search (`--semantic` flag on `search`) and automatic anchoring.
+  Long entries (>400 tokens) are automatically split into overlapping chunks,
+  with each chunk embedded separately. Short entries get a single embedding.],
   flags: (
     ([`-a, --all`], [`flag`], [Embed all knowledge entries (instead of a single ID).]),
   ),

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -449,10 +449,12 @@ embedding.]
   with each chunk embedded separately. Short entries get a single embedding.],
   flags: (
     ([`-a, --all`], [`flag`], [Embed all knowledge entries (instead of a single ID).]),
+    ([`--long-only`], [`int`], [Only re-embed entries whose `embedding_text()` exceeds this many tokens. Entries at or below the threshold are skipped entirely. Use with `--all`. Useful for selectively re-embedding long entries that were previously truncated at a smaller token limit (e.g., 512).]),
   ),
   examples: (
     "mx memory embed kn-abc123",
     "mx memory embed --all",
+    "# Re-embed only entries that exceed 512 tokens\nmx memory embed --all --long-only 512",
   ),
 )
 

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -145,6 +145,9 @@ DEFINE FIELD IF NOT EXISTS embedding ON knowledge TYPE option<array<float>>;
 DEFINE FIELD IF NOT EXISTS embedding_model ON knowledge TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS embedded_at ON knowledge TYPE option<datetime>;
 
+-- Embedding chunk count (Issue #346)
+DEFINE FIELD IF NOT EXISTS chunk_count ON knowledge TYPE int DEFAULT 0;
+
 -- Issue #122: Stele encoding format
 DEFINE FIELD IF NOT EXISTS format ON knowledge TYPE string DEFAULT 'markdown'
   ASSERT $value IN ['markdown', 'json', 'stele:markdown', 'stele:ascii', 'stele:light', 'stele:full'];
@@ -241,6 +244,24 @@ DEFINE FIELD IF NOT EXISTS created_at   ON memory_backup TYPE datetime DEFAULT t
 DEFINE INDEX IF NOT EXISTS backup_entry_id   ON memory_backup FIELDS entry_id;
 DEFINE INDEX IF NOT EXISTS backup_created    ON memory_backup FIELDS created_at;
 DEFINE INDEX IF NOT EXISTS backup_entry_time ON memory_backup FIELDS entry_id, created_at;
+
+-- =============================================================================
+-- EMBEDDING CHUNKS (Issue #346)
+-- =============================================================================
+-- Chunked embeddings for long entries (>400 tokens). Each chunk is embedded
+-- separately so semantic search covers the full content.
+
+DEFINE TABLE IF NOT EXISTS embedding_chunk SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS entry_id ON embedding_chunk TYPE string;
+DEFINE FIELD IF NOT EXISTS chunk_index ON embedding_chunk TYPE int;
+DEFINE FIELD IF NOT EXISTS chunk_text ON embedding_chunk TYPE string;
+DEFINE FIELD IF NOT EXISTS token_offset ON embedding_chunk TYPE int;
+DEFINE FIELD IF NOT EXISTS token_count ON embedding_chunk TYPE int;
+DEFINE FIELD IF NOT EXISTS embedding ON embedding_chunk TYPE array<float>;
+DEFINE FIELD IF NOT EXISTS embedding_model ON embedding_chunk TYPE string;
+DEFINE FIELD IF NOT EXISTS created_at ON embedding_chunk TYPE datetime DEFAULT time::now();
+DEFINE INDEX IF NOT EXISTS chunk_entry_id ON embedding_chunk FIELDS entry_id;
+DEFINE INDEX IF NOT EXISTS chunk_entry_idx ON embedding_chunk FIELDS entry_id, chunk_index UNIQUE;
 
 -- =============================================================================
 -- METADATA TABLES

--- a/src/chunking.rs
+++ b/src/chunking.rs
@@ -161,6 +161,16 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_text_single_chunk() {
+        let tokenizer = test_tokenizer();
+        let config = ChunkConfig::default();
+        let chunks = chunk_text("", &tokenizer, &config);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].token_count, 0);
+        assert_eq!(chunks[0].chunk_index, 0);
+    }
+
+    #[test]
     fn test_exact_boundary() {
         let tokenizer = test_tokenizer();
         let config = ChunkConfig {

--- a/src/chunking.rs
+++ b/src/chunking.rs
@@ -1,0 +1,179 @@
+use tokenizers::Tokenizer;
+
+/// Configuration for token-aware text chunking.
+pub struct ChunkConfig {
+    /// Maximum tokens per chunk.
+    pub max_tokens: usize,
+    /// Number of overlapping tokens between consecutive chunks.
+    pub overlap_tokens: usize,
+}
+
+impl Default for ChunkConfig {
+    fn default() -> Self {
+        Self {
+            max_tokens: 400,
+            overlap_tokens: 100,
+        }
+    }
+}
+
+/// A single chunk of text with its token-level metadata.
+pub struct TextChunk {
+    /// The decoded text for this chunk.
+    pub text: String,
+    /// Token offset from the start of the original text.
+    pub token_offset: usize,
+    /// Number of tokens in this chunk.
+    pub token_count: usize,
+    /// Zero-based chunk index.
+    pub chunk_index: usize,
+}
+
+/// Split text into overlapping token-aware chunks.
+///
+/// If the text fits within `config.max_tokens`, returns a single chunk
+/// containing the full text. Otherwise, produces a sliding window of
+/// chunks with stride = `max_tokens - overlap_tokens`.
+///
+/// Uses `tokenizer.encode(text, false)` (no special tokens) so that
+/// the embedding provider can add its own [CLS]/[SEP] tokens during
+/// inference.
+pub fn chunk_text(text: &str, tokenizer: &Tokenizer, config: &ChunkConfig) -> Vec<TextChunk> {
+    let encoding = tokenizer
+        .encode(text, false)
+        .expect("tokenizer.encode should not fail on valid text");
+
+    let all_ids = encoding.get_ids();
+    let total_tokens = all_ids.len();
+
+    // Base case: fits in a single chunk.
+    if total_tokens <= config.max_tokens {
+        return vec![TextChunk {
+            text: text.to_string(),
+            token_offset: 0,
+            token_count: total_tokens,
+            chunk_index: 0,
+        }];
+    }
+
+    let stride = config.max_tokens.saturating_sub(config.overlap_tokens);
+    // Guard against zero stride (would cause infinite loop).
+    let stride = if stride == 0 { 1 } else { stride };
+
+    let mut chunks = Vec::new();
+    let mut offset = 0usize;
+    let mut chunk_index = 0usize;
+
+    while offset < total_tokens {
+        let end = (offset + config.max_tokens).min(total_tokens);
+        let chunk_ids: Vec<u32> = all_ids[offset..end].to_vec();
+        let chunk_token_count = chunk_ids.len();
+
+        let decoded = tokenizer
+            .decode(&chunk_ids, true)
+            .expect("tokenizer.decode should not fail on valid IDs");
+
+        chunks.push(TextChunk {
+            text: decoded,
+            token_offset: offset,
+            token_count: chunk_token_count,
+            chunk_index,
+        });
+
+        offset += stride;
+        chunk_index += 1;
+    }
+
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a tokenizer for testing (same model as TractProvider).
+    fn test_tokenizer() -> Tokenizer {
+        let cache_dir = crate::paths::model_cache_dir();
+        let api = hf_hub::api::sync::ApiBuilder::new()
+            .with_cache_dir(cache_dir)
+            .build()
+            .expect("HF Hub API");
+        let repo = api.model("Xenova/bge-base-en-v1.5".to_string());
+        let tokenizer_path = repo.get("tokenizer.json").expect("tokenizer.json");
+        Tokenizer::from_file(&tokenizer_path).expect("load tokenizer")
+    }
+
+    #[test]
+    fn test_short_text_single_chunk() {
+        let tokenizer = test_tokenizer();
+        let config = ChunkConfig::default();
+        let chunks = chunk_text("Hello, world!", &tokenizer, &config);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert_eq!(chunks[0].token_offset, 0);
+        assert_eq!(chunks[0].text, "Hello, world!");
+    }
+
+    #[test]
+    fn test_long_text_multiple_chunks() {
+        let tokenizer = test_tokenizer();
+        let config = ChunkConfig::default();
+        // ~2000 tokens, well over the 400 limit
+        let long_text = "the quick brown fox jumps over the lazy dog ".repeat(250);
+        let chunks = chunk_text(&long_text, &tokenizer, &config);
+
+        assert!(chunks.len() > 1, "Expected multiple chunks, got {}", chunks.len());
+
+        // Verify chunk indices are sequential
+        for (i, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.chunk_index, i);
+        }
+
+        // Verify first chunk starts at offset 0
+        assert_eq!(chunks[0].token_offset, 0);
+
+        // Verify each chunk respects max_tokens
+        for chunk in &chunks {
+            assert!(
+                chunk.token_count <= config.max_tokens,
+                "Chunk {} has {} tokens, exceeding max {}",
+                chunk.chunk_index,
+                chunk.token_count,
+                config.max_tokens
+            );
+        }
+
+        // Verify overlap: each subsequent chunk's offset should be
+        // previous chunk's offset + stride (300)
+        let stride = config.max_tokens - config.overlap_tokens;
+        for i in 1..chunks.len() {
+            let expected_offset = i * stride;
+            assert_eq!(
+                chunks[i].token_offset, expected_offset,
+                "Chunk {} offset {} != expected {}",
+                i, chunks[i].token_offset, expected_offset
+            );
+        }
+    }
+
+    #[test]
+    fn test_exact_boundary() {
+        let tokenizer = test_tokenizer();
+        let config = ChunkConfig {
+            max_tokens: 10,
+            overlap_tokens: 3,
+        };
+        // Exactly 10 tokens should produce a single chunk
+        // "one two three four five six seven eight nine ten" is likely ~10 tokens
+        let text = "one two three four five six seven eight nine ten";
+        let encoding = tokenizer.encode(text, false).unwrap();
+        let total = encoding.get_ids().len();
+
+        let chunks = chunk_text(text, &tokenizer, &config);
+        if total <= 10 {
+            assert_eq!(chunks.len(), 1);
+        } else {
+            assert!(chunks.len() > 1);
+        }
+    }
+}

--- a/src/chunking.rs
+++ b/src/chunking.rs
@@ -150,12 +150,12 @@ mod tests {
         // Verify overlap: each subsequent chunk's offset should be
         // previous chunk's offset + stride (300)
         let stride = config.max_tokens - config.overlap_tokens;
-        for i in 1..chunks.len() {
+        for (i, chunk) in chunks.iter().enumerate().skip(1) {
             let expected_offset = i * stride;
             assert_eq!(
-                chunks[i].token_offset, expected_offset,
+                chunk.token_offset, expected_offset,
                 "Chunk {} offset {} != expected {}",
-                i, chunks[i].token_offset, expected_offset
+                i, chunk.token_offset, expected_offset
             );
         }
     }

--- a/src/chunking.rs
+++ b/src/chunking.rs
@@ -122,7 +122,11 @@ mod tests {
         let long_text = "the quick brown fox jumps over the lazy dog ".repeat(250);
         let chunks = chunk_text(&long_text, &tokenizer, &config);
 
-        assert!(chunks.len() > 1, "Expected multiple chunks, got {}", chunks.len());
+        assert!(
+            chunks.len() > 1,
+            "Expected multiple chunks, got {}",
+            chunks.len()
+        );
 
         // Verify chunk indices are sequential
         for (i, chunk) in chunks.iter().enumerate() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -868,6 +868,10 @@ pub enum MemoryCommands {
         /// Embed all knowledge entries
         #[arg(short, long)]
         all: bool,
+
+        /// Only re-embed entries longer than this many tokens (use with --all)
+        #[arg(long)]
+        long_only: Option<usize>,
     },
 
     /// Automatically add anchors based on embedding similarity.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -869,7 +869,10 @@ pub enum MemoryCommands {
         #[arg(short, long)]
         all: bool,
 
-        /// Only re-embed entries longer than this many tokens (use with --all)
+        /// Only re-embed entries whose embedding text exceeds N tokens (use with --all).
+        /// Entries at or below the threshold are skipped entirely.
+        /// Useful for selectively re-embedding long entries that were previously
+        /// truncated at a smaller token limit (e.g., 512).
         #[arg(long)]
         long_only: Option<usize>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -873,7 +873,7 @@ pub enum MemoryCommands {
         /// Entries at or below the threshold are skipped entirely.
         /// Useful for selectively re-embedding long entries that were previously
         /// truncated at a smaller token limit (e.g., 512).
-        #[arg(long)]
+        #[arg(long, requires = "all")]
         long_only: Option<usize>,
     },
 

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -34,6 +34,11 @@ pub struct TractProvider {
 }
 
 impl TractProvider {
+    /// Access the underlying tokenizer (used by the chunker).
+    pub fn tokenizer(&self) -> &Tokenizer {
+        &self.tokenizer
+    }
+
     pub fn new() -> Result<Self> {
         let cache_dir = crate::paths::model_cache_dir();
 

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -20,6 +20,26 @@ pub trait EmbeddingProvider: Send + Sync {
     fn model_id(&self) -> &str;
 }
 
+/// Load just the tokenizer (no ONNX model). Used for token counting
+/// without the overhead of model initialization.
+pub fn load_tokenizer() -> Result<Tokenizer> {
+    let cache_dir = crate::paths::model_cache_dir();
+    let api = hf_hub::api::sync::ApiBuilder::new()
+        .with_cache_dir(cache_dir)
+        .build()
+        .context("Failed to initialize HF Hub API")?;
+    let repo = api.model("Xenova/bge-base-en-v1.5".to_string());
+    let tokenizer_path = repo
+        .get("tokenizer.json")
+        .context("Failed to fetch tokenizer from HF Hub")?;
+    let mut tokenizer = Tokenizer::from_file(&tokenizer_path)
+        .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
+    tokenizer
+        .with_truncation(None)
+        .map_err(|e| anyhow::anyhow!("Failed to configure truncation: {}", e))?;
+    Ok(tokenizer)
+}
+
 /// Tract-ONNX provider using BGE-Base-EN-v1.5 (pure Rust, no C++ ONNX Runtime)
 ///
 /// The model is optimized once at construction time with a fixed input shape

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1644,7 +1644,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     if let Some(min_tokens) = long_only {
                         if let Some(ref tok) = tokenizer {
                             let text = entry.embedding_text();
-                            let encoding = tok.encode(text.as_str(), false)
+                            let encoding = tok
+                                .encode(text.as_str(), false)
                                 .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
                             if encoding.get_ids().len() <= min_tokens {
                                 skipped += 1;
@@ -1658,7 +1659,10 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     embedded += 1;
                 }
                 if long_only.is_some() {
-                    println!("Embedded {} entries ({} skipped below threshold)", embedded, skipped);
+                    println!(
+                        "Embedded {} entries ({} skipped below threshold)",
+                        embedded, skipped
+                    );
                 } else {
                     println!("All {} entries embedded!", total);
                 }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1641,16 +1641,16 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 println!("Found {} entries to embed", total);
                 for (idx, entry) in entries.iter().enumerate() {
                     // Check token count if --long-only is specified
-                    if let Some(min_tokens) = long_only {
-                        if let Some(ref tok) = tokenizer {
-                            let text = entry.embedding_text();
-                            let encoding = tok
-                                .encode(text.as_str(), false)
-                                .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
-                            if encoding.get_ids().len() <= min_tokens {
-                                skipped += 1;
-                                continue;
-                            }
+                    if let Some(min_tokens) = long_only
+                        && let Some(ref tok) = tokenizer
+                    {
+                        let text = entry.embedding_text();
+                        let encoding = tok
+                            .encode(text.as_str(), false)
+                            .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
+                        if encoding.get_ids().len() <= min_tokens {
+                            skipped += 1;
+                            continue;
                         }
                     }
 

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1615,7 +1615,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             }
         }
 
-        MemoryCommands::Embed { id, all } => {
+        MemoryCommands::Embed { id, all, long_only } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
 
             // Use current agent context for private entry access
@@ -1627,12 +1627,41 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             if all {
                 let entries = db.list_all(&ctx)?;
                 let total = entries.len();
+
+                // If --long-only is specified, load tokenizer for token counting
+                let tokenizer = if long_only.is_some() {
+                    Some(crate::embeddings::load_tokenizer()?)
+                } else {
+                    None
+                };
+
+                let mut embedded = 0;
+                let mut skipped = 0;
+
                 println!("Found {} entries to embed", total);
                 for (idx, entry) in entries.iter().enumerate() {
+                    // Check token count if --long-only is specified
+                    if let Some(min_tokens) = long_only {
+                        if let Some(ref tok) = tokenizer {
+                            let text = entry.embedding_text();
+                            let encoding = tok.encode(text.as_str(), false)
+                                .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
+                            if encoding.get_ids().len() <= min_tokens {
+                                skipped += 1;
+                                continue;
+                            }
+                        }
+                    }
+
                     println!("Embedding {}/{}: {}", idx + 1, total, entry.title);
                     crate::helpers::auto_embed(&entry.id, db.as_ref())?;
+                    embedded += 1;
                 }
-                println!("All {} entries embedded!", total);
+                if long_only.is_some() {
+                    println!("Embedded {} entries ({} skipped below threshold)", embedded, skipped);
+                } else {
+                    println!("All {} entries embedded!", total);
+                }
             } else {
                 let entry_id = id.ok_or_else(|| {
                     anyhow::anyhow!("Entry ID required (use --all to embed all entries)")

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1655,7 +1655,12 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     }
 
                     embedded += 1;
-                    println!("Embedding {}/{}: {}", embedded, total - skipped, entry.title);
+                    println!(
+                        "Embedding {}/{}: {}",
+                        embedded,
+                        total - skipped,
+                        entry.title
+                    );
                     crate::helpers::auto_embed(&entry.id, db.as_ref())?;
                 }
                 if long_only.is_some() {

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1639,7 +1639,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 let mut skipped = 0;
 
                 println!("Found {} entries to embed", total);
-                for (idx, entry) in entries.iter().enumerate() {
+                for entry in &entries {
                     // Check token count if --long-only is specified
                     if let Some(min_tokens) = long_only
                         && let Some(ref tok) = tokenizer
@@ -1654,9 +1654,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         }
                     }
 
-                    println!("Embedding {}/{}: {}", idx + 1, total, entry.title);
-                    crate::helpers::auto_embed(&entry.id, db.as_ref())?;
                     embedded += 1;
+                    println!("Embedding {}/{}: {}", embedded, total - skipped, entry.title);
+                    crate::helpers::auto_embed(&entry.id, db.as_ref())?;
                 }
                 if long_only.is_some() {
                     println!(

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -548,6 +548,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     embedding: None,
                     embedding_model: None,
                     embedded_at: None,
+                    chunk_count: 0,
                     format: "markdown".to_string(),
                     effective_resonance: None,
                 };
@@ -718,6 +719,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 embedding: None,
                 embedding_model: None,
                 embedded_at: None,
+                chunk_count: 0,
                 format: "markdown".to_string(),
                 effective_resonance: None,
             };
@@ -1614,8 +1616,6 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
         }
 
         MemoryCommands::Embed { id, all } => {
-            use crate::embeddings::{EmbeddingProvider, TractProvider};
-
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
 
             // Use current agent context for private entry access
@@ -1624,93 +1624,25 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 _ => store::AgentContext::public_only(),
             };
 
-            // Initialize embedding provider once
-            println!("Initializing embedding model...");
-            let provider = TractProvider::new()?;
-
             if all {
-                // Embed ALL entries
                 let entries = db.list_all(&ctx)?;
                 let total = entries.len();
-
                 println!("Found {} entries to embed", total);
-
-                for (idx, mut entry) in entries.into_iter().enumerate() {
-                    // Construct embedding text from title + summary/body + tags
-                    let mut parts = vec![entry.title.clone()];
-
-                    if let Some(summary) = &entry.summary {
-                        parts.push(summary.clone());
-                    } else if let Some(body) = &entry.body {
-                        parts.push(body.chars().take(2000).collect());
-                    }
-
-                    if !entry.tags.is_empty() {
-                        parts.push(format!("Tags: {}", entry.tags.join(", ")));
-                    }
-
-                    let embedding_text = parts.join("\n\n");
-
-                    // Generate embedding
-                    println!("Embedded {}/{}: {}", idx + 1, total, entry.title);
-                    let embedding = provider.embed(&embedding_text)?;
-
-                    // Update entry with embedding
-                    entry.embedding = Some(embedding);
-                    entry.embedding_model = Some(provider.model_id().to_string());
-                    entry.embedded_at = Some(chrono::Utc::now().to_rfc3339());
-                    entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
-
-                    // Save to database
-                    db.upsert_knowledge(&entry)?;
+                for (idx, entry) in entries.iter().enumerate() {
+                    println!("Embedding {}/{}: {}", idx + 1, total, entry.title);
+                    crate::helpers::auto_embed(&entry.id, db.as_ref())?;
                 }
-
-                println!("✓ All {} entries embedded successfully!", total);
-                println!("  Model: {}", provider.model_id());
-                println!("  Dimensions: {}", provider.dimensions());
+                println!("All {} entries embedded!", total);
             } else {
-                // Embed single entry
                 let entry_id = id.ok_or_else(|| {
                     anyhow::anyhow!("Entry ID required (use --all to embed all entries)")
                 })?;
-
-                // Fetch entry
-                let mut entry = db
+                let entry = db
                     .get(&entry_id, &ctx)?
                     .ok_or_else(|| anyhow::anyhow!("Entry not found: {}", entry_id))?;
-
-                // Construct embedding text from title + summary/body + tags
-                let mut parts = vec![entry.title.clone()];
-
-                if let Some(summary) = &entry.summary {
-                    parts.push(summary.clone());
-                } else if let Some(body) = &entry.body {
-                    parts.push(body.chars().take(2000).collect());
-                }
-
-                if !entry.tags.is_empty() {
-                    parts.push(format!("Tags: {}", entry.tags.join(", ")));
-                }
-
-                let embedding_text = parts.join("\n\n");
-
-                // Generate embedding
                 println!("Generating embedding for '{}'...", entry.title);
-                let embedding = provider.embed(&embedding_text)?;
-
-                // Update entry with embedding
-                entry.embedding = Some(embedding);
-                entry.embedding_model = Some(provider.model_id().to_string());
-                entry.embedded_at = Some(chrono::Utc::now().to_rfc3339());
-                entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
-
-                // Save to database
-                db.upsert_knowledge(&entry)?;
-
-                println!("✓ Embedding generated and saved!");
-                println!("  Entry: {}", entry_id);
-                println!("  Model: {}", provider.model_id());
-                println!("  Dimensions: {}", provider.dimensions());
+                crate::helpers::auto_embed(&entry.id, db.as_ref())?;
+                println!("Embedding generated and saved for: {}", entry_id);
             }
         }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -195,41 +195,89 @@ pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     dot_product / (magnitude_a * magnitude_b)
 }
 
-/// Auto-embed a knowledge entry after add/update
+/// Auto-embed a knowledge entry after add/update.
 ///
-/// This silently generates and updates the embedding for a single entry.
+/// For short entries (<=400 tokens): stores a single embedding on the entry.
+/// For long entries (>400 tokens): splits into overlapping chunks, embeds each
+/// chunk separately, stores chunks in `embedding_chunk` table, and stores a
+/// mean vector on the entry for auto_anchor compatibility.
 pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Result<()> {
+    use crate::chunking::{chunk_text, ChunkConfig};
     use crate::embeddings::{EmbeddingProvider, TractProvider};
 
-    // Get agent context for fetching the entry
     let ctx = match std::env::var("MX_CURRENT_AGENT") {
         Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
         _ => store::AgentContext::public_only(),
     };
 
-    // Fetch the entry
     let mut entry = match db.get(entry_id, &ctx)? {
         Some(e) => e,
-        None => return Ok(()), // Entry not found, skip silently
+        None => return Ok(()),
     };
 
-    // Initialize embedding provider
     let provider = TractProvider::new()?;
-
-    // Use the entry's embedding_text method (DRY - shared with other embedding paths)
     let embedding_text = entry.embedding_text();
+    let config = ChunkConfig::default();
+    let chunks = chunk_text(&embedding_text, provider.tokenizer(), &config);
 
-    // Generate embedding
-    let embedding = provider.embed(&embedding_text)?;
+    if chunks.len() == 1 {
+        // Short entry: single embedding, no chunks
+        let embedding = provider.embed(&chunks[0].text)?;
+        entry.embedding = Some(embedding);
+        entry.embedding_model = Some(provider.model_id().to_string());
+        entry.embedded_at = Some(chrono::Utc::now().to_rfc3339());
+        entry.chunk_count = 0;
+        entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
+        db.upsert_knowledge(&entry)?;
+        db.delete_embedding_chunks(entry_id)?; // clean up any stale chunks
+    } else {
+        // Long entry: chunk, embed each, store chunks + mean vector on entry
+        let mut chunk_embeddings = Vec::with_capacity(chunks.len());
+        for chunk in &chunks {
+            chunk_embeddings.push(provider.embed(&chunk.text)?);
+        }
 
-    // Update entry with embedding
-    entry.embedding = Some(embedding);
-    entry.embedding_model = Some(provider.model_id().to_string());
-    entry.embedded_at = Some(chrono::Utc::now().to_rfc3339());
-    entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
+        // Store chunks (delete-then-insert)
+        db.delete_embedding_chunks(entry_id)?;
+        for (chunk, embedding) in chunks.iter().zip(chunk_embeddings.iter()) {
+            db.insert_embedding_chunk(
+                entry_id,
+                chunk.chunk_index,
+                &chunk.text,
+                chunk.token_offset,
+                chunk.token_count,
+                embedding,
+                provider.model_id(),
+            )?;
+        }
 
-    // Save to database
-    db.upsert_knowledge(&entry)?;
+        // Mean vector on entry (for auto_anchor compatibility)
+        let dims = provider.dimensions();
+        let mut mean_vec = vec![0.0f32; dims];
+        for emb in &chunk_embeddings {
+            for (i, v) in emb.iter().enumerate() {
+                mean_vec[i] += v;
+            }
+        }
+        let n = chunk_embeddings.len() as f32;
+        for v in mean_vec.iter_mut() {
+            *v /= n;
+        }
+        // L2 normalize
+        let l2: f32 = mean_vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if l2 > 0.0 {
+            for v in mean_vec.iter_mut() {
+                *v /= l2;
+            }
+        }
+
+        entry.embedding = Some(mean_vec);
+        entry.embedding_model = Some(provider.model_id().to_string());
+        entry.embedded_at = Some(chrono::Utc::now().to_rfc3339());
+        entry.chunk_count = chunks.len() as i32;
+        entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
+        db.upsert_knowledge(&entry)?;
+    }
 
     Ok(())
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -202,7 +202,7 @@ pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 /// chunk separately, stores chunks in `embedding_chunk` table, and stores a
 /// mean vector on the entry for auto_anchor compatibility.
 pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Result<()> {
-    use crate::chunking::{chunk_text, ChunkConfig};
+    use crate::chunking::{ChunkConfig, chunk_text};
     use crate::embeddings::{EmbeddingProvider, TractProvider};
 
     let ctx = match std::env::var("MX_CURRENT_AGENT") {

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -90,6 +90,10 @@ pub struct KnowledgeEntry {
     #[serde(default)]
     pub embedded_at: Option<String>, // RFC3339 timestamp when embedded
 
+    // Embedding chunks (Issue #346)
+    #[serde(default)]
+    pub chunk_count: i32,
+
     // Stele encoding format (Issue #122)
     #[serde(default = "default_format")]
     pub format: String, // markdown (default), json, stele:markdown, stele:ascii, stele:light, stele:full
@@ -138,8 +142,7 @@ impl KnowledgeEntry {
         if let Some(summary) = &self.summary {
             parts.push(summary.clone());
         } else if let Some(body) = &self.body {
-            // Truncate body to avoid overwhelming the embedding model
-            parts.push(body.chars().take(2000).collect());
+            parts.push(body.clone());
         }
 
         if !self.tags.is_empty() {
@@ -272,6 +275,7 @@ mod tests {
             embedding: None,
             embedding_model: None,
             embedded_at: None,
+            chunk_count: 0,
             format: "markdown".to_string(),
             effective_resonance: None,
         };
@@ -317,6 +321,7 @@ mod tests {
             embedding: None,
             embedding_model: None,
             embedded_at: None,
+            chunk_count: 0,
             format: "markdown".to_string(),
             effective_resonance: None,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+mod chunking;
 mod cli;
 mod codex;
 mod commit;

--- a/src/store.rs
+++ b/src/store.rs
@@ -214,6 +214,32 @@ pub trait KnowledgeStore {
     ) -> Result<Option<ReinforcementResult>>;
 
     // =========================================================================
+    // EMBEDDING CHUNK OPERATIONS (Issue #346)
+    // =========================================================================
+
+    /// Delete all embedding chunks for a knowledge entry
+    fn delete_embedding_chunks(&self, entry_id: &str) -> Result<()>;
+
+    /// Insert a single embedding chunk for a knowledge entry
+    fn insert_embedding_chunk(
+        &self,
+        entry_id: &str,
+        chunk_index: usize,
+        chunk_text: &str,
+        token_offset: usize,
+        token_count: usize,
+        embedding: &[f32],
+        model_id: &str,
+    ) -> Result<()>;
+
+    /// Search embedding chunks by vector similarity, returning (entry_id, score) pairs
+    fn semantic_search_chunks(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>>;
+
+    // =========================================================================
     // CONTENT PATCH OPERATIONS
     // =========================================================================
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -221,6 +221,7 @@ pub trait KnowledgeStore {
     fn delete_embedding_chunks(&self, entry_id: &str) -> Result<()>;
 
     /// Insert a single embedding chunk for a knowledge entry
+    #[allow(clippy::too_many_arguments)]
     fn insert_embedding_chunk(
         &self,
         entry_id: &str,

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -139,6 +139,11 @@ pub(super) struct SurrealKnowledgeRecord {
     #[serde(default)]
     pub embedded_at: Option<String>,
 
+    // === Embedding chunks (Issue #346) ===
+    /// Number of embedding chunks (0 = unchunked)
+    #[serde(default)]
+    pub chunk_count: i32,
+
     // === Stele encoding (Issue #122) ===
     /// Content format: markdown (default), json, stele:markdown, stele:ascii, stele:light, stele:full
     #[serde(default = "default_format")]
@@ -193,6 +198,7 @@ impl SurrealKnowledgeRecord {
             embedding: self.embedding,
             embedding_model: self.embedding_model,
             embedded_at: self.embedded_at,
+            chunk_count: self.chunk_count,
             format: self.format,
             effective_resonance: None,
         }
@@ -224,6 +230,7 @@ impl SurrealDatabase {
         IF embedding THEN embedding ELSE null END AS embedding,
         IF embedding_model THEN embedding_model ELSE null END AS embedding_model,
         IF embedded_at THEN <string>embedded_at ELSE null END AS embedded_at,
+        IF chunk_count THEN chunk_count ELSE 0 END AS chunk_count,
         IF format THEN format ELSE 'markdown' END AS format"
     }
 
@@ -378,6 +385,7 @@ impl SurrealDatabase {
             wake_phrase = $wake_phrase,
             embedding = $embedding,
             embedding_model = $embedding_model,
+            chunk_count = $chunk_count,
             format = $format"
             .to_string();
 
@@ -452,6 +460,7 @@ impl SurrealDatabase {
                 .bind(("wake_phrase", entry.wake_phrase.clone()))
                 .bind(("embedding", entry.embedding.clone()))
                 .bind(("embedding_model", entry.embedding_model.clone()))
+                .bind(("chunk_count", entry.chunk_count))
                 .bind(("format", entry.format.clone()));
 
             // Bind optional parameters
@@ -716,6 +725,12 @@ impl SurrealDatabase {
             return Err(anyhow::anyhow!("Delete failed: {:?}", errors));
         }
 
+        // Best-effort cleanup of embedding chunks (Issue #346)
+        let full_entry_id = format!("kn-{}", id_part);
+        self.delete_embedding_chunks_async(&full_entry_id)
+            .await
+            .ok();
+
         Ok(true)
     }
 
@@ -799,11 +814,11 @@ impl SurrealDatabase {
         let resonance_clause = Self::build_resonance_filter(filter);
         let category_clause = Self::build_category_filter(filter);
 
-        // Brute force vector similarity search (no HNSW index)
-        let sql = format!(
+        // Phase 1a: Search unchunked entries (chunk_count <= 0 or absent)
+        let unchunked_sql = format!(
             "SELECT {}, vector::similarity::cosine(embedding, $query_vec) AS score
             FROM knowledge
-            WHERE embedding IS NOT NONE {} {} {}
+            WHERE embedding IS NOT NONE AND (chunk_count IS NONE OR chunk_count <= 0) {} {} {}
             ORDER BY score DESC
             LIMIT $limit",
             Self::knowledge_select_fields(),
@@ -812,12 +827,22 @@ impl SurrealDatabase {
             category_clause
         );
 
+        // Phase 1b: Search chunks (no visibility filter — applied after dedup)
+        let chunk_sql = "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
+            FROM embedding_chunk
+            ORDER BY score DESC
+            LIMIT $chunk_limit";
+
+        let chunk_limit = limit * 3; // over-fetch for dedup
+
         let mut response = with_db!(self, db, {
             let mut query_builder = db
-                .query(&sql)
+                .query(&unchunked_sql)
+                .query(chunk_sql)
                 .bind(("query_vec", query_embedding.to_vec()))
-                .bind(("limit", limit));
-            if let Some(agent) = current_agent {
+                .bind(("limit", limit))
+                .bind(("chunk_limit", chunk_limit));
+            if let Some(agent) = current_agent.clone() {
                 query_builder = query_builder.bind(("current_agent", agent));
             }
             query_builder
@@ -825,16 +850,84 @@ impl SurrealDatabase {
                 .context("Failed to execute semantic search query")
         })?;
 
-        let results: Vec<serde_json::Value> = response
+        // Parse unchunked results (statement 0)
+        let unchunked_results: Vec<serde_json::Value> = response
             .take(0)
-            .context("Failed to parse semantic search results")?;
+            .context("Failed to parse unchunked search results")?;
 
-        let mut entries = Vec::new();
-        for obj in results {
-            entries.push(self.value_to_knowledge_entry(obj).await?);
+        // Parse chunk results (statement 1)
+        let chunk_results: Vec<serde_json::Value> = response
+            .take(1)
+            .context("Failed to parse chunk search results")?;
+
+        // Phase 2: Merge results
+        // Collect unchunked entries with their scores
+        let mut scored_entries: std::collections::HashMap<String, (f32, Option<KnowledgeEntry>)> =
+            std::collections::HashMap::new();
+
+        for obj in unchunked_results {
+            let entry = self.value_to_knowledge_entry(obj.clone()).await?;
+            let score = obj["score"].as_f64().unwrap_or(0.0) as f32;
+            scored_entries.insert(entry.id.clone(), (score, Some(entry)));
         }
 
-        Ok(entries)
+        // Deduplicate chunks: keep max score per entry_id
+        let mut chunk_scores: std::collections::HashMap<String, f32> =
+            std::collections::HashMap::new();
+        for obj in &chunk_results {
+            let entry_id = obj["entry_id"].as_str().unwrap_or_default().to_string();
+            let score = obj["score"].as_f64().unwrap_or(0.0) as f32;
+            let current = chunk_scores.entry(entry_id).or_insert(0.0f32);
+            if score > *current {
+                *current = score;
+            }
+        }
+
+        // For each unique chunk entry_id, fetch the full entry (with visibility/filter check)
+        for (entry_id, score) in &chunk_scores {
+            if scored_entries.contains_key(entry_id) {
+                // Entry already in results from unchunked path — take max score
+                if let Some((existing_score, _)) = scored_entries.get_mut(entry_id) {
+                    if *score > *existing_score {
+                        *existing_score = *score;
+                    }
+                }
+                continue;
+            }
+
+            // Fetch full entry with visibility/category/resonance filtering
+            if let Some(entry) = self.get_knowledge_async(entry_id, ctx).await? {
+                // Apply resonance filter manually (get_knowledge doesn't apply it)
+                if let Some(min) = filter.min_resonance {
+                    if entry.resonance < min {
+                        continue;
+                    }
+                }
+                if let Some(max) = filter.max_resonance {
+                    if entry.resonance > max {
+                        continue;
+                    }
+                }
+                // Apply category filter
+                if let Some(cats) = &filter.categories {
+                    if !cats.is_empty() && !cats.contains(&entry.category_id) {
+                        continue;
+                    }
+                }
+                scored_entries.insert(entry_id.clone(), (*score, Some(entry)));
+            }
+            // If entry not found or not visible, skip silently
+        }
+
+        // Sort by score DESC and take limit
+        let mut sorted: Vec<(f32, KnowledgeEntry)> = scored_entries
+            .into_values()
+            .filter_map(|(score, entry)| entry.map(|e| (score, e)))
+            .collect();
+        sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.truncate(limit);
+
+        Ok(sorted.into_iter().map(|(_, entry)| entry).collect())
     }
 
     /// Helper: Convert SurrealDB query result to KnowledgeEntry
@@ -943,9 +1036,144 @@ impl SurrealDatabase {
             embedding: serde_json::from_value(obj["embedding"].clone()).ok(),
             embedding_model: serde_json::from_value(obj["embedding_model"].clone()).ok(),
             embedded_at: serde_json::from_value(obj["embedded_at"].clone()).ok(),
+            chunk_count: serde_json::from_value(obj["chunk_count"].clone()).unwrap_or(0),
             format: serde_json::from_value(obj["format"].clone())
                 .unwrap_or_else(|_| "markdown".to_string()),
             effective_resonance: obj.get("effective_resonance").and_then(|v| v.as_f64()),
         })
+    }
+
+    // =========================================================================
+    // EMBEDDING CHUNK OPERATIONS (Issue #346)
+    // =========================================================================
+
+    /// Delete all embedding chunks for a knowledge entry (sync wrapper)
+    pub fn delete_embedding_chunks(&self, entry_id: &str) -> Result<()> {
+        Self::runtime().block_on(self.delete_embedding_chunks_async(entry_id))
+    }
+
+    async fn delete_embedding_chunks_async(&self, entry_id: &str) -> Result<()> {
+        let mut response = with_db!(self, db, {
+            db.query("DELETE FROM embedding_chunk WHERE entry_id = $entry_id")
+                .bind(("entry_id", entry_id.to_string()))
+                .await
+                .context("Failed to delete embedding chunks")
+        })?;
+
+        let errors = response.take_errors();
+        if !errors.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Failed to delete embedding chunks: {:?}",
+                errors
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Insert a single embedding chunk (sync wrapper)
+    pub fn insert_embedding_chunk(
+        &self,
+        entry_id: &str,
+        chunk_index: usize,
+        chunk_text: &str,
+        token_offset: usize,
+        token_count: usize,
+        embedding: &[f32],
+        model_id: &str,
+    ) -> Result<()> {
+        Self::runtime().block_on(self.insert_embedding_chunk_async(
+            entry_id,
+            chunk_index,
+            chunk_text,
+            token_offset,
+            token_count,
+            embedding,
+            model_id,
+        ))
+    }
+
+    async fn insert_embedding_chunk_async(
+        &self,
+        entry_id: &str,
+        chunk_index: usize,
+        chunk_text: &str,
+        token_offset: usize,
+        token_count: usize,
+        embedding: &[f32],
+        model_id: &str,
+    ) -> Result<()> {
+        let sql = "CREATE embedding_chunk SET
+            entry_id = $entry_id,
+            chunk_index = $chunk_index,
+            chunk_text = $chunk_text,
+            token_offset = $token_offset,
+            token_count = $token_count,
+            embedding = $embedding,
+            embedding_model = $embedding_model";
+
+        let mut response = with_db!(self, db, {
+            db.query(sql)
+                .bind(("entry_id", entry_id.to_string()))
+                .bind(("chunk_index", chunk_index as i64))
+                .bind(("chunk_text", chunk_text.to_string()))
+                .bind(("token_offset", token_offset as i64))
+                .bind(("token_count", token_count as i64))
+                .bind(("embedding", embedding.to_vec()))
+                .bind(("embedding_model", model_id.to_string()))
+                .await
+                .context("Failed to insert embedding chunk")
+        })?;
+
+        let errors = response.take_errors();
+        if !errors.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Failed to insert embedding chunk: {:?}",
+                errors
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Search embedding chunks by vector similarity (sync wrapper)
+    pub fn semantic_search_chunks(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>> {
+        Self::runtime().block_on(self.semantic_search_chunks_async(query_embedding, limit))
+    }
+
+    async fn semantic_search_chunks_async(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>> {
+        let sql = "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
+            FROM embedding_chunk
+            ORDER BY score DESC
+            LIMIT $limit";
+
+        let mut response = with_db!(self, db, {
+            db.query(sql)
+                .bind(("query_vec", query_embedding.to_vec()))
+                .bind(("limit", limit))
+                .await
+                .context("Failed to search embedding chunks")
+        })?;
+
+        let results: Vec<serde_json::Value> = response
+            .take(0)
+            .context("Failed to parse chunk search results")?;
+
+        let mut pairs = Vec::new();
+        for obj in results {
+            let entry_id = obj["entry_id"].as_str().unwrap_or_default().to_string();
+            let score = obj["score"].as_f64().unwrap_or(0.0) as f32;
+            pairs.push((entry_id, score));
+        }
+
+        Ok(pairs)
     }
 }

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -288,10 +288,10 @@ impl SurrealDatabase {
         let resonance = entry.resonance as f64;
 
         // Foundational and transformative entries are exempt from decay
-        if let Some(ref rtype) = entry.resonance_type {
-            if rtype == "foundational" || rtype == "transformative" {
-                return resonance;
-            }
+        if let Some(ref rtype) = entry.resonance_type
+            && (rtype == "foundational" || rtype == "transformative")
+        {
+            return resonance;
         }
 
         // Determine the reference timestamp: last_activated, falling back to created_at

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -888,10 +888,10 @@ impl SurrealDatabase {
         for (entry_id, score) in &chunk_scores {
             if scored_entries.contains_key(entry_id) {
                 // Entry already in results from unchunked path — take max score
-                if let Some((existing_score, _)) = scored_entries.get_mut(entry_id) {
-                    if *score > *existing_score {
-                        *existing_score = *score;
-                    }
+                if let Some((existing_score, _)) = scored_entries.get_mut(entry_id)
+                    && *score > *existing_score
+                {
+                    *existing_score = *score;
                 }
                 continue;
             }
@@ -899,21 +899,22 @@ impl SurrealDatabase {
             // Fetch full entry with visibility/category/resonance filtering
             if let Some(entry) = self.get_knowledge_async(entry_id, ctx).await? {
                 // Apply resonance filter manually (get_knowledge doesn't apply it)
-                if let Some(min) = filter.min_resonance {
-                    if entry.resonance < min {
-                        continue;
-                    }
+                if let Some(min) = filter.min_resonance
+                    && entry.resonance < min
+                {
+                    continue;
                 }
-                if let Some(max) = filter.max_resonance {
-                    if entry.resonance > max {
-                        continue;
-                    }
+                if let Some(max) = filter.max_resonance
+                    && entry.resonance > max
+                {
+                    continue;
                 }
                 // Apply category filter
-                if let Some(cats) = &filter.categories {
-                    if !cats.is_empty() && !cats.contains(&entry.category_id) {
-                        continue;
-                    }
+                if let Some(cats) = &filter.categories
+                    && !cats.is_empty()
+                    && !cats.contains(&entry.category_id)
+                {
+                    continue;
                 }
                 scored_entries.insert(entry_id.clone(), (*score, Some(entry)));
             }
@@ -1073,6 +1074,7 @@ impl SurrealDatabase {
     }
 
     /// Insert a single embedding chunk (sync wrapper)
+    #[allow(clippy::too_many_arguments)]
     pub fn insert_embedding_chunk(
         &self,
         entry_id: &str,
@@ -1094,6 +1096,7 @@ impl SurrealDatabase {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn insert_embedding_chunk_async(
         &self,
         entry_id: &str,

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -828,7 +828,8 @@ impl SurrealDatabase {
         );
 
         // Phase 1b: Search chunks (no visibility filter — applied after dedup)
-        let chunk_sql = "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
+        let chunk_sql =
+            "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
             FROM embedding_chunk
             ORDER BY score DESC
             LIMIT $chunk_limit";

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -277,6 +277,53 @@ impl SurrealDatabase {
          END"
     }
 
+    /// Compute effective resonance in Rust, matching the SQL in `effective_resonance_expr()`.
+    ///
+    /// Tiered decay rates (per week):
+    ///   resonance <= 3  -> 10%/week (base 0.90)
+    ///   resonance 4-5   -> 5%/week  (base 0.95)
+    ///   resonance 6+    -> 2.5%/week (base 0.975)
+    /// foundational/transformative entries are exempt from decay (return raw resonance).
+    fn compute_effective_resonance(entry: &KnowledgeEntry) -> f64 {
+        let resonance = entry.resonance as f64;
+
+        // Foundational and transformative entries are exempt from decay
+        if let Some(ref rtype) = entry.resonance_type {
+            if rtype == "foundational" || rtype == "transformative" {
+                return resonance;
+            }
+        }
+
+        // Determine the reference timestamp: last_activated, falling back to created_at
+        let reference_ts = entry
+            .last_activated
+            .as_deref()
+            .or(entry.created_at.as_deref());
+
+        let weeks_elapsed = match reference_ts {
+            Some(ts) => {
+                if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+                    let elapsed = chrono::Utc::now() - dt.to_utc();
+                    elapsed.num_seconds() as f64 / (7.0 * 86400.0)
+                } else {
+                    0.0
+                }
+            }
+            None => 0.0,
+        };
+
+        // Tiered decay base matching the SQL expression
+        let decay_base: f64 = if entry.resonance <= 3 {
+            0.90
+        } else if entry.resonance <= 5 {
+            0.95
+        } else {
+            0.975
+        };
+
+        resonance * decay_base.powf(weeks_elapsed)
+    }
+
     /// Build resonance filter clauses using computed effective_resonance.
     /// Tiered decay rates:
     ///   resonance <= 3  -> 10%/week (base 0.90)
@@ -898,14 +945,15 @@ impl SurrealDatabase {
 
             // Fetch full entry with visibility/category/resonance filtering
             if let Some(entry) = self.get_knowledge_async(entry_id, ctx).await? {
-                // Apply resonance filter manually (get_knowledge doesn't apply it)
+                // Apply decay-adjusted resonance filter (matching the SQL in effective_resonance_expr)
+                let effective = Self::compute_effective_resonance(&entry);
                 if let Some(min) = filter.min_resonance
-                    && entry.resonance < min
+                    && effective < min as f64
                 {
                     continue;
                 }
                 if let Some(max) = filter.max_resonance
-                    && entry.resonance > max
+                    && effective > max as f64
                 {
                     continue;
                 }
@@ -1107,7 +1155,8 @@ impl SurrealDatabase {
         embedding: &[f32],
         model_id: &str,
     ) -> Result<()> {
-        let sql = "CREATE embedding_chunk SET
+        let chunk_id = format!("{}_{}", entry_id, chunk_index);
+        let sql = "UPSERT type::thing('embedding_chunk', $chunk_id) SET
             entry_id = $entry_id,
             chunk_index = $chunk_index,
             chunk_text = $chunk_text,
@@ -1118,6 +1167,7 @@ impl SurrealDatabase {
 
         let mut response = with_db!(self, db, {
             db.query(sql)
+                .bind(("chunk_id", chunk_id))
                 .bind(("entry_id", entry_id.to_string()))
                 .bind(("chunk_index", chunk_index as i64))
                 .bind(("chunk_text", chunk_text.to_string()))

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -1741,3 +1741,166 @@ fn test_search_select_no_results_is_noop() {
         "update_activations with empty IDs should not error"
     );
 }
+
+// =========================================================================
+// CHUNKED EMBEDDING SEARCH TEST (PR #348)
+// =========================================================================
+
+/// Generate a long test entry with a pizza passage buried deep in unrelated content.
+///
+/// The entry is ~1500+ tokens: ~500 tokens of software engineering filler,
+/// then a distinctive passage about Neapolitan pizza, then ~500 more tokens
+/// of filler. Without chunked embedding the pizza passage sits well beyond
+/// the old 512-token truncation point.
+fn make_pizza_test_entry() -> String {
+    // ~700 tokens of generic content about software (repeated for length)
+    let prefix = "Software engineering is a discipline that encompasses the systematic \
+        design, development, testing, and maintenance of software applications. \
+        The field has evolved significantly since its inception in the 1960s, \
+        when the term was first coined at the NATO Software Engineering Conference. \
+        Early software development was characterized by ad-hoc approaches and a lack \
+        of formal methodologies. The waterfall model emerged as one of the first \
+        structured approaches, dividing the development process into distinct phases: \
+        requirements analysis, design, implementation, testing, and maintenance. \
+        However, the rigidity of this approach led to the development of more flexible \
+        methodologies. Agile development, introduced through the Agile Manifesto in 2001, \
+        emphasized iterative development, collaboration, and adaptability. \
+        ".repeat(4);
+
+    // The buried pizza passage (~200 tokens)
+    let pizza = "The art of pizza making is a fascinating departure from our main topic. \
+        A proper Neapolitan pizza requires a dough made from type 00 flour with 60-65% \
+        hydration, fermented for at least 24 hours. The sauce should be made from San \
+        Marzano tomatoes, crushed by hand, with nothing more than salt and fresh basil. \
+        Mozzarella di bufala, made from water buffalo milk, provides the ideal cheese \
+        topping. The pizza must be baked in a wood-fired oven at 485 degrees Celsius \
+        for exactly 60 to 90 seconds. The cornicione, or outer crust, should be puffy \
+        and leopard-spotted with char marks. A pizzaiolo trains for years to master the \
+        art of stretching dough by hand without tearing, creating a perfectly thin center \
+        with an airy, risen edge. The Associazione Verace Pizza Napoletana certifies \
+        pizzerias worldwide that meet their strict standards for authentic preparation.";
+
+    // ~700 more tokens of generic content
+    let suffix = "Returning to software engineering, modern practices include continuous \
+        integration and continuous deployment, microservices architecture, and cloud-native \
+        development. The rise of DevOps has blurred the traditional boundaries between \
+        development and operations teams, fostering a culture of shared responsibility. \
+        Container technologies like Docker and orchestration platforms like Kubernetes \
+        have revolutionized how applications are packaged and deployed. \
+        ".repeat(4);
+
+    format!("{}\n\n{}\n\n{}", prefix, pizza, suffix)
+}
+
+#[test]
+fn test_chunked_search_finds_buried_content() {
+    use crate::chunking::{ChunkConfig, chunk_text};
+    use crate::embeddings::{EmbeddingProvider, TractProvider};
+    use crate::store::KnowledgeStore;
+
+    // 1. Create provider and test database
+    let provider = TractProvider::new().expect("TractProvider should initialize");
+    let db = SurrealDatabase::open_in_memory().expect("in-memory DB should open");
+
+    // 2. Create a long entry with pizza buried deep inside
+    let long_body = make_pizza_test_entry();
+
+    // Sanity check: the body should be >512 tokens so the old truncation
+    // would have missed the pizza passage entirely. Use load_tokenizer()
+    // which has truncation disabled -- the provider's tokenizer truncates
+    // at 512, so it would always report <= 512.
+    {
+        let counting_tok = crate::embeddings::load_tokenizer()
+            .expect("load_tokenizer should succeed");
+        let encoding = counting_tok.encode(long_body.as_str(), false)
+            .expect("tokenizer.encode should succeed");
+        assert!(
+            encoding.get_ids().len() > 512,
+            "Test body must exceed 512 tokens to validate chunked search (got {})",
+            encoding.get_ids().len()
+        );
+    }
+
+    let mut entry = make_test_entry("kn-pizza-deep", 5, 0.0);
+    entry.title = "Software Engineering History".to_string();
+    entry.body = Some(long_body);
+    db.upsert_knowledge(&entry).unwrap();
+
+    // 3. Embed with chunking (replicate auto_embed logic inline so we
+    //    don't depend on MX_CURRENT_AGENT being set)
+    let ctx = crate::store::AgentContext::public_only();
+    let embedding_text = entry.embedding_text();
+    let config = ChunkConfig::default();
+    let chunks = chunk_text(&embedding_text, provider.tokenizer(), &config);
+
+    assert!(
+        chunks.len() > 1,
+        "Entry should produce multiple chunks (got {})",
+        chunks.len()
+    );
+
+    let mut chunk_embeddings = Vec::with_capacity(chunks.len());
+    for chunk in &chunks {
+        chunk_embeddings.push(provider.embed(&chunk.text).unwrap());
+    }
+
+    // Store chunks
+    db.delete_embedding_chunks("kn-pizza-deep").unwrap();
+    for (chunk, embedding) in chunks.iter().zip(chunk_embeddings.iter()) {
+        db.insert_embedding_chunk(
+            "kn-pizza-deep",
+            chunk.chunk_index,
+            &chunk.text,
+            chunk.token_offset,
+            chunk.token_count,
+            embedding,
+            provider.model_id(),
+        )
+        .unwrap();
+    }
+
+    // Mean vector on entry (for the unchunked search path and auto_anchor)
+    let dims = provider.dimensions();
+    let mut mean_vec = vec![0.0f32; dims];
+    for emb in &chunk_embeddings {
+        for (i, v) in emb.iter().enumerate() {
+            mean_vec[i] += v;
+        }
+    }
+    let n = chunk_embeddings.len() as f32;
+    for v in mean_vec.iter_mut() {
+        *v /= n;
+    }
+    let l2: f32 = mean_vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if l2 > 0.0 {
+        for v in mean_vec.iter_mut() {
+            *v /= l2;
+        }
+    }
+
+    entry.embedding = Some(mean_vec);
+    entry.embedding_model = Some(provider.model_id().to_string());
+    entry.embedded_at = Some(chrono::Utc::now().to_rfc3339());
+    entry.chunk_count = chunks.len() as i32;
+    entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
+    db.upsert_knowledge(&entry).unwrap();
+
+    // 4. Embed the pizza query
+    let query = "pizza making techniques and oven temperature";
+    let query_embedding = provider.embed(query).expect("query embedding should succeed");
+
+    // 5. Semantic search -- this exercises the two-phase search
+    //    (unchunked entries + embedding_chunk table).
+    let filter = crate::store::KnowledgeFilter::default();
+    let results = db.semantic_search(&query_embedding, &ctx, &filter, 10).unwrap();
+
+    // 6. Assert the long entry appears in results
+    let found = results.iter().any(|e| e.id == "kn-pizza-deep");
+    assert!(
+        found,
+        "Chunked semantic search should find the entry with buried pizza content. \
+         Got {} results: {:?}",
+        results.len(),
+        results.iter().map(|e| e.id.as_str()).collect::<Vec<_>>()
+    );
+}

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -146,6 +146,7 @@ fn make_test_entry(id: &str, resonance: i32, decay_rate: f64) -> crate::knowledg
         embedding: None,
         embedding_model: None,
         embedded_at: None,
+        chunk_count: 0,
         format: "markdown".to_string(),
         effective_resonance: None,
     }

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -1765,7 +1765,8 @@ fn make_pizza_test_entry() -> String {
         However, the rigidity of this approach led to the development of more flexible \
         methodologies. Agile development, introduced through the Agile Manifesto in 2001, \
         emphasized iterative development, collaboration, and adaptability. \
-        ".repeat(4);
+        "
+    .repeat(4);
 
     // The buried pizza passage (~200 tokens)
     let pizza = "The art of pizza making is a fascinating departure from our main topic. \
@@ -1787,7 +1788,8 @@ fn make_pizza_test_entry() -> String {
         development and operations teams, fostering a culture of shared responsibility. \
         Container technologies like Docker and orchestration platforms like Kubernetes \
         have revolutionized how applications are packaged and deployed. \
-        ".repeat(4);
+        "
+    .repeat(4);
 
     format!("{}\n\n{}\n\n{}", prefix, pizza, suffix)
 }
@@ -1810,9 +1812,10 @@ fn test_chunked_search_finds_buried_content() {
     // which has truncation disabled -- the provider's tokenizer truncates
     // at 512, so it would always report <= 512.
     {
-        let counting_tok = crate::embeddings::load_tokenizer()
-            .expect("load_tokenizer should succeed");
-        let encoding = counting_tok.encode(long_body.as_str(), false)
+        let counting_tok =
+            crate::embeddings::load_tokenizer().expect("load_tokenizer should succeed");
+        let encoding = counting_tok
+            .encode(long_body.as_str(), false)
             .expect("tokenizer.encode should succeed");
         assert!(
             encoding.get_ids().len() > 512,
@@ -1887,12 +1890,16 @@ fn test_chunked_search_finds_buried_content() {
 
     // 4. Embed the pizza query
     let query = "pizza making techniques and oven temperature";
-    let query_embedding = provider.embed(query).expect("query embedding should succeed");
+    let query_embedding = provider
+        .embed(query)
+        .expect("query embedding should succeed");
 
     // 5. Semantic search -- this exercises the two-phase search
     //    (unchunked entries + embedding_chunk table).
     let filter = crate::store::KnowledgeFilter::default();
-    let results = db.semantic_search(&query_embedding, &ctx, &filter, 10).unwrap();
+    let results = db
+        .semantic_search(&query_embedding, &ctx, &filter, 10)
+        .unwrap();
 
     // 6. Assert the long entry appears in results
     let found = results.iter().any(|e| e.id == "kn-pizza-deep");

--- a/src/surreal_db/trait_impl.rs
+++ b/src/surreal_db/trait_impl.rs
@@ -261,6 +261,39 @@ impl KnowledgeStore for SurrealDatabase {
         self.list_relationship_types()
     }
 
+    fn delete_embedding_chunks(&self, entry_id: &str) -> Result<()> {
+        self.delete_embedding_chunks(entry_id)
+    }
+
+    fn insert_embedding_chunk(
+        &self,
+        entry_id: &str,
+        chunk_index: usize,
+        chunk_text: &str,
+        token_offset: usize,
+        token_count: usize,
+        embedding: &[f32],
+        model_id: &str,
+    ) -> Result<()> {
+        self.insert_embedding_chunk(
+            entry_id,
+            chunk_index,
+            chunk_text,
+            token_offset,
+            token_count,
+            embedding,
+            model_id,
+        )
+    }
+
+    fn semantic_search_chunks(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>> {
+        self.semantic_search_chunks(query_embedding, limit)
+    }
+
     fn edit_content(
         &self,
         id: &str,

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1555,6 +1555,29 @@ mod tests {
                 unreachable!()
             }
 
+            fn delete_embedding_chunks(&self, _id: &str) -> Result<()> {
+                unreachable!()
+            }
+            fn insert_embedding_chunk(
+                &self,
+                _id: &str,
+                _ci: usize,
+                _ct: &str,
+                _to: usize,
+                _tc: usize,
+                _emb: &[f32],
+                _m: &str,
+            ) -> Result<()> {
+                unreachable!()
+            }
+            fn semantic_search_chunks(
+                &self,
+                _emb: &[f32],
+                _l: usize,
+            ) -> Result<Vec<(String, f32)>> {
+                unreachable!()
+            }
+
             fn sweep_ghost_anchors(
                 &self,
                 _dry_run: bool,


### PR DESCRIPTION
## Summary

- Long memory entries (>400 tokens) are now split into overlapping chunks (400-token windows, 100-token overlap), each embedded separately, so semantic search covers the full content instead of just the first ~512 tokens
- New `embedding_chunk` table stores per-chunk embeddings; semantic search queries both unchunked entries and chunks, then merges results by max score per entry
- Refactored `auto_embed()` and the `Embed` command handler to use the chunking pipeline, removed the 2000-char body truncation in `embedding_text()`

## Files changed

- `src/chunking.rs` (NEW) -- token-aware text chunking module
- `src/main.rs` -- register `mod chunking`
- `src/embeddings.rs` -- add `tokenizer()` accessor to TractProvider
- `src/knowledge.rs` -- add `chunk_count` field, remove 2000-char truncation
- `schema/surrealdb-schema.surql` -- add `embedding_chunk` table and `chunk_count` field
- `src/store.rs` -- add 3 trait methods for chunk CRUD/search
- `src/surreal_db/knowledge.rs` -- implement chunk methods, modify semantic search to query both tables, add chunk cleanup on delete
- `src/surreal_db/trait_impl.rs` -- wire 3 new trait methods
- `src/helpers.rs` -- rewrite `auto_embed()` with chunking pipeline
- `src/handlers/memory.rs` -- refactor `Embed` command to use `auto_embed()`
- `src/surreal_db/tests.rs` -- add `chunk_count` to test fixtures
- `src/wake_ritual.rs` -- add 3 new methods to MockStore

## Test plan

- [x] `cargo build` passes clean
- [x] `cargo test` passes (1043 tests, 0 failures)
- [x] `cargo clippy --tests -- -D warnings` passes clean
- [x] `cargo fmt -- --check` passes clean
- [ ] Verify `mx memory embed --all` re-embeds entries with chunking
- [ ] Verify `mx memory search --semantic` returns results from chunked entries
- [ ] Verify `test_schema_applies_without_error` validates new schema