### PR TITLE
feat: auto-apply schema migrations on network mode connections

### DIFF
--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -50,9 +50,10 @@ mx log
 
 ### Knowledge graph
 
-The memory system is a knowledge graph backed by SurrealDB (or embedded
-SurrealKV). Entries have categories, tags, resonance levels, embeddings,
-and relationships.
+The memory system is a knowledge graph backed by SurrealDB (embedded
+SurrealKV or network WebSocket). The schema is applied automatically on
+every connection in both modes. Entries have categories, tags, resonance
+levels, embeddings, and relationships.
 
 ``` bash
 mx memory search "session bootstrap"
@@ -342,6 +343,18 @@ for offline editing and batch operations.
 ``` bash
 mx sync pull owner/repo
 mx sync push owner/repo --dry-run
+```
+
+### Migrate
+
+`mx migrate` explicitly applies the database schema to SurrealDB. The
+schema is normally applied automatically on every connection (both
+embedded and network mode), but `migrate` is useful after upgrading mx,
+or to apply the schema on an instance where `MX_SKIP_SCHEMA=1` is set.
+
+``` bash
+mx migrate            # apply schema (ignores MX_SKIP_SCHEMA)
+mx migrate -v         # verbose: see connection and schema details
 ```
 
 ## What's next
@@ -1074,6 +1087,15 @@ title, body content, optional tags, a resonance level (1--10+), and
 timestamps. Entries can be linked via typed relationships, anchored to
 each other by embedding similarity, and surfaced through keyword or
 semantic search.
+
+::: {.admonition .note}
+**NOTE:** The database schema is applied automatically on every
+connection, in both embedded and network mode. All schema statements are
+idempotent (`IF NOT EXISTS` / `UPSERT`), so no manual setup is required.
+Set `MX_SKIP_SCHEMA=1` to skip auto-apply in environments with
+restricted DB permissions. Run `mx migrate` to explicitly apply the
+schema (it ignores `MX_SKIP_SCHEMA`).
+:::
 
 ## Table of contents
 
@@ -6425,6 +6447,20 @@ talks to, not where files live on disk (with the exception of
 |                         |                 |                       | `ns`), `database` |
 |                         |                 |                       | (or `db`)         |
 +-------------------------+-----------------+-----------------------+-------------------+
+| `MX_SKIP_SCHEMA`        | boolean         | unset                 | Set to `1` or     |
+|                         |                 |                       | `true` to skip    |
+|                         |                 |                       | automatic schema  |
+|                         |                 |                       | application on    |
+|                         |                 |                       | connection.       |
+|                         |                 |                       | Escape hatch for  |
+|                         |                 |                       | restricted DB     |
+|                         |                 |                       | permissions.      |
+|                         |                 |                       | Ignored by        |
+|                         |                 |                       | `mx migrate`,     |
+|                         |                 |                       | which always      |
+|                         |                 |                       | applies the       |
+|                         |                 |                       | schema            |
++-------------------------+-----------------+-----------------------+-------------------+
 
 ### GitHub App auth (sync) {#env-github}
 
@@ -6649,13 +6685,23 @@ form is what the lookup helper handles; for an absolute or relative file
 path, just pass the path directly (see `state/schemas/` for the
 path-vs-ID heuristic).
 
-Point SurrealDB at a remote network instance:
+Point SurrealDB at a remote network instance (schema is applied
+automatically on connection, just like embedded mode):
 
 ``` bash
 export MX_SURREAL_MODE=network
 export MX_SURREAL_URL=ws://surreal.internal:8000
 export MX_SURREAL_USER=mx
 export MX_SURREAL_PASS_FILE=/run/agenix/mx-surreal-pass
