### PR TITLE
fix: backfill stranded rows on schema-tightening (#352)

### DIFF
--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -7093,6 +7093,70 @@ schema. Use it after upgrading mx to ensure the remote database has any
 new tables or indexes, or to re-apply the schema on an instance where
 `MX_SKIP_SCHEMA` is normally set.
 
+### Evolving the schema: the BACKFILL convention {#schema-backfill}
+
+There is no separate migration tool and no ordered migration history.
+The schema file *is* the migration: it is replayed in full on every
+connection and on every `mx migrate`. Schema evolution therefore happens
+by editing `schema/surrealdb-schema.surql` so that re-applying it is
+always idempotent.
+
+This model has one sharp edge that every contributor adding a field must
+know about, because the model is SCHEMAFULL.
+
+#### The SCHEMAFULL-stranding trap
+
+When you add a new **required** field (one whose type is not
+`option<...>`) to an existing table, SurrealDB does *not* retroactively
+populate it. Every pre-existing row keeps that field as `NONE`. Reads
+usually survive, because projections coalesce the missing value (for
+example the `IF chunk_count THEN chunk_count ELSE 0 END` projection in
+`knowledge_select_fields()`). The danger is the next **write**:
+SurrealDB validates the whole record on any write, so the first time
+anything touches a stranded row it throws
+
+    Found NONE for field X ... but expected a <type>
+
+This is how issue #352 stranded 340 of 368 `knowledge` rows:
+`chunk_count` was added as a required `int`, and the pre-chunking rows
+had no value for it.
+
+#### THE RULE
+
+Whenever you add a required field to an existing table, add a paired,
+idempotent backfill `UPDATE` immediately after the `DEFINE`:
+
+``` surql
+DEFINE FIELD chunk_count ON knowledge TYPE int DEFAULT 0;
+-- Backfill: required field added to an existing table strands old rows at NONE.
+UPDATE knowledge SET chunk_count = 0 WHERE chunk_count IS NONE;
+```
+
+Three requirements make a correct backfill:
+
+1.  **Guard with `WHERE <field> IS NONE`.** This makes the statement a
+    no-op once applied, so replaying the schema on every connection
+    costs nothing and never double-counts.
+
+2.  **Backfill, do not dodge.** Do not make the field `option<...>` just
+    to avoid the trap. Downstream code assumes the field is present; the
+    backfill is the correct fix.
+
+3.  **If the backfill computes a value, test the non-empty case.** A
+    constant backfill is self-evidently correct, but a computed one is
+    not. Add a regression test that asserts the computed value matches
+    the real data, not merely that the statement runs. The `chunk_count`
+    backfill computes a count by joining `embedding_chunk`, so
+    `test_backfill_chunk_count_*` in `src/surreal_db/tests.rs` guards
+    it. Those tests use the `cfg(test)`-only `test_exec` /
+    `test_raw_chunk_count` helpers on `SurrealDatabase`, which read the
+    raw stored value *without* the read-coalescing projection so a
+    lingering `NONE` cannot masquerade as `0`.
+
+The backfill block at the bottom of `schema/surrealdb-schema.surql`
+documents this rule inline and collects every historical backfill as a
+worked example.
+
 ### Connection architecture
 
 The connection is represented as an enum:
@@ -7219,7 +7283,8 @@ entry with the following field groups:
 - `chunk_count` (int, default 0) -- number of embedding chunks. Zero
   means the entry is unchunked (single embedding). A positive value
   means the entry was split into overlapping chunks stored in the
-  `embedding_chunk` table.
+  `embedding_chunk` table. This is a required field; rows that predate
+  it are repaired by a backfill -- see the BACKFILL convention.
 
 ### Graph relations
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -350,6 +350,66 @@ and all connection variables) and runs the full schema. Use it after upgrading
 mx to ensure the remote database has any new tables or indexes, or to
 re-apply the schema on an instance where `MX_SKIP_SCHEMA` is normally set.
 
