### PR TITLE
fix(memory): divert large `mx memory show` output to temp file (#181)

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -29,60 +29,75 @@ pub(crate) fn print_entry_summary(entry: &knowledge::KnowledgeEntry) {
 }
 
 pub(crate) fn print_entry_full(entry: &knowledge::KnowledgeEntry) {
-    println!("ID:       {}", entry.id);
-    println!("Category: {}", entry.category_id);
+    print!("{}", format_entry_full(entry));
+}
+
+/// Render the full detail view of an entry into a String.
+///
+/// Split out from `print_entry_full` so callers (e.g. `mx memory show`) can
+/// measure the rendered byte length before deciding whether to print it to
+/// stdout or divert it to a temp file. The returned string ends with a
+/// trailing newline, matching the previous `println!`-based output exactly.
+pub(crate) fn format_entry_full(entry: &knowledge::KnowledgeEntry) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    let _ = writeln!(out, "ID:       {}", entry.id);
+    let _ = writeln!(out, "Category: {}", entry.category_id);
 
     // Extract state from summary if present
     let state = entry.get_summary_state();
 
     if let Some(state) = state {
-        println!("Title:    {} ({})", entry.title, state);
+        let _ = writeln!(out, "Title:    {} ({})", entry.title, state);
     } else {
-        println!("Title:    {}", entry.title);
+        let _ = writeln!(out, "Title:    {}", entry.title);
     }
 
     if entry.resonance > 0 {
-        println!("Resonance: {}", entry.resonance);
+        let _ = writeln!(out, "Resonance: {}", entry.resonance);
     }
     if let Some(ref rtype) = entry.resonance_type {
-        println!("Resonance Type: {}", rtype);
+        let _ = writeln!(out, "Resonance Type: {}", rtype);
     }
     if let Some(ref phrase) = entry.wake_phrase {
-        println!("Wake Phrase: {}", phrase);
+        let _ = writeln!(out, "Wake Phrase: {}", phrase);
     }
     if !entry.wake_phrases.is_empty() {
-        println!("Wake Phrases: {}", entry.wake_phrases.join(", "));
+        let _ = writeln!(out, "Wake Phrases: {}", entry.wake_phrases.join(", "));
     }
     if let Some(path) = &entry.file_path {
-        println!("File:     {}", path);
+        let _ = writeln!(out, "File:     {}", path);
     }
     if !entry.tags.is_empty() {
-        println!("Tags:     {}", entry.tags.join(", "));
+        let _ = writeln!(out, "Tags:     {}", entry.tags.join(", "));
     }
     if !entry.applicability.is_empty() {
-        println!("Applicability: {}", entry.applicability.join(", "));
+        let _ = writeln!(out, "Applicability: {}", entry.applicability.join(", "));
     }
     if !entry.anchors.is_empty() {
-        println!("Anchors:  {}", entry.anchors.join(", "));
+        let _ = writeln!(out, "Anchors:  {}", entry.anchors.join(", "));
     }
     // Always show visibility for private entries (public is the default)
     if entry.visibility == "private" {
-        println!("Visibility: {}", entry.visibility);
+        let _ = writeln!(out, "Visibility: {}", entry.visibility);
         if let Some(ref o) = entry.owner {
-            println!("Owner:    {}", o);
+            let _ = writeln!(out, "Owner:    {}", o);
         }
     }
     if let Some(created) = &entry.created_at {
-        println!("Created:  {}", created);
+        let _ = writeln!(out, "Created:  {}", created);
     }
     if let Some(updated) = &entry.updated_at {
-        println!("Updated:  {}", updated);
+        let _ = writeln!(out, "Updated:  {}", updated);
     }
-    println!("Format:   {}", entry.format);
-    println!();
+    let _ = writeln!(out, "Format:   {}", entry.format);
+    let _ = writeln!(out);
     if let Some(body) = &entry.body {
-        println!("{}", body);
+        let _ = writeln!(out, "{}", body);
     }
+
+    out
 }
 
 pub(crate) fn print_wake_cascade(cascade: &store::WakeCascade) {

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -11,6 +11,88 @@ use crate::wake_ritual;
 
 use super::metadata::*;
 
+/// Maximum byte length of `mx memory show` stdout before content is diverted
+/// to a temp file instead.
+///
+/// Claude Code's Bash tool persists any command stdout larger than exactly
+/// 30,000 bytes to a temp file and shows the model only a ~2KB preview -- the
+/// model does NOT auto-read the persisted file, so large memories become
+/// effectively invisible. We divert at a safe margin below that hard ceiling
+/// so the pointer message (plus any minor overhead) always stays inline.
+///
+/// This is a pure BYTE count: the Bash ceiling is not affected by token
+/// density, line count, or content type, so we measure `str::len()` (bytes),
+/// never `chars().count()`.
+const BASH_STDOUT_DIVERT_THRESHOLD: usize = 28_000;
+
+/// What to do with a rendered `mx memory show` payload.
+#[derive(Debug, PartialEq, Eq)]
+enum ShowOutput {
+    /// Content fits under the threshold -- print it to stdout as-is.
+    Inline,
+    /// Content exceeds the threshold -- write it to `path` and print `pointer`.
+    Divert {
+        path: std::path::PathBuf,
+        pointer: String,
+    },
+}
+
+/// Decide whether a rendered payload should be printed inline or diverted to a
+/// temp file, and (for the divert case) compute the target path and the short
+/// pointer message that will be printed to stdout instead.
+///
+/// Pure function (no IO) so the threshold logic, byte-length measurement, and
+/// pointer message can be unit-tested directly. `temp_dir` is injected for the
+/// same reason. `id` is the normalized memory id (e.g. `kn-99e08808`).
+fn plan_show_output(content: &str, id: &str, temp_dir: &std::path::Path) -> ShowOutput {
+    // BYTE length -- multibyte UTF-8 makes char count an undercount, and the
+    // Bash ceiling is a hard byte count.
+    let byte_len = content.len();
+    if byte_len <= BASH_STDOUT_DIVERT_THRESHOLD {
+        return ShowOutput::Inline;
+    }
+
+    let line_count = content.lines().count();
+    let path = temp_dir.join(format!("mx-memory-{}.md", id));
+    let pointer = format!(
+        "Memory {id} is {byte_len} bytes ({line_count} lines).\n\
+         Content written to: {path}\n\
+         Read the file to see full content.\n",
+        id = id,
+        byte_len = byte_len,
+        line_count = line_count,
+        path = path.display(),
+    );
+    ShowOutput::Divert { path, pointer }
+}
+
+/// Emit a rendered `mx memory show` payload, diverting to a temp file when it
+/// would exceed the Bash stdout ceiling. `trailing_newline` controls whether a
+/// newline is appended in the inline case (the `--content-only` path historically
+/// uses `print!` with no trailing newline; the JSON and full views already end
+/// in one).
+fn emit_show_output(content: &str, id: &str, trailing_newline: bool) -> Result<()> {
+    use std::io::Write;
+    match plan_show_output(content, id, &std::env::temp_dir()) {
+        ShowOutput::Inline => {
+            let mut stdout = std::io::stdout();
+            stdout.write_all(content.as_bytes())?;
+            if trailing_newline {
+                stdout.write_all(b"\n")?;
+            }
+            // Flush explicitly -- line-buffered stdout may not flush when piped.
+            stdout.flush()?;
+        }
+        ShowOutput::Divert { path, pointer } => {
+            std::fs::write(&path, content)
+                .with_context(|| format!("failed to write memory content to {}", path.display()))?;
+            print!("{}", pointer);
+            std::io::stdout().flush()?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
     let config = IndexConfig::default();
 
@@ -186,19 +268,21 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         eprintln!("Warning: failed to update activation: {}", e);
                     }
 
+                    // Render the chosen view to a String first, then route it
+                    // through emit_show_output so any view that would blow past
+                    // the Bash stdout ceiling gets diverted to a temp file.
                     if content_only {
                         if let Some(body) = &entry.body {
-                            print!("{}", body);
-                            // Flush stdout explicitly -- `print!` (no newline)
-                            // uses line-buffered stdout which may not flush when
-                            // output is piped to a file or another process.
-                            use std::io::Write;
-                            std::io::stdout().flush()?;
+                            // Preserve historical behavior: no trailing newline.
+                            emit_show_output(body, &entry.id, false)?;
                         }
                     } else if json {
-                        println!("{}", serde_json::to_string_pretty(&entry)?);
+                        let rendered = serde_json::to_string_pretty(&entry)?;
+                        emit_show_output(&rendered, &entry.id, true)?;
                     } else {
-                        print_entry_full(&entry);
+                        let rendered = format_entry_full(&entry);
+                        // format_entry_full already ends in a newline.
+                        emit_show_output(&rendered, &entry.id, false)?;
                     }
                 }
                 None => {
@@ -2482,4 +2566,101 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod show_divert_tests {
+    use super::*;
+    use std::path::Path;
+
+    const ID: &str = "kn-99e08808";
+
+    #[test]
+    fn under_threshold_prints_inline() {
+        let content = "small memory body\n";
+        let plan = plan_show_output(content, ID, Path::new("/tmp"));
+        assert_eq!(plan, ShowOutput::Inline);
+    }
+
+    #[test]
+    fn empty_content_is_inline() {
+        let plan = plan_show_output("", ID, Path::new("/tmp"));
+        assert_eq!(plan, ShowOutput::Inline);
+    }
+
+    #[test]
+    fn over_threshold_writes_file_and_pointer() {
+        // One byte over the threshold must divert.
+        let content = "a".repeat(BASH_STDOUT_DIVERT_THRESHOLD + 1);
+        let plan = plan_show_output(&content, ID, Path::new("/tmp"));
+        match plan {
+            ShowOutput::Divert { path, pointer } => {
+                assert_eq!(path, Path::new("/tmp/mx-memory-kn-99e08808.md"));
+                // Pointer reports the true BYTE length.
+                assert!(
+                    pointer.contains(&format!("{} bytes", BASH_STDOUT_DIVERT_THRESHOLD + 1)),
+                    "pointer missing byte count: {pointer}"
+                );
+                assert!(pointer.contains("/tmp/mx-memory-kn-99e08808.md"));
+                assert!(pointer.contains("Read the file to see full content."));
+                // The pointer itself must stay safely under the ceiling.
+                assert!(pointer.len() < BASH_STDOUT_DIVERT_THRESHOLD);
+            }
+            ShowOutput::Inline => panic!("expected divert for oversized content"),
+        }
+    }
+
+    #[test]
+    fn boundary_exactly_at_threshold_is_inline() {
+        // Exactly at the threshold stays inline (the check is `<=`).
+        let content = "a".repeat(BASH_STDOUT_DIVERT_THRESHOLD);
+        assert_eq!(content.len(), BASH_STDOUT_DIVERT_THRESHOLD);
+        let plan = plan_show_output(&content, ID, Path::new("/tmp"));
+        assert_eq!(plan, ShowOutput::Inline);
+    }
+
+    #[test]
+    fn boundary_counts_bytes_not_chars() {
+        // 'é' (U+00E9) is 2 bytes in UTF-8 but 1 char. A string whose CHAR
+        // count is under the threshold but whose BYTE count is over it must
+        // divert -- proving we measure bytes, not chars.
+        let multibyte = "é".repeat(BASH_STDOUT_DIVERT_THRESHOLD - 1);
+        assert!(multibyte.chars().count() < BASH_STDOUT_DIVERT_THRESHOLD);
+        assert!(multibyte.len() > BASH_STDOUT_DIVERT_THRESHOLD);
+        let plan = plan_show_output(&multibyte, ID, Path::new("/tmp"));
+        assert!(
+            matches!(plan, ShowOutput::Divert { .. }),
+            "multibyte content over the byte ceiling must divert"
+        );
+    }
+
+    #[test]
+    fn pointer_line_count_is_accurate() {
+        // 5 lines, each padded so the total exceeds the threshold.
+        let line = "x".repeat(BASH_STDOUT_DIVERT_THRESHOLD);
+        let content = format!("{line}\n{line}\n{line}\n{line}\n{line}\n");
+        match plan_show_output(&content, ID, Path::new("/tmp")) {
+            ShowOutput::Divert { pointer, .. } => {
+                assert!(
+                    pointer.contains("(5 lines)"),
+                    "expected 5 lines in pointer: {pointer}"
+                );
+            }
+            ShowOutput::Inline => panic!("expected divert"),
+        }
+    }
+
+    #[test]
+    fn emit_diverts_oversized_content_to_real_temp_file() {
+        // End-to-end through the IO wrapper: file is written with full content.
+        let id = "kn-emittest1";
+        let content = "z".repeat(BASH_STDOUT_DIVERT_THRESHOLD + 100);
+        emit_show_output(&content, id, false).expect("emit should succeed");
+
+        let expected = std::env::temp_dir().join(format!("mx-memory-{id}.md"));
+        let written = std::fs::read_to_string(&expected).expect("temp file should exist");
+        assert_eq!(written, content, "diverted file must hold the full content");
+
+        let _ = std::fs::remove_file(&expected);
+    }
 }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -2592,16 +2592,29 @@ mod show_divert_tests {
     fn over_threshold_writes_file_and_pointer() {
         // One byte over the threshold must divert.
         let content = "a".repeat(BASH_STDOUT_DIVERT_THRESHOLD + 1);
-        let plan = plan_show_output(&content, ID, Path::new("/tmp"));
+        let temp_dir = Path::new("/tmp");
+        let plan = plan_show_output(&content, ID, temp_dir);
+        // Derive the expected path the same way the code does (`temp_dir.join`)
+        // so the assertion is platform-agnostic -- on Windows the joined
+        // separator is a backslash, so a hardcoded `/tmp/...` literal can never
+        // match. Comparing against the joined path proves the real derived path.
+        let expected_path = temp_dir.join("mx-memory-kn-99e08808.md");
         match plan {
             ShowOutput::Divert { path, pointer } => {
-                assert_eq!(path, Path::new("/tmp/mx-memory-kn-99e08808.md"));
+                assert_eq!(path, expected_path);
                 // Pointer reports the true BYTE length.
                 assert!(
                     pointer.contains(&format!("{} bytes", BASH_STDOUT_DIVERT_THRESHOLD + 1)),
                     "pointer missing byte count: {pointer}"
                 );
-                assert!(pointer.contains("/tmp/mx-memory-kn-99e08808.md"));
+                // The pointer renders the path via `Path::display()`, so derive
+                // the expected substring the same way rather than assuming a
+                // POSIX separator.
+                let expected_path_str = expected_path.display().to_string();
+                assert!(
+                    pointer.contains(&expected_path_str),
+                    "pointer missing path {expected_path_str}: {pointer}"
+                );
                 assert!(pointer.contains("Read the file to see full content."));
                 // The pointer itself must stay safely under the ceiling.
                 assert!(pointer.len() < BASH_STDOUT_DIVERT_THRESHOLD);


### PR DESCRIPTION
## Problem

When `mx memory show` outputs content larger than ~30,000 bytes, Claude Code's Bash tool persists the output to a temp file and shows the model only a ~2KB preview. The model does **not** auto-read the persisted file, so large memories are effectively invisible.

The 30,000-byte threshold is a hard **byte** count (empirically determined via binary search in the truncation lab, shift 2026-03-25) -- not tokens, not lines, not content-type dependent.

## Fix

`mx memory show` now measures the **byte length** of its rendered output and, when it would exceed a safe margin below the ceiling, writes the content to a temp file and prints a short pointer message instead:

```
Memory kn-99e08808 is 49646 bytes (300 lines).
Content written to: /tmp/mx-memory-kn-99e08808.md
Read the file to see full content.
```

The model then uses the Read tool (which handles large files via its own paging) to access the full content through the right pipe.

### Details

- **Named threshold constant** `BASH_STDOUT_DIVERT_THRESHOLD = 28_000` in `src/handlers/memory.rs`, with a comment documenting the 30KB Bash ceiling rationale and why we leave margin.
- **Measures bytes, not chars/lines** (`str::len()`), since the ceiling is a hard byte count and multibyte UTF-8 makes char count an undercount.
- **No regression for small memories**: at or below the threshold, output prints to stdout exactly as before (verified: small `show` is byte-identical to prior output, including `--content-only`'s no-trailing-newline behavior).
- **All three view modes** are routed through the diversion logic: default full view, `--json`, and `--content-only`.
- **Deterministic temp path**: `<system temp dir>/mx-memory-<id>.md` via `std::env::temp_dir()` (honors `TMPDIR`).
- **Pointer message stays safely under the threshold** (asserted in tests; ~140 bytes in practice).
- **Missing-id error behavior preserved** (`Error: Entry '...' not found`, exit 1).

### Refactor

`display::print_entry_full` is split into a pure `format_entry_full(&entry) -> String` (returns the rendered view, trailing newline preserved) plus a thin printing wrapper, so the Show handler can measure byte length before deciding how to emit.

## Design decisions / scope

- The issue's "Additionally" suggestion to add a size warning to `mx memory add` is **intentionally out of scope** for this PR -- it's a separate concern (input validation) from the read-path ceiling fix. Happy to follow up in a separate issue/PR if desired.
- Diversion applies to **all** view modes, not just `--content-only`, because the full and JSON views can also exceed 30KB for large bodies.

## Tests

Added `show_divert_tests` in `src/handlers/memory.rs` covering:
- under-threshold prints inline
- empty content is inline
- over-threshold writes file + prints pointer (with correct byte count and path)
- boundary exactly at threshold is inline
- **byte-length boundary**: multibyte UTF-8 whose *char* count is under but *byte* count is over the threshold diverts (proves bytes, not chars)
- pointer line count accuracy
- end-to-end through the IO wrapper: the temp file holds the full content

Results: `cargo test` -> 1033 unit + 22 integration tests pass, 0 failures. `cargo clippy --all-targets` clean. `cargo fmt --check` clean.

Manually verified against the real binary: small memory prints inline byte-identically; a ~53KB memory diverts with 142-byte stdout and a complete 52986-byte temp file.

Closes #181