+```
+
+Skip auto-apply when the DB user lacks DDL permissions (schema managed
+externally by an admin):
+
+``` bash
+export MX_SKIP_SCHEMA=1
+# To explicitly apply schema when needed, use:
+# mx migrate
 ```
 
 ## Notes for contributors {#contributors}
@@ -7042,6 +7088,37 @@ path is unused. Authentication supports three levels (root, namespace,
 database), configured via `MX_SURREAL_AUTH_LEVEL`. Password can be
 provided directly (`MX_SURREAL_PASS`) or read from a file
 (`MX_SURREAL_PASS_FILE`, useful for agenix-managed secrets on NixOS).
+
+### Schema auto-apply
+
+The embedded schema (`schema/surrealdb-schema.surql`) is applied on
+every database connection, in both embedded and network mode. All
+statements use `DEFINE ... IF NOT EXISTS` and `UPSERT`, so
+re-application is idempotent and safe. This means a fresh network-mode
+database is bootstrapped automatically on first connection -- no manual
+schema setup is required.
+
+The `apply_schema` method on `SurrealDatabase` uses the `with_db!` macro
+so the same code path runs against both the embedded and network
+backends.
+
+#### `MX_SKIP_SCHEMA`
+
+Set `MX_SKIP_SCHEMA=1` (or `true`) to skip schema application at
+connection time. This is an escape hatch for environments where the
+database user lacks DDL permissions (e.g., a read-only replica or a
+locked-down network instance where an admin applies the schema
+separately). When the variable is set, a `--verbose` message confirms
+the skip.
+
+#### `mx migrate`
+
+The `mx migrate` command explicitly applies the schema, ignoring
+`MX_SKIP_SCHEMA`. It connects to the database (respecting
+`MX_SURREAL_MODE` and all connection variables) and runs the full
+schema. Use it after upgrading mx to ensure the remote database has any
+new tables or indexes, or to re-apply the schema on an instance where
+`MX_SKIP_SCHEMA` is normally set.
 
 ### Connection architecture
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -323,6 +323,33 @@ via `MX_SURREAL_AUTH_LEVEL`. Password can be provided directly
 (`MX_SURREAL_PASS`) or read from a file (`MX_SURREAL_PASS_FILE`, useful for
 agenix-managed secrets on NixOS).
 
+=== Schema auto-apply
+
+The embedded schema (`schema/surrealdb-schema.surql`) is applied on every
+database connection, in both embedded and network mode. All statements use
+`DEFINE ... IF NOT EXISTS` and `UPSERT`, so re-application is idempotent and
+safe. This means a fresh network-mode database is bootstrapped automatically on
+first connection -- no manual schema setup is required.
+
+The `apply_schema` method on `SurrealDatabase` uses the `with_db!` macro so the
+same code path runs against both the embedded and network backends.
+
+==== `MX_SKIP_SCHEMA`
+
+Set `MX_SKIP_SCHEMA=1` (or `true`) to skip schema application at connection
+time. This is an escape hatch for environments where the database user lacks
+DDL permissions (e.g., a read-only replica or a locked-down network instance
+where an admin applies the schema separately). When the variable is set,
+a `--verbose` message confirms the skip.
+
+==== `mx migrate`
+
+The `mx migrate` command explicitly applies the schema, ignoring
+`MX_SKIP_SCHEMA`. It connects to the database (respecting `MX_SURREAL_MODE`
+and all connection variables) and runs the full schema. Use it after upgrading
+mx to ensure the remote database has any new tables or indexes, or to
+re-apply the schema on an instance where `MX_SKIP_SCHEMA` is normally set.
+
 === Connection architecture
 
 The connection is represented as an enum:

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -215,6 +215,18 @@ mx sync pull owner/repo
 mx sync push owner/repo --dry-run
 ```
 
+=== Migrate
+
+`mx migrate` explicitly applies the database schema to SurrealDB. The schema is
+normally applied automatically on every connection (both embedded and network
+mode), but `migrate` is useful after upgrading mx, or to apply the schema on an
+instance where `MX_SKIP_SCHEMA=1` is set.
+
+```bash
+mx migrate            # apply schema (ignores MX_SKIP_SCHEMA)
+mx migrate -v         # verbose: see connection and schema details
+```
+
 == What's next
 
 - Read the #link("commit.html")[commit], #link("log.html")[log], and