+=== Evolving the schema: the BACKFILL convention <schema-backfill>
+
+There is no separate migration tool and no ordered migration history. The
+schema file _is_ the migration: it is replayed in full on every connection and
+on every `mx migrate`. Schema evolution therefore happens by editing
+`schema/surrealdb-schema.surql` so that re-applying it is always idempotent.
+
+This model has one sharp edge that every contributor adding a field must know
+about, because the model is SCHEMAFULL.
+
+==== The SCHEMAFULL-stranding trap
+
+When you add a new *required* field (one whose type is not `option<...>`) to an
+existing table, SurrealDB does _not_ retroactively populate it. Every
+pre-existing row keeps that field as `NONE`. Reads usually survive, because
+projections coalesce the missing value (for example the
+`IF chunk_count THEN chunk_count ELSE 0 END` projection in
+`knowledge_select_fields()`). The danger is the next *write*: SurrealDB
+validates the whole record on any write, so the first time anything touches a
+stranded row it throws
+
+```
+Found NONE for field X ... but expected a <type>
+```
+
+This is how issue \#352 stranded 340 of 368 `knowledge` rows: `chunk_count`
+was added as a required `int`, and the pre-chunking rows had no value for it.
+
+==== THE RULE
+
+Whenever you add a required field to an existing table, add a paired,
+idempotent backfill `UPDATE` immediately after the `DEFINE`:
+
+```surql
+DEFINE FIELD chunk_count ON knowledge TYPE int DEFAULT 0;
+-- Backfill: required field added to an existing table strands old rows at NONE.
+UPDATE knowledge SET chunk_count = 0 WHERE chunk_count IS NONE;
+```
+
+Three requirements make a correct backfill:
+
++ *Guard with `WHERE <field> IS NONE`.* This makes the statement a no-op once
+  applied, so replaying the schema on every connection costs nothing and never
+  double-counts.
++ *Backfill, do not dodge.* Do not make the field `option<...>` just to avoid
+  the trap. Downstream code assumes the field is present; the backfill is the
+  correct fix.
++ *If the backfill computes a value, test the non-empty case.* A constant
+  backfill is self-evidently correct, but a computed one is not. Add a
+  regression test that asserts the computed value matches the real data, not
+  merely that the statement runs. The `chunk_count` backfill computes a count
+  by joining `embedding_chunk`, so `test_backfill_chunk_count_*` in
+  `src/surreal_db/tests.rs` guards it. Those tests use the `cfg(test)`-only
+  `test_exec` / `test_raw_chunk_count` helpers on `SurrealDatabase`, which read
+  the raw stored value _without_ the read-coalescing projection so a lingering
+  `NONE` cannot masquerade as `0`.
+
+The backfill block at the bottom of `schema/surrealdb-schema.surql` documents
+this rule inline and collects every historical backfill as a worked example.
+
 === Connection architecture
 
 The connection is represented as an enum:
@@ -447,7 +507,9 @@ the following field groups:
 - `embedding_model` (optional string), `embedded_at` (optional datetime)
 - `chunk_count` (int, default 0) -- number of embedding chunks. Zero means the
   entry is unchunked (single embedding). A positive value means the entry was
-  split into overlapping chunks stored in the `embedding_chunk` table.
+  split into overlapping chunks stored in the `embedding_chunk` table. This is a
+  required field; rows that predate it are repaired by a backfill -- see the
+  #link(<schema-backfill>)[BACKFILL convention].
 
 === Graph relations
 

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -367,8 +367,10 @@ UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 -- existing field is re-DEFINEd. So when we add a new REQUIRED (non-`option<>`)
 -- field to an existing table, every pre-existing row is left with that field
 -- as NONE. Reads survive via projection coalescing (e.g. the
--- `IF chunk_count THEN ... ELSE 0 END` projection), but the next WRITE that
--- touches such a row throws `Found NONE for field X ... but expected a <type>`.
+-- `IF chunk_count THEN chunk_count ELSE 0 END` projection — see
+-- knowledge_select_fields() in src/surreal_db/knowledge.rs), but the next WRITE
+-- that touches such a row throws
+-- `Found NONE for field X ... but expected a <type>`.
 --
 -- This file is replayed on EVERY connection (embedded AND network — see
 -- connection.rs apply_schema) and on every `mx migrate`. The DEFINE statements
@@ -382,6 +384,12 @@ UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 -- always guard with `WHERE <field> IS NONE` so re-running over already-fixed
 -- rows changes nothing. Never make a field `option<>` just to dodge this;
 -- backfill is the correct fix because downstream code assumes presence.
