### PR TITLE
feat(memory): add triggers field to knowledge store (#246) [1/4]

### DIFF
--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -131,6 +131,25 @@ DEFINE FIELD IF NOT EXISTS wake_phrases ON knowledge TYPE array<string> DEFAULT 
 DEFINE FIELD IF NOT EXISTS wake_order ON knowledge TYPE option<int>;
 DEFINE INDEX IF NOT EXISTS knowledge_wake_order ON knowledge FIELDS wake_order;
 
+-- Issue #246: Trigger keywords for reactive memory injection.
+-- Mirrors the wake_phrases field exactly: `array<string> DEFAULT []`.
+--
+-- NO BACKFILL IS NEEDED HERE (and a future reader should NOT add one).
+-- The stranding bug documented in the BACKFILL section below only afflicts
+-- REQUIRED SCALAR fields (e.g. `int DEFAULT 0`): when such a field is added to
+-- a SCHEMAFULL table, pre-existing rows hold NONE and the next write throws
+-- "Found NONE for field X". `array<string> DEFAULT []` is the safe pattern and
+-- is immune for two reasons working together:
+--   1. READ PATH coalesce: knowledge_select_fields() projects
+--      `IF triggers THEN triggers ELSE [] END`, so any pre-existing row whose
+--      `triggers` is NONE reads back as `[]` -- never observed as NONE.
+--   2. WRITE PATH always binds: upsert_knowledge_async always sets
+--      `triggers = $triggers` (bound, never NONE), so the moment any row is
+--      written it gets a concrete array. No row is ever left stranded with NONE.
+-- Because both halves hold, there is no window in which a row needs a backfill.
+DEFINE FIELD IF NOT EXISTS triggers ON knowledge TYPE array<string> DEFAULT [];
+DEFINE INDEX IF NOT EXISTS knowledge_triggers ON knowledge FIELDS triggers;
+
 -- DEPRECATED: Kept for backward compatibility during migration
 DEFINE FIELD IF NOT EXISTS wake_phrase ON knowledge TYPE option<string>;
 

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -626,6 +626,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     decay_rate: 0.0,
                     anchors: vec![],
                     wake_phrases: vec![],
+                    // Issue #246: triggers wired through the CLI in PR2; default empty for now.
+                    triggers: vec![],
                     wake_order: None,
                     wake_phrase: None,
                     embedding: None,
@@ -797,6 +799,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 decay_rate: 0.0,
                 anchors: anchor_list,
                 wake_phrases: wake_phrase_list,
+                // Issue #246: triggers wired through the CLI in PR2; default empty for now.
+                triggers: vec![],
                 wake_order,
                 wake_phrase,
                 embedding: None,

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -74,6 +74,10 @@ pub struct KnowledgeEntry {
     #[serde(default)]
     pub wake_phrases: Vec<String>, // Multiple phrases for ritual variety
 
+    // Issue #246: Trigger keywords for reactive memory injection
+    #[serde(default)]
+    pub triggers: Vec<String>, // Keywords/phrases that reactively inject this memory
+
     // Issue #73: Custom wake order
     #[serde(default)]
     pub wake_order: Option<i32>, // Custom wake sequence (lower = earlier)
@@ -103,6 +107,44 @@ pub struct KnowledgeEntry {
     // raw `resonance` does not account for age.
     #[serde(default)]
     pub effective_resonance: Option<f64>,
+}
+
+/// Normalize a single trigger keyword/phrase for storage and matching (Issue #246).
+///
+/// Lowercases, trims, and collapses internal whitespace runs to a single space.
+/// Returns `None` when the input is empty after trimming, so callers can drop
+/// blank entries.
+///
+/// This is the single source of truth for trigger normalization, shared by the
+/// store write path (PR1), the CLI flag parsing (PR2), and the trigger matcher
+/// (PR3): all three MUST normalize identically so author-time and match-time
+/// values line up.
+pub fn normalize_trigger(raw: &str) -> Option<String> {
+    let collapsed = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        None
+    } else {
+        Some(collapsed.to_lowercase())
+    }
+}
+
+/// Normalize a collection of triggers: apply `normalize_trigger` to each, drop
+/// empties, and dedupe while preserving first-seen order (Issue #246).
+pub fn normalize_triggers<I, S>(raw: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for item in raw {
+        if let Some(norm) = normalize_trigger(item.as_ref())
+            && seen.insert(norm.clone())
+        {
+            out.push(norm);
+        }
+    }
+    out
 }
 
 fn default_format() -> String {
@@ -241,6 +283,41 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_trigger() {
+        // Lowercase + trim + collapse internal whitespace
+        assert_eq!(
+            normalize_trigger("  Blood   Sugar "),
+            Some("blood sugar".to_string())
+        );
+        assert_eq!(normalize_trigger("Brad"), Some("brad".to_string()));
+        // Empty / whitespace-only -> None
+        assert_eq!(normalize_trigger(""), None);
+        assert_eq!(normalize_trigger("   "), None);
+        assert_eq!(normalize_trigger("\t\n"), None);
+    }
+
+    #[test]
+    fn test_normalize_triggers_dedupe_and_order() {
+        let out = normalize_triggers(vec![
+            "Brad",
+            "  blood   sugar ",
+            "BLOOD SUGAR", // dup after normalization
+            "Glucose",
+            "",     // dropped
+            "   ",  // dropped
+            "brad", // dup
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                "brad".to_string(),
+                "blood sugar".to_string(),
+                "glucose".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn test_embedding_text() {
         let entry = KnowledgeEntry {
             id: "kn-test".to_string(),
@@ -270,6 +347,7 @@ mod tests {
             decay_rate: 0.0,
             anchors: vec![],
             wake_phrases: vec![],
+            triggers: vec![],
             wake_order: None,
             wake_phrase: None,
             embedding: None,
@@ -316,6 +394,7 @@ mod tests {
             decay_rate: 0.0,
             anchors: vec![],
             wake_phrases: vec![],
+            triggers: vec![],
             wake_order: None,
             wake_phrase: None,
             embedding: None,

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -118,6 +118,10 @@ pub(super) struct SurrealKnowledgeRecord {
     #[serde(default)]
     pub wake_phrases: Vec<String>,
 
+    // Issue #246: Trigger keywords for reactive memory injection
+    #[serde(default)]
+    pub triggers: Vec<String>,
+
     // Issue #73: Custom wake order
     #[serde(default)]
     pub wake_order: Option<i32>,
@@ -193,6 +197,7 @@ impl SurrealKnowledgeRecord {
             decay_rate: self.decay_rate,
             anchors: self.anchors,
             wake_phrases: self.wake_phrases,
+            triggers: self.triggers,
             wake_order: self.wake_order,
             wake_phrase: self.wake_phrase,
             embedding: self.embedding,
@@ -225,6 +230,7 @@ impl SurrealDatabase {
         IF decay_rate THEN decay_rate ELSE 0.0 END AS decay_rate,
         IF anchors THEN anchors ELSE [] END AS anchors,
         IF wake_phrases THEN wake_phrases ELSE [] END AS wake_phrases,
+        IF triggers THEN triggers ELSE [] END AS triggers,
         IF wake_order THEN wake_order ELSE null END AS wake_order,
         IF wake_phrase THEN wake_phrase ELSE null END AS wake_phrase,
         IF embedding THEN embedding ELSE null END AS embedding,
@@ -428,6 +434,7 @@ impl SurrealDatabase {
             decay_rate = $decay_rate,
             anchors = $anchors,
             wake_phrases = $wake_phrases,
+            triggers = $triggers,
             wake_order = $wake_order,
             wake_phrase = $wake_phrase,
             embedding = $embedding,
@@ -503,6 +510,13 @@ impl SurrealDatabase {
                 .bind(("decay_rate", entry.decay_rate))
                 .bind(("anchors", entry.anchors.clone()))
                 .bind(("wake_phrases", entry.wake_phrases.clone()))
+                // Issue #246: normalize triggers on write (lowercase + collapse
+                // whitespace, drop empties, dedupe) so author-time values line up
+                // with match-time lookups in PR3. Bound param, never interpolated.
+                .bind((
+                    "triggers",
+                    crate::knowledge::normalize_triggers(entry.triggers.iter()),
+                ))
                 .bind(("wake_order", entry.wake_order))
                 .bind(("wake_phrase", entry.wake_phrase.clone()))
                 .bind(("embedding", entry.embedding.clone()))
@@ -1081,6 +1095,7 @@ impl SurrealDatabase {
             decay_rate: serde_json::from_value(obj["decay_rate"].clone()).unwrap_or(0.0),
             anchors: serde_json::from_value(obj["anchors"].clone()).unwrap_or_default(),
             wake_phrases: serde_json::from_value(obj["wake_phrases"].clone()).unwrap_or_default(),
+            triggers: serde_json::from_value(obj["triggers"].clone()).unwrap_or_default(),
             wake_order: serde_json::from_value(obj["wake_order"].clone()).ok(),
             wake_phrase: serde_json::from_value(obj["wake_phrase"].clone()).ok(),
             embedding: serde_json::from_value(obj["embedding"].clone()).ok(),

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -141,6 +141,7 @@ fn make_test_entry(id: &str, resonance: i32, decay_rate: f64) -> crate::knowledg
         decay_rate,
         anchors: vec![],
         wake_phrases: vec![],
+        triggers: vec![],
         wake_order: None,
         wake_phrase: None,
         embedding: None,
@@ -2494,5 +2495,69 @@ fn test_backfill_chunk_count_idempotent() {
         db.test_raw_chunk_count("kn-w1idem").unwrap(),
         Some(2),
         "re-running backfill must not change an already-set chunk_count"
+    );
+}
+
+// =========================================================================
+// TRIGGERS (Issue #246, PR 1/4 -- data layer)
+// =========================================================================
+
+#[test]
+fn test_triggers_round_trip_normalized_and_deduped() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    let mut entry = make_test_entry("kn-trig1", 5, 0.0);
+    // Mix of cases needing normalization: uppercase, leading/trailing space,
+    // collapsible internal whitespace, an exact duplicate (post-normalization),
+    // and an empty string that must be dropped.
+    entry.triggers = vec![
+        "Brad".to_string(),
+        "  blood   sugar ".to_string(),
+        "BLOOD SUGAR".to_string(), // dup of "blood sugar" after normalization
+        "Glucose".to_string(),
+        "".to_string(),    // empty -> dropped
+        "   ".to_string(), // whitespace-only -> dropped
+    ];
+    db.upsert_knowledge(&entry).unwrap();
+
+    let ctx = crate::store::AgentContext::public_only();
+    let got = db
+        .get("kn-trig1", &ctx)
+        .unwrap()
+        .expect("entry should exist");
+
+    // Normalized: lowercased, whitespace-collapsed, empties dropped, deduped,
+    // first-seen order preserved.
+    assert_eq!(
+        got.triggers,
+        vec![
+            "brad".to_string(),
+            "blood sugar".to_string(),
+            "glucose".to_string(),
+        ],
+        "triggers must be normalized, deduped, and empty-dropped on write"
+    );
+}
+
+#[test]
+fn test_triggers_default_empty_when_absent() {
+    // No-backfill safety: an entry created WITHOUT triggers must read back as
+    // `[]` (never NONE), via the `IF triggers THEN triggers ELSE [] END`
+    // read-path coalesce plus the always-bound write path.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    let entry = make_test_entry("kn-trig2", 5, 0.0); // make_test_entry sets triggers: vec![]
+    db.upsert_knowledge(&entry).unwrap();
+
+    let ctx = crate::store::AgentContext::public_only();
+    let got = db
+        .get("kn-trig2", &ctx)
+        .unwrap()
+        .expect("entry should exist");
+
+    assert_eq!(
+        got.triggers,
+        Vec::<String>::new(),
+        "an entry with no triggers must read back as an empty array"
     );
 }


### PR DESCRIPTION
## PR 1 of 4 — Triggered Memories (data layer only)

Foundation PR for #246 (keyword "triggers" for reactive memory injection). This PR does **only** the data-layer plumbing for the `triggers` field, end to end. It gates the later PRs and is intentionally tight.

This PR does **NOT** close #246 — the feature is completed by later PRs:
- **PR 2/4:** CLI flags (`mx memory add/update --triggers`)
- **PR 3/4:** trigger matcher + `mx memory trigger-check`
- **PR 4/4:** hook integration + session-scoped one-shot dedup

### What this PR does
Adds the `triggers` field (`array<string>`, like `wake_phrases`) through every data layer, mirroring the `wake_phrases` precedent line-for-line:

- **Schema** (`schema/surrealdb-schema.surql`): `DEFINE FIELD triggers ... TYPE array<string> DEFAULT []` + `DEFINE INDEX knowledge_triggers`.
- **Rust structs**: `triggers: Vec<String>` with `#[serde(default)]` on both `KnowledgeEntry` and the `SurrealKnowledgeRecord` DTO (old serialized data deserializes cleanly to `[]`).
- **Read path**: `IF triggers THEN triggers ELSE [] END` coalesce in `knowledge_select_fields()`, wired through `into_knowledge_entry` and `value_to_knowledge_entry`.
- **Write path**: `triggers = $triggers` in the upsert SET clause, bound (never interpolated).
- **Normalization on write**: reusable `normalize_trigger(&str) -> Option<String>` and `normalize_triggers(...)` in `src/knowledge.rs` (lowercase + whitespace-collapse, drop empties, dedupe preserving first-seen order). The write path normalizes before binding. These helpers are `pub` so PR2 (CLI) and PR3 (matcher) import the **single source of truth** for normalization.

### No-backfill rationale (read before "fixing")
Unlike the SCHEMAFULL stranding bug that required backfill for required **scalar** fields (e.g. `chunk_count`, Issue #352), `array<string> DEFAULT []` is the safe pattern and needs **no** backfill. A documented comment in the schema explains why, so a future reader does not add one:
1. **Read coalesce** — pre-existing rows whose `triggers` is NONE read back as `[]`.
2. **Write always binds** — any write sets a concrete array, so no row is ever stranded with NONE.

### Tests (all green)
- `normalize_trigger` / `normalize_triggers` unit tests (case, whitespace, empty-drop, dedupe, order).
- Round-trip integration test (`open_in_memory`): persist an entry with messy triggers (mixed case, extra spaces, a dup, empty strings) → read back normalized/deduped/empty-dropped.
- No-backfill safety test: an entry created **without** triggers reads back as `[]`.

`cargo build` + `cargo test --bin mx` (1057 passed) + `cargo clippy --bin mx` (clean) + `cargo fmt` — all green.