--- a/docs/src/index.typ
+++ b/docs/src/index.typ
@@ -41,8 +41,9 @@ mx log
 === Knowledge graph
 
 The #link("memory.html")[memory] system is a knowledge graph backed by SurrealDB
-(or embedded SurrealKV). Entries have categories, tags, resonance levels,
-embeddings, and relationships.
+(embedded SurrealKV or network WebSocket). The schema is applied automatically
+on every connection in both modes. Entries have categories, tags, resonance
+levels, embeddings, and relationships.
 
 ```bash
 mx memory search "session bootstrap"

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -15,6 +15,12 @@ body content, optional tags, a resonance level (1--10+), and timestamps. Entries
 can be linked via typed relationships, anchored to each other by embedding
 similarity, and surfaced through keyword or semantic search.
 
+#note[The database schema is applied automatically on every connection, in both
+embedded and network mode. All schema statements are idempotent (`IF NOT EXISTS`
+/ `UPSERT`), so no manual setup is required. Set `MX_SKIP_SCHEMA=1` to skip
+auto-apply in environments with restricted DB permissions. Run `mx migrate` to
+explicitly apply the schema (it ignores `MX_SKIP_SCHEMA`).]
+
 == Table of contents
 
 - #link(<adding>)[Adding entries]

--- a/docs/src/paths.typ
+++ b/docs/src/paths.typ
@@ -210,6 +210,7 @@ which is the embedded-mode storage location).
   [`MX_SURREAL_NS`], [string], [`memory`], [Namespace],
   [`MX_SURREAL_DB`], [string], [`knowledge`], [Database name],
   [`MX_SURREAL_AUTH_LEVEL`], [enum], [`root`], [One of `root`, `namespace` (or `ns`), `database` (or `db`)],
+  [`MX_SKIP_SCHEMA`], [boolean], [unset], [Set to `1` or `true` to skip automatic schema application on connection. Escape hatch for restricted DB permissions. Ignored by `mx migrate`, which always applies the schema],
 )
 
 === GitHub App auth (sync) <env-github>
@@ -361,13 +362,23 @@ form is what the lookup helper handles; for an absolute or relative file
 path, just pass the path directly (see
 #link(<layout-state>)[`state/schemas/`] for the path-vs-ID heuristic).
 
-Point SurrealDB at a remote network instance:
+Point SurrealDB at a remote network instance (schema is applied automatically
+on connection, just like embedded mode):
 
 ```bash
 export MX_SURREAL_MODE=network
 export MX_SURREAL_URL=ws://surreal.internal:8000
 export MX_SURREAL_USER=mx
 export MX_SURREAL_PASS_FILE=/run/agenix/mx-surreal-pass