+-- If the backfill COMPUTES a value (not a constant), add a test that exercises
+-- the non-empty case — assert the computed value matches the real count, not
+-- just that the statement runs. Issue #352 is the cautionary tale: a chunk_count
+-- backfill shipped relying on a non-obvious SurrealDB sub-select quirk with only
+-- a throwaway probe; the permanent test (test_backfill_chunk_count_* in
+-- src/surreal_db/tests.rs) now guards it.
 
 -- Issues #72/#73: migrate single wake_phrase to wake_phrases array.
 -- Guard: only rows where wake_phrases was never set.
@@ -396,16 +404,22 @@ UPDATE knowledge SET format = 'markdown' WHERE format IS NONE;
 -- stranded with NONE — broken on next write.
 --
 -- The correct value is the actual number of embedding_chunk rows for the entry.
--- ID MISMATCH (kn-cb0a1fa2 / kn-747f2f37): a knowledge record id is
--- `knowledge:<hex>`, but `embedding_chunk.entry_id` stores the `kn-<hex>` form
--- as a plain string — NOT string-identical. We must translate the prefix when
+-- ID MISMATCH: a knowledge record id is `knowledge:<hex>`, but
+-- `embedding_chunk.entry_id` stores the `kn-<hex>` form (e.g. kn-<hex>) as a
+-- plain string — NOT string-identical. We must translate the prefix when
 -- joining: build the `kn-<hex>` key from meta::id(id) and count matching chunks.
--- For the 340 pre-chunking rows this correctly yields 0; for genuinely chunked
+-- For the pre-chunking rows this correctly yields 0; for genuinely chunked
 -- entries it yields the real count. Guard `WHERE chunk_count IS NONE` keeps it a
 -- no-op once applied.
-UPDATE knowledge SET chunk_count = (
-    SELECT VALUE count() FROM embedding_chunk
+--
+-- We use `array::len(SELECT id FROM ...)` rather than a `count() ... GROUP ALL`
+-- sub-select: it returns a plain int (naturally 0 on no matches), so there is no
+-- `[0].count ?? 0` projection-shape dependency to break across SurrealDB
+-- versions. Verified empirically against the live DB (2.6.1): both forms yield
+-- identical per-entry counts (24 chunked entries, 64 chunks total over 368 rows).
+-- Regression coverage: see test_backfill_chunk_count_* in src/surreal_db/tests.rs.
+UPDATE knowledge SET chunk_count = array::len(
+    SELECT id FROM embedding_chunk
     WHERE entry_id = string::concat('kn-', meta::id($parent.id))
-    GROUP ALL
-)[0].count ?? 0
+)
 WHERE chunk_count IS NONE;

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -356,13 +356,56 @@ UPSERT applicability_type:cli SET description = 'Command-line tools', scope = 'd
 UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 
 -- =============================================================================
