### PR TITLE
fix: use non-truncating tokenizer for chunking

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -218,7 +218,11 @@ pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Resu
     let provider = TractProvider::new()?;
     let embedding_text = entry.embedding_text();
     let config = ChunkConfig::default();
-    let chunks = chunk_text(&embedding_text, provider.tokenizer(), &config);
+    // Use load_tokenizer() (no truncation) for chunking — the provider's
+    // tokenizer truncates at 512 which would hide content beyond that point.
+    // Chunking must see ALL tokens to split them correctly.
+    let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
+    let chunks = chunk_text(&embedding_text, &chunking_tokenizer, &config);
 
     if chunks.len() == 1 {
         // Short entry: single embedding, no chunks

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -1834,7 +1834,11 @@ fn test_chunked_search_finds_buried_content() {
     let ctx = crate::store::AgentContext::public_only();
     let embedding_text = entry.embedding_text();
     let config = ChunkConfig::default();
-    let chunks = chunk_text(&embedding_text, provider.tokenizer(), &config);
+    // Use load_tokenizer() (no truncation) for chunking — provider.tokenizer()
+    // truncates at 512 which would hide the buried pizza content.
+    let chunking_tokenizer =
+        crate::embeddings::load_tokenizer().expect("load_tokenizer should succeed");
+    let chunks = chunk_text(&embedding_text, &chunking_tokenizer, &config);
 
     assert!(
         chunks.len() > 1,


### PR DESCRIPTION
## Summary

Critical bug in chunked embedding (PR #348): `chunk_text()` was called with `provider.tokenizer()` which has truncation enabled at 512 tokens. This means the chunker only ever saw the first 512 tokens of any text, producing at most 2 chunks regardless of content length. The pizza content buried at token ~700 in a 1500-token entry was completely invisible.

**Fix:** Use `load_tokenizer()` (no truncation) for the chunking step. The embedding step continues to use the provider's truncating tokenizer correctly — each chunk is ≤400 tokens, well within the 512 model limit.

Closes the gap found during live testing with `mx memory add` + `mx memory search --semantic`.

## Files changed
- `src/helpers.rs` — `auto_embed()` now uses `load_tokenizer()` for chunking
- `src/surreal_db/tests.rs` — integration test updated to use non-truncating tokenizer

## Test plan
- [x] `test_chunked_search_finds_buried_content` passes (pizza found)
- [x] All embedding tests pass
- [x] clippy clean, fmt clean