+```
+
+Skip auto-apply when the DB user lacks DDL permissions (schema managed
+externally by an admin):
+
+```bash
+export MX_SKIP_SCHEMA=1
+# To explicitly apply schema when needed, use:
+# mx migrate
 ```
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,6 +142,14 @@ pub enum Commands {
         command: WorktreeCommands,
     },
 
+    /// Apply database schema migrations
+    ///
+    /// Connects to the database (respects MX_SURREAL_MODE) and applies
+    /// the embedded schema. All statements use IF NOT EXISTS, so this is
+    /// idempotent. Ignores MX_SKIP_SCHEMA -- if you run `mx migrate`
+    /// explicitly, you want the schema applied.
+    Migrate,
+
     /// Print the full mx documentation as Markdown
     Docs,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,14 @@ fn main() -> Result<()> {
             Ok(())
         }
         Commands::Worktree { command } => handle_worktree(command),
+        Commands::Migrate => {
+            let db_path = paths::surreal_root().with_extension("surreal");
+            let db =
+                surreal_db::SurrealDatabase::open_with_verbose(&db_path, cli.verbose)?;
+            db.apply_schema_explicit(cli.verbose)?;
+            eprintln!("[mx] Schema applied successfully");
+            Ok(())
+        }
         Commands::Docs => {
             print!("{}", embedded::docs_markdown());
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
         Commands::Worktree { command } => handle_worktree(command),
         Commands::Migrate => {
             let db_path = paths::surreal_root().with_extension("surreal");
-            let db = surreal_db::SurrealDatabase::open_with_verbose(&db_path, cli.verbose)?;
+            let db = surreal_db::SurrealDatabase::open_connection_only(&db_path, cli.verbose)?;
             db.apply_schema_explicit(cli.verbose)?;
             eprintln!("[mx] Schema applied successfully");
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,8 +90,7 @@ fn main() -> Result<()> {
         Commands::Worktree { command } => handle_worktree(command),
         Commands::Migrate => {
             let db_path = paths::surreal_root().with_extension("surreal");
-            let db =
-                surreal_db::SurrealDatabase::open_with_verbose(&db_path, cli.verbose)?;
+            let db = surreal_db::SurrealDatabase::open_with_verbose(&db_path, cli.verbose)?;
             db.apply_schema_explicit(cli.verbose)?;
             eprintln!("[mx] Schema applied successfully");
             Ok(())

--- a/src/surreal_db/connection.rs
+++ b/src/surreal_db/connection.rs
@@ -490,8 +490,7 @@ impl SurrealDatabase {
     /// (used by `mx migrate`), the env var is ignored.
     async fn apply_schema(&self, verbose: bool, force: bool) -> Result<()> {
         if !force
-            && std::env::var("MX_SKIP_SCHEMA")
-                .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+            && std::env::var("MX_SKIP_SCHEMA").is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
         {
             if verbose {
                 eprintln!("[mx] Skipping schema application (MX_SKIP_SCHEMA=1)");

--- a/src/surreal_db/connection.rs
+++ b/src/surreal_db/connection.rs
@@ -76,6 +76,8 @@ impl std::fmt::Display for AuthLevel {
 /// - `MX_SURREAL_AUTH_LEVEL`: Auth level for signin: "root" (default), "namespace"/"ns", or "database"/"db"
 /// - `MX_SURREAL_NS`: Namespace (default: memory)
 /// - `MX_SURREAL_DB`: Database name (default: knowledge)
+/// - `MX_SKIP_SCHEMA`: Set to "1" or "true" to skip auto-schema application on connect
+///   (escape hatch for restricted DB permissions; `mx migrate` ignores this)
 #[derive(Debug, Clone)]
 pub struct SurrealConfig {
     /// Connection mode
@@ -213,13 +215,22 @@ impl SurrealDatabase {
     /// the path is ignored and a network connection is established instead.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let config = SurrealConfig::from_env();
-        Self::runtime().block_on(Self::open_with_config_async(path, &config, false))
+        Self::runtime().block_on(Self::open_with_config_async(path, &config, false, false))
     }
 
     /// Open database with verbose control
     pub fn open_with_verbose<P: AsRef<Path>>(path: P, verbose: bool) -> Result<Self> {
         let config = SurrealConfig::from_env();
-        Self::runtime().block_on(Self::open_with_config_async(path, &config, verbose))
+        Self::runtime().block_on(Self::open_with_config_async(path, &config, verbose, false))
+    }
+
+    /// Open database connection without applying schema.
+    ///
+    /// Used by `mx migrate` to avoid double schema application — it opens
+    /// the connection, then applies schema explicitly via `apply_schema_explicit`.
+    pub fn open_connection_only<P: AsRef<Path>>(path: P, verbose: bool) -> Result<Self> {
+        let config = SurrealConfig::from_env();
+        Self::runtime().block_on(Self::open_with_config_async(path, &config, verbose, true))
     }
 
     /// Connect using explicit configuration
@@ -227,7 +238,7 @@ impl SurrealDatabase {
     /// For embedded mode, `path` specifies the database location.
     /// For network mode, `path` is ignored.
     pub fn connect<P: AsRef<Path>>(path: P, config: &SurrealConfig) -> Result<Self> {
-        Self::runtime().block_on(Self::open_with_config_async(path, config, false))
+        Self::runtime().block_on(Self::open_with_config_async(path, config, false, false))
     }
 
     /// Internal: open with config, branching on mode
@@ -235,10 +246,13 @@ impl SurrealDatabase {
         path: P,
         config: &SurrealConfig,
         verbose: bool,
+        skip_schema: bool,
     ) -> Result<Self> {
         match config.mode {
-            SurrealMode::Embedded => Self::open_embedded_async(path, config, verbose).await,
-            SurrealMode::Network => Self::open_network_async(config, verbose).await,
+            SurrealMode::Embedded => {
+                Self::open_embedded_async(path, config, verbose, skip_schema).await
+            }
+            SurrealMode::Network => Self::open_network_async(config, verbose, skip_schema).await,
         }
     }
 
@@ -247,6 +261,7 @@ impl SurrealDatabase {
         path: P,
         config: &SurrealConfig,
         verbose: bool,
+        skip_schema: bool,
     ) -> Result<Self> {
         let path = path.as_ref();
 
@@ -288,8 +303,9 @@ impl SurrealDatabase {
             conn: SurrealConnection::Embedded(db),
         };
 
-        // Apply schema (idempotent)
-        instance.apply_schema(verbose, false).await?;
+        if !skip_schema {
+            instance.apply_schema(verbose, false).await?;
+        }
 
         if verbose {
             eprintln!("[mx] Embedded connection established successfully");
@@ -317,7 +333,11 @@ impl SurrealDatabase {
     /// Open network connection via WebSocket
     ///
     /// Authenticates with the remote SurrealDB server using credentials from config.
-    async fn open_network_async(config: &SurrealConfig, verbose: bool) -> Result<Self> {
+    async fn open_network_async(
+        config: &SurrealConfig,
+        verbose: bool,
+        skip_schema: bool,
+    ) -> Result<Self> {
         // Diagnostic: Log connection attempt (to stderr, doesn't interfere with stdout)
         if verbose {
             eprintln!(
@@ -448,9 +468,9 @@ impl SurrealDatabase {
             conn: SurrealConnection::Network(db),
         };
 
-        // Apply schema (idempotent) -- all statements use IF NOT EXISTS,
-        // so this is safe to run on every connection including network mode.
-        instance.apply_schema(verbose, false).await?;
+        if !skip_schema {
+            instance.apply_schema(verbose, false).await?;
+        }
 
         if verbose {
             eprintln!("[mx] Network connection established successfully");
@@ -463,7 +483,7 @@ impl SurrealDatabase {
     #[allow(dead_code)]
     async fn open_async<P: AsRef<Path>>(path: P) -> Result<Self> {
         let config = SurrealConfig::from_env();
-        Self::open_with_config_async(path, &config, false).await
+        Self::open_with_config_async(path, &config, false, false).await
     }
 
     /// Test helper - open temporary database

--- a/src/surreal_db/connection.rs
+++ b/src/surreal_db/connection.rs
@@ -284,28 +284,18 @@ impl SurrealDatabase {
             .await
             .context("Failed to set namespace and database")?;
 
-        // Apply schema (idempotent)
-        if verbose {
-            eprintln!("[mx] Applying database schema");
-        }
-        let mut response = db
-            .query(SCHEMA)
-            .await
-            .context("Failed to apply database schema")?;
+        let instance = Self {
+            conn: SurrealConnection::Embedded(db),
+        };
 
-        // Check for errors - schema application returns multiple results
-        let errors = response.take_errors();
-        if !errors.is_empty() {
-            return Err(anyhow::anyhow!("Schema application failed: {:?}", errors));
-        }
+        // Apply schema (idempotent)
+        instance.apply_schema(verbose, false).await?;
 
         if verbose {
             eprintln!("[mx] Embedded connection established successfully");
         }
 
-        Ok(Self {
-            conn: SurrealConnection::Embedded(db),
-        })
+        Ok(instance)
     }
 
     /// Check if URL is localhost (safe for unencrypted traffic)
@@ -454,17 +444,19 @@ impl SurrealDatabase {
                 )
             })?;
 
+        let instance = Self {
+            conn: SurrealConnection::Network(db),
+        };
+
+        // Apply schema (idempotent) -- all statements use IF NOT EXISTS,
+        // so this is safe to run on every connection including network mode.
+        instance.apply_schema(verbose, false).await?;
+
         if verbose {
             eprintln!("[mx] Network connection established successfully");
         }
 
-        // Note: Schema is NOT applied for network mode
-        // The remote server should already have the schema
-        // (Schema is applied via NixOS module or manual setup)
-
-        Ok(Self {
-            conn: SurrealConnection::Network(db),
-        })
+        Ok(instance)
     }
 
     /// Legacy async open - kept for compatibility
@@ -485,6 +477,52 @@ impl SurrealDatabase {
         let temp_dir = tempdir()?;
         let config = SurrealConfig::default(); // always Embedded
         Self::connect(temp_dir.path(), &config)
+    }
+
+    /// Apply the embedded schema to the connected database.
+    ///
+    /// All statements use `IF NOT EXISTS`, so this is idempotent and safe
+    /// to run on every connection (embedded or network).
+    ///
+    /// When `force` is false, the `MX_SKIP_SCHEMA` environment variable
+    /// is respected: set it to `1` or `true` to skip schema application
+    /// (escape hatch for restricted DB permissions). When `force` is true
+    /// (used by `mx migrate`), the env var is ignored.
+    async fn apply_schema(&self, verbose: bool, force: bool) -> Result<()> {
+        if !force
+            && std::env::var("MX_SKIP_SCHEMA")
+                .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+        {
+            if verbose {
+                eprintln!("[mx] Skipping schema application (MX_SKIP_SCHEMA=1)");
+            }
+            return Ok(());
+        }
+
+        if verbose {
+            eprintln!("[mx] Applying database schema");
+        }
+
+        let mut response = with_db!(self, db, {
+            db.query(SCHEMA)
+                .await
+                .context("Failed to apply database schema")?
+        });
+
+        let errors = response.take_errors();
+        if !errors.is_empty() {
+            return Err(anyhow::anyhow!("Schema application failed: {:?}", errors));
+        }
+
+        Ok(())
+    }
+
+    /// Explicitly apply the database schema, ignoring `MX_SKIP_SCHEMA`.
+    ///
+    /// This is the public entry point used by `mx migrate`. It always
+    /// applies the schema regardless of environment variable overrides.
+    pub fn apply_schema_explicit(&self, verbose: bool) -> Result<()> {
+        Self::runtime().block_on(self.apply_schema(verbose, true))
     }
 
     /// Get reference to underlying Surreal instance (embedded only)


### PR DESCRIPTION
## Summary

- Extract schema application from `open_embedded_async` into a shared `apply_schema()` method on `SurrealDatabase` that uses the `with_db!` macro to work with both embedded and network connections
- Network mode now runs the same idempotent `IF NOT EXISTS` schema on every connection, so new tables/fields from binary upgrades are applied automatically
- Add `MX_SKIP_SCHEMA=1` env var as an escape hatch for environments with restricted DB permissions
- Add `mx migrate` command that explicitly applies the schema (ignores `MX_SKIP_SCHEMA`) for debugging and manual operations

Closes #350

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` -- all 1045 tests pass (1023 + 22 integration)
- [x] Existing `test_schema_applies_without_error` validates schema application
- [ ] Manual: verify `mx migrate` prints success message
- [ ] Manual: verify `MX_SKIP_SCHEMA=1 mx memory stats` skips schema application (with `-v`)
- [ ] Manual: verify `MX_SKIP_SCHEMA=1 mx migrate` still applies schema (force override)