--- DATA MIGRATION (Issues #72, #73, #122)
+-- BACKFILL (Issues #72, #73, #122, #352)
 -- =============================================================================
+--
+-- WHY THIS SECTION EXISTS
+-- -----------------------
+-- Our tables are SCHEMAFULL. SurrealDB validates the ENTIRE record on ANY
+-- write — both a full UPSERT and a partial `SET`. A `DEFAULT` clause on a
+-- field only fires when a NEW record is created; it does NOT fire when an
+-- existing field is re-DEFINEd. So when we add a new REQUIRED (non-`option<>`)
+-- field to an existing table, every pre-existing row is left with that field
+-- as NONE. Reads survive via projection coalescing (e.g. the
+-- `IF chunk_count THEN ... ELSE 0 END` projection), but the next WRITE that
+-- touches such a row throws `Found NONE for field X ... but expected a <type>`.
+--
+-- This file is replayed on EVERY connection (embedded AND network — see
+-- connection.rs apply_schema) and on every `mx migrate`. The DEFINE statements
+-- above are idempotent via `IF NOT EXISTS`; the statements below must be
+-- idempotent too.
+--
+-- THE RULE (read this before adding a required field)
+-- ---------------------------------------------------
+-- Whenever you add a new REQUIRED field to an existing table, add a PAIRED
+-- backfill statement here. Each statement MUST be a no-op once applied —
+-- always guard with `WHERE <field> IS NONE` so re-running over already-fixed
+-- rows changes nothing. Never make a field `option<>` just to dodge this;
+-- backfill is the correct fix because downstream code assumes presence.
 
--- Migrate existing single wake_phrase to wake_phrases array
--- Handle records where wake_phrases is NONE (not yet created)
+-- Issues #72/#73: migrate single wake_phrase to wake_phrases array.
+-- Guard: only rows where wake_phrases was never set.
 UPDATE knowledge SET wake_phrases = IF wake_phrase != NONE THEN [wake_phrase] ELSE [] END
 WHERE wake_phrases IS NONE;
 
--- Issue #122: Backfill format field for existing entries
+-- Issue #122: backfill format field for existing entries.
 UPDATE knowledge SET format = 'markdown' WHERE format IS NONE;
+
+-- Issue #352: backfill chunk_count for entries that predate chunking (Issue #346).
+-- chunk_count is `int DEFAULT 0` (required); 340/368 rows predate it and are
+-- stranded with NONE — broken on next write.
+--
+-- The correct value is the actual number of embedding_chunk rows for the entry.
+-- ID MISMATCH (kn-cb0a1fa2 / kn-747f2f37): a knowledge record id is
+-- `knowledge:<hex>`, but `embedding_chunk.entry_id` stores the `kn-<hex>` form
+-- as a plain string — NOT string-identical. We must translate the prefix when
+-- joining: build the `kn-<hex>` key from meta::id(id) and count matching chunks.
+-- For the 340 pre-chunking rows this correctly yields 0; for genuinely chunked
+-- entries it yields the real count. Guard `WHERE chunk_count IS NONE` keeps it a
+-- no-op once applied.
+UPDATE knowledge SET chunk_count = (
+    SELECT VALUE count() FROM embedding_chunk
+    WHERE entry_id = string::concat('kn-', meta::id($parent.id))
+    GROUP ALL
+)[0].count ?? 0
+WHERE chunk_count IS NONE;

--- a/src/store.rs
+++ b/src/store.rs
@@ -169,7 +169,11 @@ pub trait KnowledgeStore {
     /// Use for intentional single-entry access (e.g. `show`, `fact-session`).
     fn update_activations(&self, ids: &[String]) -> Result<()>;
 
-    /// Update only the summary field of a knowledge entry (targeted update, bypasses SCHEMAFULL UPSERT)
+    /// Update only the summary field of a knowledge entry (targeted partial `SET`).
+    /// NOTE: a partial `SET` does NOT bypass SCHEMAFULL validation — SurrealDB
+    /// validates the ENTIRE record on any write, so this still requires every
+    /// required field on the row to be present (see Issue #352 / the BACKFILL
+    /// section in schema/surrealdb-schema.surql).
     /// Respects visibility: agents can only update summaries on entries they can see.
     /// Returns Ok(false) for entries that don't exist OR that the agent can't see
     /// (to avoid leaking existence of private entries).

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -1230,4 +1230,57 @@ impl SurrealDatabase {
 
         Ok(pairs)
     }
+
+    // ------------------------------------------------------------------
+    // Test-only raw helpers (Issue #352 / W1 regression coverage).
+    //
+    // These exist so the chunk_count backfill test can drive a raw
+    // statement and read the stored value back WITHOUT going through the
+    // read-coalescing projection (which would mask a NONE as 0). They are
+    // compiled only under `cfg(test)` and never ship.
+    // ------------------------------------------------------------------
+
+    /// Execute an arbitrary statement, surfacing any per-statement errors.
+    #[cfg(test)]
+    pub(crate) fn test_exec(&self, sql: &str) -> Result<()> {
+        Self::runtime().block_on(async {
+            let mut response = with_db!(self, db, {
+                db.query(sql).await.context("test_exec query failed")
+            })?;
+            let errors = response.take_errors();
+            if !errors.is_empty() {
+                return Err(anyhow::anyhow!("test_exec statement errors: {:?}", errors));
+            }
+            Ok(())
+        })
+    }
+
+    /// Read the RAW stored `chunk_count` for `kn-<id_part>` without the
+    /// read-coalescing projection. Returns `None` when the field is NONE
+    /// (i.e. the pre-backfill state) and `Some(n)` once it holds an int.
+    #[cfg(test)]
+    pub(crate) fn test_raw_chunk_count(&self, entry_id: &str) -> Result<Option<i64>> {
+        let id_part = entry_id.strip_prefix("kn-").unwrap_or(entry_id).to_string();
+        Self::runtime().block_on(async {
+            let mut response = with_db!(self, db, {
+                db.query("SELECT chunk_count FROM type::thing('knowledge', $id)")
+                    .bind(("id", id_part.clone()))
+                    .await
+                    .context("test_raw_chunk_count query failed")
+            })?;
+            let rows: Vec<serde_json::Value> = response
+                .take(0)
+                .context("test_raw_chunk_count parse failed")?;
+            let row = match rows.first() {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+            // NONE serializes to JSON null; an int serializes to a number.
+            match row.get("chunk_count") {
+                Some(v) if v.is_null() => Ok(None),
+                Some(v) => Ok(v.as_i64()),
+                None => Ok(None),
+            }
+        })
+    }
 }

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -1915,3 +1915,130 @@ fn test_chunked_search_finds_buried_content() {
         results.iter().map(|e| e.id.as_str()).collect::<Vec<_>>()
     );
 }
+
+// =========================================================================
+// Issue #352 — chunk_count backfill regression coverage (W1).
+//
+// The chunk_count backfill computes a value rather than a constant, so it
+// gets a real test (per "THE RULE" in schema/surrealdb-schema.surql). It
+// covers: the non-empty case (entry with N>0 embedding_chunk rows), the zero
+// case (entry with no chunks), and idempotency (re-running over an
+// already-set value is a no-op). The throwaway probe that once "tested" this
+// was deleted; this is its permanent replacement.
+// =========================================================================
+
+/// The exact chunk_count backfill statement that ships in
+/// schema/surrealdb-schema.surql (Issue #352). Kept in sync with the schema:
+/// this test is the guard that the idiom actually counts chunks correctly.
+const BACKFILL_CHUNK_COUNT_SQL: &str = "UPDATE knowledge SET chunk_count = array::len(\
+    SELECT id FROM embedding_chunk \
+    WHERE entry_id = string::concat('kn-', meta::id($parent.id))) \
+    WHERE chunk_count IS NONE";
+
+/// Strand a knowledge row's `chunk_count` as NONE, faithfully reproducing the
+/// production pre-chunking state: SurrealDB forbids writing NONE to a required
+/// `int` field, so the only way a live row got NONE was the field being DEFINEd
+/// AFTER the row already existed (a re-DEFINE does not backfill existing rows).
+/// We reproduce that exactly: drop the field constraint, set the value to NONE,
+/// then re-DEFINE the field — the row keeps NONE, which the backfill must fix.
+fn strand_chunk_count_none(db: &SurrealDatabase, record: &str) {
+    db.test_exec("REMOVE FIELD IF EXISTS chunk_count ON knowledge")
+        .unwrap();
+    db.test_exec(&format!("UPDATE {} SET chunk_count = NONE", record))
+        .unwrap();
+    db.test_exec("DEFINE FIELD IF NOT EXISTS chunk_count ON knowledge TYPE int DEFAULT 0")
+        .unwrap();
+}
+
+/// Insert `n` embedding_chunk rows for `entry_id` (kn-<hex> form).
+fn insert_n_chunks(db: &SurrealDatabase, entry_id: &str, n: usize) {
+    for i in 0..n {
+        db.insert_embedding_chunk(
+            entry_id,
+            i,
+            &format!("chunk {} text", i),
+            i * 10,
+            10,
+            &[0.1f32, 0.2, 0.3],
+            "test-model",
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn test_backfill_chunk_count_nonempty() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Entry with 3 chunks. The id "kn-w1chunked" maps to record
+    // knowledge:w1chunked, and meta::id(id) yields "w1chunked", so the
+    // chunks must use entry_id "kn-w1chunked" (the backfill rebuilds that
+    // key via string::concat('kn-', meta::id(id))).
+    let entry = make_test_entry("kn-w1chunked", 5, 0.5);
+    db.upsert_knowledge(&entry).unwrap();
+    insert_n_chunks(&db, "kn-w1chunked", 3);
+
+    // Reproduce a pre-chunking row whose chunk_count is genuinely NONE.
+    strand_chunk_count_none(&db, "knowledge:w1chunked");
+    assert_eq!(
+        db.test_raw_chunk_count("kn-w1chunked").unwrap(),
+        None,
+        "precondition: chunk_count should be NONE before backfill"
+    );
+
+    // Run the real backfill.
+    db.test_exec(BACKFILL_CHUNK_COUNT_SQL).unwrap();
+
+    assert_eq!(
+        db.test_raw_chunk_count("kn-w1chunked").unwrap(),
+        Some(3),
+        "backfill must count the 3 embedding_chunk rows"
+    );
+}
+
+#[test]
+fn test_backfill_chunk_count_zero_case() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Entry with NO chunks (a pre-chunking row that was never chunked).
+    let entry = make_test_entry("kn-w1zero", 5, 0.5);
+    db.upsert_knowledge(&entry).unwrap();
+
+    strand_chunk_count_none(&db, "knowledge:w1zero");
+    assert_eq!(db.test_raw_chunk_count("kn-w1zero").unwrap(), None);
+
+    db.test_exec(BACKFILL_CHUNK_COUNT_SQL).unwrap();
+
+    // array::len over an empty SELECT is naturally 0 — no projection-shape
+    // dependency, which is the whole point of the S1 form.
+    assert_eq!(
+        db.test_raw_chunk_count("kn-w1zero").unwrap(),
+        Some(0),
+        "entry with no chunks must backfill to 0"
+    );
+}
+
+#[test]
+fn test_backfill_chunk_count_idempotent() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    let entry = make_test_entry("kn-w1idem", 5, 0.5);
+    db.upsert_knowledge(&entry).unwrap();
+    insert_n_chunks(&db, "kn-w1idem", 2);
+
+    strand_chunk_count_none(&db, "knowledge:w1idem");
+    db.test_exec(BACKFILL_CHUNK_COUNT_SQL).unwrap();
+    assert_eq!(db.test_raw_chunk_count("kn-w1idem").unwrap(), Some(2));
+
+    // Add MORE chunks after the value is set. The guard WHERE chunk_count IS
+    // NONE means a second run must NOT touch the already-set value, even
+    // though the underlying chunk count has changed. This proves the no-op
+    // guarantee that keeps the statement safe to replay on every connection.
+    insert_n_chunks(&db, "kn-w1idem", 5); // now 5 chunks total on disk
+    db.test_exec(BACKFILL_CHUNK_COUNT_SQL).unwrap();
+    assert_eq!(
+        db.test_raw_chunk_count("kn-w1idem").unwrap(),
+        Some(2),
+        "re-running backfill must not change an already-set chunk_count"
+    );
+}


### PR DESCRIPTION
## Summary
- Fixes the systemic SCHEMAFULL bug where adding a required field strands pre-existing rows (they error on the next write because SurrealDB validates the whole record, and `DEFAULT` only fires on new-record creation).
- Backfills `knowledge.chunk_count` — 340 of 368 rows were live-broken (`Found NONE for field chunk_count`).
- Formalizes the ad-hoc data-migration block in `schema/surrealdb-schema.surql` into a documented, idempotent **BACKFILL** convention: every new required field gets a paired `UPDATE ... WHERE field IS NONE`.
- Corrects a false comment in `src/store.rs` that claimed partial `SET` bypasses SCHEMAFULL validation (it does not).

## Files affected
- `schema/surrealdb-schema.surql` — BACKFILL section + chunk_count backfill (mind the `kn-<hex>` vs `knowledge:<hex>` id translation)
- `src/store.rs` — corrected comment

## Test results
- `cargo build`: clean
- `cargo test`: 1045 passed (1023 lib + 22 integration), 0 failed, 3 ignored
- Live DB: after migrate, 0 of 368 rows have `chunk_count IS NONE`; the previously-broken row `knowledge:000e0212` now accepts a write and persists.

## Notes
- The 340 backfilled rows all predate chunking, so their true count is 0; the count-join path for genuinely-chunked entries was exercised only by a throwaway probe test (now deleted) — reviewer should scrutinize that query's correctness.

Closes #352