### PR TITLE
feat(memory): trigger-check matching engine + session dedup [3/4]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,12 @@ tempfile = "3"
 # CommonMark parser (fence-aware heading extraction — mx#215)
 pulldown-cmark = { version = "0.13", default-features = false }
 
+# Triggered memories (Issue #246, PR3): stemming + Unicode canonicalization +
+# cross-process file locking for session-scoped fired-state.
+rust-stemmers = "1"
+unicode-normalization = "0.1"
+fs2 = "0.4"
+
 # Terminal colors
 colored = "2"
 

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -148,6 +148,15 @@ DEFINE INDEX IF NOT EXISTS knowledge_wake_order ON knowledge FIELDS wake_order;
 --      written it gets a concrete array. No row is ever left stranded with NONE.
 -- Because both halves hold, there is no window in which a row needs a backfill.
 DEFINE FIELD IF NOT EXISTS triggers ON knowledge TYPE array<string> DEFAULT [];
+-- INDEX HONESTY (Issue #246, PR3): this is a per-ELEMENT index over the array
+-- contents. It accelerates equality/CONTAINS lookups (e.g.
+-- `WHERE triggers CONTAINS 'brad'`), NOT the `array::len(triggers ?? []) > 0`
+-- non-emptiness prefilter that `mx memory trigger-check` currently uses (that
+-- resolves via full scan regardless). It is kept deliberately: the actual
+-- matching is word-boundary + stemmed and happens in Rust (it cannot be pushed
+-- into a SurrealDB index), but a future hook-side fast path / "which memory owns
+-- trigger X" lookup will want CONTAINS, which this index serves. If those never
+-- materialize, this index is a candidate for removal.
 DEFINE INDEX IF NOT EXISTS knowledge_triggers ON knowledge FIELDS triggers;
 
 -- DEPRECATED: Kept for backward compatibility during migration

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -400,6 +400,14 @@ pub enum RecentSortOrder {
     Resonance,
 }
 
+/// Output format for `mx memory trigger-check` (Issue #246).
+#[derive(Clone, Debug, ValueEnum, PartialEq, Eq)]
+pub enum TriggerFormat {
+    /// Rendered memory bodies ready for context injection (title + body per
+    /// fired memory, separated by `---`). Empty stdout when nothing fires.
+    Context,
+}
+
 #[derive(Subcommand)]
 pub enum MemoryCommands {
     /// Removed -- see follow-up for markdown ingest plans
@@ -452,6 +460,37 @@ pub enum MemoryCommands {
         /// Output only the body content (for piping)
         #[arg(long)]
         content_only: bool,
+    },
+
+    /// Check a message for trigger-word matches and inject matching memories
+    /// (Issue #246). Reactive memory: dormant memories whose triggers appear in
+    /// the message fire ONCE per session. Exit 0 = ran (firing nothing is still
+    /// success); exit 4 = empty message after stdin fallback.
+    TriggerCheck {
+        /// Message to check. If omitted/empty, read the message from stdin to EOF.
+        message: Option<String>,
+
+        /// Output as JSON: {"fired":[{"id","title","triggers_matched":[...]}],"deferred_count":N}
+        #[arg(long)]
+        json: bool,
+
+        /// Output format when not --json. `context` (default) renders memory
+        /// bodies for injection; empty stdout when nothing fires.
+        #[arg(long, value_enum, default_value_t = TriggerFormat::Context)]
+        format: TriggerFormat,
+
+        /// Report matches WITHOUT marking them fired (debugging). A subsequent
+        /// real check will still fire them.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Clear the session-scoped trigger fired-state file (Issue #246). Lets a
+    /// memory fire again — for testing or a deliberate mid-session reset.
+    TriggerReset {
+        /// Output as JSON: {"reset":true,"path":"..."}
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show index statistics

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -181,6 +181,17 @@ fn handle_trigger_check(
     // Drop already-fired entries (one-shot dedup) using a read-only peek so the
     // cap is computed over GENUINELY new matches. The authoritative mark happens
     // atomically below; this read just lets us cap + count deferred correctly.
+    //
+    // CONCURRENCY: this is a SHARED-lock peek that is released before the
+    // EXCLUSIVE-lock mark in `mark_survivors`. Firing is race-safe — the mark
+    // re-checks the fired set under the exclusive lock, so two concurrent
+    // trigger-checks on the same session can never double-fire a memory. But
+    // `deferred_count` (computed below from this pre-lock peek) is BEST-EFFORT:
+    // if a concurrent check fires some of these matches between this peek and
+    // our mark, those become survivors there and we may OVER-count them as
+    // "deferred" here. That's an accepted, reported-count-only inaccuracy under
+    // concurrent same-session checks; the authoritative fired set is always the
+    // one returned by `mark_survivors`. Not worth a single-lock refactor.
     let fired_store = crate::triggers::FiredStore::open();
     let already_fired = fired_store.read_fired()?;
     let new_matches: Vec<&knowledge::KnowledgeEntry> = matched_entries

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -93,6 +93,176 @@ fn emit_show_output(content: &str, id: &str, trailing_newline: bool) -> Result<(
     Ok(())
 }
 
+/// Maximum number of memories to fire on a single `trigger-check`. If more than
+/// this many match, the top `TRIGGER_FIRE_CAP` by resonance fire and the rest
+/// stay UNFIRED (eligible to fire on a later turn). Keeps a single message from
+/// flooding context. (Issue #246, Savorist decision.)
+const TRIGGER_FIRE_CAP: usize = 5;
+
+/// Resolve the message for `trigger-check`: use the positional arg if present
+/// and non-empty (after trim), otherwise read stdin to EOF. Returns `None` when
+/// there is no usable message (empty arg AND empty/whitespace stdin) — the
+/// caller maps that to exit code 4.
+fn resolve_trigger_message(arg: Option<String>) -> Result<Option<String>> {
+    if let Some(m) = arg
+        && !m.trim().is_empty()
+    {
+        return Ok(Some(m));
+    }
+    // Stdin fallback.
+    use std::io::Read;
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .context("failed to read message from stdin")?;
+    if buf.trim().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(buf))
+    }
+}
+
+/// `mx memory trigger-check` handler (Issue #246, PR3).
+///
+/// Pipeline: resolve message (arg or stdin) → load trigger-bearing entries
+/// VISIBLE to the current agent → run the matcher → drop already-fired → sort by
+/// resonance desc → cap at `TRIGGER_FIRE_CAP` → mark survivors fired (unless
+/// `--dry-run`) → emit. Firing nothing is success (exit 0). Empty message exits 4.
+fn handle_trigger_check(
+    config: &IndexConfig,
+    verbose: bool,
+    message: Option<String>,
+    json: bool,
+    _format: TriggerFormat,
+    dry_run: bool,
+) -> Result<()> {
+    use std::io::Write;
+
+    let Some(message) = resolve_trigger_message(message)? else {
+        // Invalid input: empty message even after stdin fallback.
+        eprintln!("[mx] trigger-check: empty message (provide an argument or pipe via stdin)");
+        std::process::exit(4);
+    };
+
+    let db = store::create_store_with_verbose(&config.db_path, verbose)?;
+
+    // Visibility: the SAME filter used by every other read path. A private
+    // triggered memory only fires for its owner. (See store::list_with_triggers.)
+    let ctx = match std::env::var("MX_CURRENT_AGENT") {
+        Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
+        _ => store::AgentContext::public_only(),
+    };
+
+    let entries = db.list_with_triggers(&ctx)?;
+
+    // Run the matcher over (id, triggers) pairs. `match_entries` tokenizes the
+    // message once and checks every entry against the shared stem stream.
+    let pairs: Vec<(&str, &[String])> = entries
+        .iter()
+        .map(|e| (e.id.as_str(), e.triggers.as_slice()))
+        .collect();
+    let matches = crate::triggers::match_entries(&message, pairs);
+
+    // Index matches by id so we can carry triggers_matched alongside the entry.
+    let matched_triggers: std::collections::HashMap<&str, Vec<String>> = matches
+        .iter()
+        .map(|m| (m.id.as_str(), m.triggers_matched.clone()))
+        .collect();
+
+    // Collect the matched entries, then sort by resonance DESC (id asc as a
+    // deterministic tiebreaker) BEFORE applying the fire cap, so the highest-
+    // resonance memories win the 5 slots.
+    let mut matched_entries: Vec<&knowledge::KnowledgeEntry> = entries
+        .iter()
+        .filter(|e| matched_triggers.contains_key(e.id.as_str()))
+        .collect();
+    matched_entries.sort_by(|a, b| b.resonance.cmp(&a.resonance).then_with(|| a.id.cmp(&b.id)));
+
+    // Drop already-fired entries (one-shot dedup) using a read-only peek so the
+    // cap is computed over GENUINELY new matches. The authoritative mark happens
+    // atomically below; this read just lets us cap + count deferred correctly.
+    let fired_store = crate::triggers::FiredStore::open();
+    let already_fired = fired_store.read_fired()?;
+    let new_matches: Vec<&knowledge::KnowledgeEntry> = matched_entries
+        .into_iter()
+        .filter(|e| !already_fired.contains(&e.id))
+        .collect();
+
+    // Cap at TRIGGER_FIRE_CAP by resonance desc; overflow stays unfired.
+    let total_new = new_matches.len();
+    let to_fire: Vec<&knowledge::KnowledgeEntry> =
+        new_matches.into_iter().take(TRIGGER_FIRE_CAP).collect();
+    let deferred_count = total_new.saturating_sub(to_fire.len());
+
+    // Mark survivors fired atomically (unless dry-run). mark_survivors re-checks
+    // the fired set under flock, so even if a concurrent check fired one of these
+    // between our peek and now, it is excluded here — the returned survivors are
+    // the authoritative set that THIS invocation owns.
+    let fired_ids: Vec<String> = to_fire.iter().map(|e| e.id.clone()).collect();
+    let survivors: Vec<String> = if dry_run {
+        // Dry-run: do not mark. Report what WOULD fire.
+        fired_ids.clone()
+    } else {
+        fired_store.mark_survivors(&fired_ids)?
+    };
+    let survivor_set: std::collections::HashSet<&String> = survivors.iter().collect();
+
+    // Final fired list = the capped entries that this invocation actually owns,
+    // preserving resonance-desc order.
+    let fired: Vec<&knowledge::KnowledgeEntry> = to_fire
+        .iter()
+        .copied()
+        .filter(|e| survivor_set.contains(&e.id))
+        .collect();
+
+    if json {
+        let fired_json: Vec<serde_json::Value> = fired
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "id": e.id,
+                    "title": e.title,
+                    "triggers_matched": matched_triggers
+                        .get(e.id.as_str())
+                        .cloned()
+                        .unwrap_or_default(),
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string(&serde_json::json!({
+                "fired": fired_json,
+                "deferred_count": deferred_count,
+            }))?
+        );
+    } else {
+        // `context` format: title + body per fired memory, separated by `---`.
+        // EMPTY stdout when nothing fires (caller injects nothing).
+        let mut out = String::new();
+        for (i, e) in fired.iter().enumerate() {
+            if i > 0 {
+                out.push_str("\n---\n\n");
+            }
+            out.push_str("# ");
+            out.push_str(&e.title);
+            out.push('\n');
+            if let Some(body) = &e.body {
+                out.push('\n');
+                out.push_str(body);
+                out.push('\n');
+            }
+        }
+        if !out.is_empty() {
+            let mut stdout = std::io::stdout();
+            stdout.write_all(out.as_bytes())?;
+            stdout.flush()?;
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
     let config = IndexConfig::default();
 
@@ -288,6 +458,34 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 None => {
                     bail!("Entry '{}' not found", id);
                 }
+            }
+        }
+
+        MemoryCommands::TriggerCheck {
+            message,
+            json,
+            format,
+            dry_run,
+        } => {
+            handle_trigger_check(&config, verbose, message, json, format, dry_run)?;
+        }
+
+        MemoryCommands::TriggerReset { json } => {
+            let store = crate::triggers::FiredStore::open();
+            store.reset()?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string(&serde_json::json!({
+                        "reset": true,
+                        "path": crate::triggers::fired_path().display().to_string(),
+                    }))?
+                );
+            } else {
+                eprintln!(
+                    "[mx] trigger fired-state cleared: {}",
+                    crate::triggers::fired_path().display()
+                );
             }
         }
 

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -111,16 +111,27 @@ pub struct KnowledgeEntry {
 
 /// Normalize a single trigger keyword/phrase for storage and matching (Issue #246).
 ///
-/// Lowercases, trims, and collapses internal whitespace runs to a single space.
-/// Returns `None` when the input is empty after trimming, so callers can drop
-/// blank entries.
+/// Pipeline: Unicode NFC canonicalization, lowercase, trim, and collapse
+/// internal whitespace runs to a single space. Returns `None` when the input is
+/// empty after trimming, so callers can drop blank entries.
 ///
 /// This is the single source of truth for trigger normalization, shared by the
 /// store write path (PR1), the CLI flag parsing (PR2), and the trigger matcher
 /// (PR3): all three MUST normalize identically so author-time and match-time
 /// values line up.
+///
+/// NFC matters because precomposed "café" (U+00E9) and decomposed "café"
+/// (e + U+0301 combining acute) are visually identical but byte-distinct. Author
+/// time and match time can each arrive in either form (different keyboards,
+/// editors, OSes), so we canonicalize BOTH sides to NFC here — the one shared
+/// helper — guaranteeing they compare equal (Verdictia PR1 review, #246).
 pub fn normalize_trigger(raw: &str) -> Option<String> {
-    let collapsed = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    use unicode_normalization::UnicodeNormalization;
+    // NFC first so combining sequences fold into precomposed code points before
+    // we lowercase/compare. `to_lowercase` is locale-independent (Unicode default
+    // case folding) and stable across the NFC-canonicalized input.
+    let canonical: String = raw.nfc().collect();
+    let collapsed = canonical.split_whitespace().collect::<Vec<_>>().join(" ");
     if collapsed.is_empty() {
         None
     } else {
@@ -294,6 +305,24 @@ mod tests {
         assert_eq!(normalize_trigger(""), None);
         assert_eq!(normalize_trigger("   "), None);
         assert_eq!(normalize_trigger("\t\n"), None);
+    }
+
+    #[test]
+    fn test_normalize_trigger_nfc_canonicalization() {
+        // Precomposed "café": ...caf + é (U+00E9).
+        let precomposed = "caf\u{00e9}";
+        // Decomposed "café": ...caf + e + combining acute (U+0301).
+        let decomposed = "cafe\u{0301}";
+        // Byte-distinct inputs...
+        assert_ne!(precomposed, decomposed);
+        // ...must normalize to the SAME canonical form (NFC). Without NFC in the
+        // shared helper, a precomposed stored trigger would never fire on a
+        // decomposed message token (or vice versa). #246 / Verdictia review.
+        assert_eq!(
+            normalize_trigger(precomposed),
+            normalize_trigger(decomposed)
+        );
+        assert_eq!(normalize_trigger(decomposed), Some("café".to_string()));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod store_update;
 mod surreal_db;
 mod sync;
 mod tensor;
+mod triggers;
 mod types;
 mod wake_chunk;
 mod wake_ritual;

--- a/src/store.rs
+++ b/src/store.rs
@@ -154,6 +154,14 @@ pub trait KnowledgeStore {
     /// List all entries
     fn list_all(&self, ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>>;
 
+    /// List entries that have at least one trigger keyword, respecting agent
+    /// visibility (Issue #246). Used by `mx memory trigger-check` to scan only
+    /// candidate entries rather than every row. Private entries are returned
+    /// only to their owner — the visibility filter is the same one used by all
+    /// other read paths, so a triggered private memory never fires for another
+    /// agent.
+    fn list_with_triggers(&self, ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>>;
+
     /// Count total entries
     fn count(&self) -> Result<usize>;
 

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1362,6 +1362,72 @@ impl SurrealDatabase {
         Ok(entries)
     }
 
+    /// List entries with at least one trigger keyword (Issue #246, PR3).
+    pub fn list_with_triggers(
+        &self,
+        ctx: &crate::store::AgentContext,
+    ) -> Result<Vec<KnowledgeEntry>> {
+        Self::runtime().block_on(self.list_with_triggers_async(ctx))
+    }
+
+    async fn list_with_triggers_async(
+        &self,
+        ctx: &crate::store::AgentContext,
+    ) -> Result<Vec<KnowledgeEntry>> {
+        let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
+
+        // Prefilter to only entries that actually have triggers, shrinking the
+        // scan. visibility_clause already begins with "AND", so it appends
+        // cleanly after this leading predicate.
+        //
+        // COALESCE IN THE WHERE (subtle, do not "simplify" away): the read-path
+        // `IF triggers THEN triggers ELSE [] END` coalesce lives only in the
+        // SELECT projection — it does NOT apply inside WHERE. Pre-existing rows
+        // (and freshly-defined SCHEMAFULL fields before any write) can still hold
+        // `triggers = NONE` at filter time, and `array::len(NONE)` is a hard
+        // ERROR ("Expected a array but found NONE"), not a falsy 0. So we coalesce
+        // here with `?? []` before measuring length. Verified against an on-disk
+        // store; the in-memory round-trip tests never hit it because every test
+        // row is written (and thus already an array).
+        //
+        // INDEX HONESTY (Verdictia, #246): PR1 added
+        // `DEFINE INDEX knowledge_triggers ON knowledge FIELDS triggers`. That
+        // is a per-ELEMENT index over the array contents — it accelerates
+        // equality lookups like `triggers CONTAINS 'brad'`, NOT this
+        // non-emptiness test, which the planner resolves with a full table scan
+        // regardless. We KEEP the index because the future hook-side fast path
+        // (and any "which memory owns trigger X" query) will want CONTAINS
+        // lookups, but for THIS query it is not consulted. See the PR body.
+        // ORDER BY id (not title) for the same #191 planner reason as list_all.
+        let sql = format!(
+            "SELECT {}
+            FROM knowledge
+            WHERE array::len(triggers ?? []) > 0 {}
+            ORDER BY id",
+            Self::knowledge_select_fields(),
+            visibility_clause
+        );
+
+        let mut response = with_db!(self, db, {
+            let mut query = db.query(&sql);
+            if let Some(agent) = current_agent {
+                query = query.bind(("current_agent", agent));
+            }
+            query
+                .await
+                .context("Failed to query knowledge entries with triggers")
+        })?;
+
+        let results: Vec<serde_json::Value> = response.take(0)?;
+        let mut entries = Vec::new();
+
+        for obj in results {
+            entries.push(self.value_to_knowledge_entry(obj).await?);
+        }
+
+        Ok(entries)
+    }
+
     /// List entries by category
     pub fn list_by_category(
         &self,

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -2561,3 +2561,176 @@ fn test_triggers_default_empty_when_absent() {
         "an entry with no triggers must read back as an empty array"
     );
 }
+
+// =========================================================================
+// Issue #246 PR3: trigger-check matching engine + visibility + dedup + cap
+// =========================================================================
+
+/// `list_with_triggers` returns only entries with a non-empty `triggers` array,
+/// and applies the agent visibility filter (private entries only for owner).
+#[test]
+fn test_list_with_triggers_prefilters_and_respects_visibility() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Public entry WITH triggers -> should appear for everyone.
+    let mut public_trig = make_test_entry("kn-pub-trig", 5, 0.0);
+    public_trig.triggers = vec!["brad".to_string()];
+    db.upsert_knowledge(&public_trig).unwrap();
+
+    // Public entry WITHOUT triggers -> filtered out by array::len > 0.
+    let no_trig = make_test_entry("kn-pub-notrig", 5, 0.0);
+    db.upsert_knowledge(&no_trig).unwrap();
+
+    // Private entry WITH triggers, owned by agent-a -> only agent-a sees it.
+    let mut priv_trig = make_test_entry("kn-priv-trig", 5, 0.0);
+    priv_trig.triggers = vec!["secret".to_string()];
+    priv_trig.visibility = "private".to_string();
+    priv_trig.owner = Some("agent-a".to_string());
+    db.upsert_knowledge(&priv_trig).unwrap();
+
+    // agent-b: sees only the public trigger-bearing entry.
+    let ctx_b = crate::store::AgentContext::for_agent("agent-b");
+    let ids_b: HashSet<String> = db
+        .list_with_triggers(&ctx_b)
+        .unwrap()
+        .into_iter()
+        .map(|e| e.id)
+        .collect();
+    assert!(ids_b.contains("kn-pub-trig"));
+    assert!(
+        !ids_b.contains("kn-pub-notrig"),
+        "entries without triggers must be prefiltered out"
+    );
+    assert!(
+        !ids_b.contains("kn-priv-trig"),
+        "agent-b must NOT see agent-a's private triggered memory"
+    );
+
+    // agent-a: sees both their private trigger entry and the public one.
+    let ctx_a = crate::store::AgentContext::for_agent("agent-a");
+    let ids_a: HashSet<String> = db
+        .list_with_triggers(&ctx_a)
+        .unwrap()
+        .into_iter()
+        .map(|e| e.id)
+        .collect();
+    assert!(ids_a.contains("kn-pub-trig"));
+    assert!(
+        ids_a.contains("kn-priv-trig"),
+        "agent-a must see their own private triggered memory"
+    );
+}
+
+/// End-to-end VISIBILITY at the matcher layer: agent-b's check does NOT fire
+/// agent-a's private triggered memory, even when the message contains the
+/// trigger word.
+#[test]
+fn test_trigger_check_visibility_private_does_not_fire_for_other_agent() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    let mut priv_trig = make_test_entry("kn-brad-private", 8, 0.0);
+    priv_trig.triggers = vec!["brad".to_string()];
+    priv_trig.visibility = "private".to_string();
+    priv_trig.owner = Some("agent-a".to_string());
+    db.upsert_knowledge(&priv_trig).unwrap();
+
+    let message = "what is brad up to";
+
+    // agent-b: the private memory is not even in the candidate set -> no match.
+    let ctx_b = crate::store::AgentContext::for_agent("agent-b");
+    let entries_b = db.list_with_triggers(&ctx_b).unwrap();
+    let pairs_b: Vec<(&str, &[String])> = entries_b
+        .iter()
+        .map(|e| (e.id.as_str(), e.triggers.as_slice()))
+        .collect();
+    assert!(
+        crate::triggers::match_entries(message, pairs_b).is_empty(),
+        "agent-b must not fire agent-a's private memory"
+    );
+
+    // agent-a: same message DOES fire it.
+    let ctx_a = crate::store::AgentContext::for_agent("agent-a");
+    let entries_a = db.list_with_triggers(&ctx_a).unwrap();
+    let pairs_a: Vec<(&str, &[String])> = entries_a
+        .iter()
+        .map(|e| (e.id.as_str(), e.triggers.as_slice()))
+        .collect();
+    let matches_a = crate::triggers::match_entries(message, pairs_a);
+    assert_eq!(matches_a.len(), 1);
+    assert_eq!(matches_a[0].id, "kn-brad-private");
+}
+
+/// Fire cap of 5 by resonance desc: 6 matches -> top 5 fire, 1 deferred; the
+/// deferred one fires on a subsequent check (after the first five are marked).
+/// Exercises the same logic the handler uses (sort by resonance desc, cap,
+/// then FiredStore dedup), wired directly so it needs no CLI add-flag.
+#[test]
+fn test_trigger_check_cap_and_deferred_fires_next_turn() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Six entries, all triggered by "topic", distinct resonance 1..=6 so the
+    // ordering is unambiguous. Highest resonance should win the 5 slots.
+    for r in 1..=6 {
+        let mut e = make_test_entry(&format!("kn-cap-{r}"), r, 0.0);
+        e.triggers = vec!["topic".to_string()];
+        db.upsert_knowledge(&e).unwrap();
+    }
+
+    // Isolated fired-state file.
+    let dir = tempfile::tempdir().unwrap();
+    let store = crate::triggers::FiredStore::at(dir.path().join("fired.json"));
+
+    let run_check = |store: &crate::triggers::FiredStore| -> Vec<String> {
+        let ctx = crate::store::AgentContext::public_only();
+        let entries = db.list_with_triggers(&ctx).unwrap();
+        let matched: HashSet<String> = {
+            let pairs: Vec<(&str, &[String])> = entries
+                .iter()
+                .map(|e| (e.id.as_str(), e.triggers.as_slice()))
+                .collect();
+            crate::triggers::match_entries("a topic question", pairs)
+                .into_iter()
+                .map(|m| m.id)
+                .collect()
+        };
+        // Sort matched entries by resonance desc, id asc (handler's ordering).
+        let mut matched_entries: Vec<_> =
+            entries.iter().filter(|e| matched.contains(&e.id)).collect();
+        matched_entries.sort_by(|a, b| b.resonance.cmp(&a.resonance).then(a.id.cmp(&b.id)));
+        let already = store.read_fired().unwrap();
+        let to_fire: Vec<String> = matched_entries
+            .into_iter()
+            .filter(|e| !already.contains(&e.id))
+            .take(5)
+            .map(|e| e.id.clone())
+            .collect();
+        store.mark_survivors(&to_fire).unwrap()
+    };
+
+    // First check: top 5 by resonance (6,5,4,3,2) fire; resonance-1 deferred.
+    let fired1 = run_check(&store);
+    assert_eq!(
+        fired1,
+        vec![
+            "kn-cap-6".to_string(),
+            "kn-cap-5".to_string(),
+            "kn-cap-4".to_string(),
+            "kn-cap-3".to_string(),
+            "kn-cap-2".to_string(),
+        ],
+        "top 5 by resonance desc fire"
+    );
+
+    // Second check (same message): the 5 already fired are deduped, the deferred
+    // resonance-1 entry now fires.
+    let fired2 = run_check(&store);
+    assert_eq!(
+        fired2,
+        vec!["kn-cap-1".to_string()],
+        "the deferred (overflow) memory fires on a subsequent check"
+    );
+
+    // Third check: everything fired -> nothing new.
+    let fired3 = run_check(&store);
+    assert!(fired3.is_empty(), "all memories already fired this session");
+}

--- a/src/surreal_db/trait_impl.rs
+++ b/src/surreal_db/trait_impl.rs
@@ -68,6 +68,10 @@ impl KnowledgeStore for SurrealDatabase {
         self.list_all(ctx)
     }
 
+    fn list_with_triggers(&self, ctx: &crate::store::AgentContext) -> Result<Vec<KnowledgeEntry>> {
+        self.list_with_triggers(ctx)
+    }
+
     fn count(&self) -> Result<usize> {
         self.count()
     }

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -1,0 +1,451 @@
+//! Triggered-memory matching engine and session-scoped fired-state (Issue #246, PR3).
+//!
+//! Two responsibilities live here, kept deliberately separate so the matcher is a
+//! pure, exhaustively testable function and the IO (file locking) is isolated:
+//!
+//! 1. **The matcher** (`match_entries`, `match_triggers`): given a raw message and
+//!    a set of stored triggers, decide which triggers fire. The pipeline is
+//!    `normalize → tokenize → stem → contiguous-sequence match` and is described
+//!    on [`match_triggers`].
+//!
+//! 2. **Session fired-state** (`FiredStore`): a flock-guarded JSON file recording
+//!    which memory IDs have already fired this session, so a triggered memory
+//!    fires exactly ONCE per session (the immune-system "one-shot per encounter"
+//!    property from #246). The read-modify-write is performed inside a single
+//!    `flock` critical section so two concurrent `trigger-check` invocations
+//!    (e.g. two hooks racing) can never both claim the same memory.
+
+use std::collections::HashSet;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use fs2::FileExt;
+use rust_stemmers::{Algorithm, Stemmer};
+use serde::{Deserialize, Serialize};
+
+use crate::knowledge::normalize_trigger;
+
+/// Default location of the session fired-state file. Overridable via the
+/// `MX_TRIGGER_FIRED_PATH` env var (mirrors `MX_KV_DATA` for the KV store) so
+/// tests get an isolated temp file and so a hook can scope it per session.
+const DEFAULT_FIRED_PATH: &str = "/tmp/wonka-triggered-fired.json";
+
+/// Environment override for the fired-state file path.
+const FIRED_PATH_ENV: &str = "MX_TRIGGER_FIRED_PATH";
+
+/// Resolve the fired-state file path: env override if set & non-empty, else the
+/// default. Empty env value is treated as unset (same convention as `MX_KV_DATA`).
+pub fn fired_path() -> PathBuf {
+    match std::env::var(FIRED_PATH_ENV) {
+        Ok(p) if !p.trim().is_empty() => PathBuf::from(p),
+        _ => PathBuf::from(DEFAULT_FIRED_PATH),
+    }
+}
+
+/// Tokenize a raw string into stemmed tokens for trigger matching.
+///
+/// Steps, in order, so author-time and match-time agree exactly:
+///   1. `normalize_trigger` — NFC canonicalize + lowercase + whitespace-collapse
+///      (the single shared normalizer; see `src/knowledge.rs`). Returns no tokens
+///      for empty/whitespace-only input.
+///   2. Split on Unicode word boundaries: any run of non-alphanumeric characters
+///      separates tokens. This is what makes matching **word-boundary** — "ai"
+///      tokenizes "said" as `["said"]`, never exposing a bare "ai" token, so the
+///      "ai" trigger cannot fire on "said".
+///   3. Porter/Snowball English stem each token, so "diabetes" and "diabetic"
+///      collapse to the same stem and a "diabetes" trigger fires on "diabetic".
+fn stem_tokens(raw: &str) -> Vec<String> {
+    // Normalize first; empty result -> no tokens.
+    let Some(normalized) = normalize_trigger(raw) else {
+        return Vec::new();
+    };
+
+    // Unicode word-boundary tokenization: split on non-alphanumeric runs.
+    // `char::is_alphanumeric` is Unicode-aware, so accented letters and
+    // non-Latin scripts stay inside tokens.
+    let stemmer = Stemmer::create(Algorithm::English);
+    normalized
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|tok| !tok.is_empty())
+        .map(|tok| stemmer.stem(tok).into_owned())
+        .collect()
+}
+
+/// Return true if `needle` appears as a contiguous subsequence of `haystack`.
+///
+/// Empty `needle` never matches (a trigger that tokenizes to nothing is inert).
+/// Single-token needles match when that one stem appears anywhere as a whole
+/// token. Multi-token (phrase) needles require the tokens to appear **adjacent
+/// and in order** — this is what makes "blood sugar" fire on "his blood sugar
+/// today" but NOT on "sugar in blood" (order) or "blood pressure and sugar"
+/// (contiguity).
+fn contains_contiguous(haystack: &[String], needle: &[String]) -> bool {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return false;
+    }
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+/// Match a single message against one entry's normalized trigger list.
+///
+/// Returns the subset of `triggers` that fire, in their stored order (so output
+/// is deterministic). `triggers` are expected already-normalized (stored that
+/// way by PR1), but we re-tokenize/stem them here so author-time stemming uses
+/// the exact same code path as match-time — the only safe way to guarantee they
+/// line up.
+pub fn match_triggers(message_tokens: &[String], triggers: &[String]) -> Vec<String> {
+    triggers
+        .iter()
+        .filter(|trig| {
+            let trig_tokens = stem_tokens(trig);
+            contains_contiguous(message_tokens, &trig_tokens)
+        })
+        .cloned()
+        .collect()
+}
+
+/// A matched entry: the entry id plus which of its triggers fired.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TriggerMatch {
+    pub id: String,
+    pub triggers_matched: Vec<String>,
+}
+
+/// Run the matcher over a message and a collection of (id, triggers) pairs.
+///
+/// Tokenizes/stems the message ONCE, then checks every entry against the shared
+/// token stream. Returns one `TriggerMatch` per entry that has at least one
+/// firing trigger, preserving the input entry order.
+pub fn match_entries<'a, I>(message: &str, entries: I) -> Vec<TriggerMatch>
+where
+    I: IntoIterator<Item = (&'a str, &'a [String])>,
+{
+    let message_tokens = stem_tokens(message);
+    if message_tokens.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for (id, triggers) in entries {
+        let matched = match_triggers(&message_tokens, triggers);
+        if !matched.is_empty() {
+            out.push(TriggerMatch {
+                id: id.to_string(),
+                triggers_matched: matched,
+            });
+        }
+    }
+    out
+}
+
+/// On-disk shape of the fired-state file: `{"fired":["kn-...", ...]}`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct FiredState {
+    #[serde(default)]
+    fired: Vec<String>,
+}
+
+/// Handle to the session fired-state file. All mutation goes through
+/// [`FiredStore::mark_survivors`] under an exclusive `flock`.
+pub struct FiredStore {
+    path: PathBuf,
+}
+
+impl FiredStore {
+    /// Open the fired store at the resolved path (env override or default).
+    pub fn open() -> Self {
+        Self { path: fired_path() }
+    }
+
+    /// Construct against an explicit path (used by tests / callers that already
+    /// resolved the path).
+    pub fn at(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Atomically read the fired set, compute survivors (the matched ids that
+    /// have NOT already fired), append survivors to the fired set, persist, and
+    /// return the survivors — all inside one `flock` critical section.
+    ///
+    /// `matched` is expected pre-sorted/pre-capped by the CALLER (resonance desc,
+    /// cap 5): this function only enforces the one-shot dedup invariant, it does
+    /// not reorder or cap. It preserves the caller's order in the returned
+    /// survivors.
+    ///
+    /// Critical-section ordering (single `flock(LOCK_EX)`):
+    ///   open(rw,create) → lock_exclusive → read → diff → append → rewrite →
+    ///   flush+sync → unlock(drop).
+    /// Because read and write share one lock, a concurrent `trigger-check` either
+    /// runs entirely before or entirely after — it can never observe the file
+    /// mid-update and double-fire a memory.
+    pub fn mark_survivors(&self, matched: &[String]) -> Result<Vec<String>> {
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&self.path)
+            .with_context(|| format!("failed to open fired-state file: {}", self.path.display()))?;
+
+        // Block until we hold the exclusive lock. On the same process this is
+        // advisory; across processes flock serializes the whole RMW.
+        file.lock_exclusive()
+            .with_context(|| format!("failed to flock {}", self.path.display()))?;
+
+        // Guard so the lock is always released, even on an early error return.
+        let result = self.read_modify_write(&mut file, matched);
+        // Best-effort unlock; drop also releases, but be explicit.
+        let _ = FileExt::unlock(&file);
+        result
+    }
+
+    /// The read-modify-write body, run while holding the exclusive lock.
+    fn read_modify_write(
+        &self,
+        file: &mut std::fs::File,
+        matched: &[String],
+    ) -> Result<Vec<String>> {
+        let mut contents = String::new();
+        file.seek(SeekFrom::Start(0))?;
+        file.read_to_string(&mut contents)
+            .with_context(|| format!("failed to read fired-state file: {}", self.path.display()))?;
+
+        // Empty file (freshly created) -> empty state. Tolerate a corrupt/partial
+        // file by treating it as empty rather than hard-failing the whole check;
+        // a triggered-memory hook should degrade to "re-fire" rather than break.
+        let mut state: FiredState = if contents.trim().is_empty() {
+            FiredState::default()
+        } else {
+            serde_json::from_str(&contents).unwrap_or_default()
+        };
+
+        let already: HashSet<&String> = state.fired.iter().collect();
+        let survivors: Vec<String> = matched
+            .iter()
+            .filter(|id| !already.contains(id))
+            .cloned()
+            .collect();
+
+        if survivors.is_empty() {
+            // Nothing new to record — leave the file untouched.
+            return Ok(survivors);
+        }
+
+        state.fired.extend(survivors.iter().cloned());
+        let serialized = serde_json::to_string(&state)?;
+
+        // Overwrite in place: truncate to the new length then write from offset 0.
+        file.seek(SeekFrom::Start(0))?;
+        file.set_len(0)?;
+        file.write_all(serialized.as_bytes()).with_context(|| {
+            format!("failed to write fired-state file: {}", self.path.display())
+        })?;
+        file.flush()?;
+        file.sync_all()?;
+
+        Ok(survivors)
+    }
+
+    /// Read the current fired set WITHOUT marking anything. Used by `--dry-run`
+    /// (report which matches would be new) and by tests. Takes a shared lock so
+    /// it does not observe a half-written file.
+    pub fn read_fired(&self) -> Result<HashSet<String>> {
+        if !self.path.exists() {
+            return Ok(HashSet::new());
+        }
+        let file = std::fs::File::open(&self.path)
+            .with_context(|| format!("failed to open fired-state file: {}", self.path.display()))?;
+        file.lock_shared()
+            .with_context(|| format!("failed to flock(shared) {}", self.path.display()))?;
+        let mut contents = String::new();
+        let mut f = &file;
+        let read = f.read_to_string(&mut contents);
+        let _ = FileExt::unlock(&file);
+        read.with_context(|| format!("failed to read fired-state file: {}", self.path.display()))?;
+        if contents.trim().is_empty() {
+            return Ok(HashSet::new());
+        }
+        let state: FiredState = serde_json::from_str(&contents).unwrap_or_default();
+        Ok(state.fired.into_iter().collect())
+    }
+
+    /// Clear the fired-state file (for `mx memory trigger-reset` and tests).
+    /// Removes the file entirely; the next `mark_survivors` recreates it. A
+    /// missing file is success (idempotent).
+    pub fn reset(&self) -> Result<()> {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e).with_context(|| {
+                format!("failed to remove fired-state file: {}", self.path.display())
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toks(s: &str) -> Vec<String> {
+        stem_tokens(s)
+    }
+
+    // ---- Word-boundary matching ----
+
+    #[test]
+    fn word_boundary_ai_does_not_fire_on_said_or_maintain() {
+        let msg = toks("he said we should maintain it");
+        // Single-word trigger "ai" must NOT match inside "said" or "maintain".
+        assert!(match_triggers(&msg, &["ai".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn word_boundary_ai_fires_as_whole_token() {
+        let msg = toks("the ai is helpful");
+        assert_eq!(
+            match_triggers(&msg, &["ai".to_string()]),
+            vec!["ai".to_string()]
+        );
+    }
+
+    // ---- Stemming ----
+
+    #[test]
+    fn stemming_diabetes_fires_on_diabetic() {
+        let msg = toks("he is diabetic");
+        assert_eq!(
+            match_triggers(&msg, &["diabetes".to_string()]),
+            vec!["diabetes".to_string()]
+        );
+    }
+
+    #[test]
+    fn stemming_run_fires_on_running() {
+        let msg = toks("she is running today");
+        assert_eq!(
+            match_triggers(&msg, &["run".to_string()]),
+            vec!["run".to_string()]
+        );
+    }
+
+    // ---- Phrase (contiguous-sequence) matching ----
+
+    #[test]
+    fn phrase_fires_on_contiguous_in_order() {
+        let msg = toks("what is his blood sugar today");
+        assert_eq!(
+            match_triggers(&msg, &["blood sugar".to_string()]),
+            vec!["blood sugar".to_string()]
+        );
+    }
+
+    #[test]
+    fn phrase_does_not_fire_out_of_order() {
+        let msg = toks("there is sugar in blood");
+        assert!(match_triggers(&msg, &["blood sugar".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn phrase_does_not_fire_when_not_contiguous() {
+        let msg = toks("blood pressure and high sugar");
+        assert!(match_triggers(&msg, &["blood sugar".to_string()]).is_empty());
+    }
+
+    // ---- NFC (proves the shared normalizer carries through tokenization) ----
+
+    #[test]
+    fn nfc_precomposed_and_decomposed_cafe_match() {
+        // Trigger stored precomposed, message arrives decomposed.
+        let msg = toks("meet me at the cafe\u{0301} later");
+        assert_eq!(
+            match_triggers(&msg, &["caf\u{00e9}".to_string()]),
+            vec!["caf\u{00e9}".to_string()]
+        );
+    }
+
+    // ---- match_entries integration ----
+
+    #[test]
+    fn match_entries_returns_per_entry_matched_triggers() {
+        let brad = vec!["brad".to_string(), "blood sugar".to_string()];
+        let drew = vec!["drew".to_string()];
+        let entries: Vec<(&str, &[String])> =
+            vec![("kn-brad", brad.as_slice()), ("kn-drew", drew.as_slice())];
+        let matches = match_entries("can you check brad's blood sugar?", entries);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].id, "kn-brad");
+        assert_eq!(
+            matches[0].triggers_matched,
+            vec!["brad".to_string(), "blood sugar".to_string()]
+        );
+    }
+
+    #[test]
+    fn match_entries_empty_message_matches_nothing() {
+        let trig = vec!["brad".to_string()];
+        let entries: Vec<(&str, &[String])> = vec![("kn-brad", trig.as_slice())];
+        assert!(match_entries("   ", entries).is_empty());
+    }
+
+    // ---- FiredStore dedup ----
+
+    fn temp_store() -> (tempfile::TempDir, FiredStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fired.json");
+        (dir, FiredStore::at(path))
+    }
+
+    #[test]
+    fn fired_store_marks_and_dedupes() {
+        let (_dir, store) = temp_store();
+        // First check: both survive.
+        let survivors = store
+            .mark_survivors(&["kn-a".to_string(), "kn-b".to_string()])
+            .unwrap();
+        assert_eq!(survivors, vec!["kn-a".to_string(), "kn-b".to_string()]);
+
+        // Second check with one repeat + one new: only the new one survives.
+        let survivors = store
+            .mark_survivors(&["kn-a".to_string(), "kn-c".to_string()])
+            .unwrap();
+        assert_eq!(survivors, vec!["kn-c".to_string()]);
+
+        // Third check, all already fired: nothing survives.
+        let survivors = store
+            .mark_survivors(&["kn-a".to_string(), "kn-b".to_string(), "kn-c".to_string()])
+            .unwrap();
+        assert!(survivors.is_empty());
+    }
+
+    #[test]
+    fn fired_store_reset_clears_state() {
+        let (_dir, store) = temp_store();
+        store.mark_survivors(&["kn-a".to_string()]).unwrap();
+        assert!(store.read_fired().unwrap().contains("kn-a"));
+        store.reset().unwrap();
+        assert!(store.read_fired().unwrap().is_empty());
+        // After reset, the same id fires again.
+        let survivors = store.mark_survivors(&["kn-a".to_string()]).unwrap();
+        assert_eq!(survivors, vec!["kn-a".to_string()]);
+    }
+
+    #[test]
+    fn fired_store_reset_missing_file_is_ok() {
+        let (_dir, store) = temp_store();
+        // Never written yet.
+        store.reset().unwrap();
+        assert!(store.read_fired().unwrap().is_empty());
+    }
+
+    #[test]
+    fn fired_store_read_does_not_mark() {
+        let (_dir, store) = temp_store();
+        // read_fired on a fresh store -> empty, and does not create the file.
+        assert!(store.read_fired().unwrap().is_empty());
+        let survivors = store.mark_survivors(&["kn-a".to_string()]).unwrap();
+        assert_eq!(survivors, vec!["kn-a".to_string()]);
+    }
+}

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -181,6 +181,17 @@ impl FiredStore {
     /// runs entirely before or entirely after — it can never observe the file
     /// mid-update and double-fire a memory.
     pub fn mark_survivors(&self, matched: &[String]) -> Result<Vec<String>> {
+        // Hot-path short-circuit: a no-match check passes an empty slice, and
+        // most user prompts match nothing. There is nothing to record, so do
+        // ZERO file IO — no open/create, no flock, no empty fired-state file
+        // littered into /tmp on every prompt. Guarding here (rather than only
+        // in the caller) keeps the invariant safe even if a future caller
+        // forgets to skip the call. The in-lock `survivors.is_empty()` early
+        // return in `read_modify_write` remains as defense in depth.
+        if matched.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let mut file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -267,6 +278,9 @@ impl FiredStore {
         if contents.trim().is_empty() {
             return Ok(HashSet::new());
         }
+        // Deliberate fail-safe (mirrors `read_modify_write`): a corrupt/partial
+        // fired-state file degrades to "empty fired set" rather than hard-failing
+        // the check, so a triggered-memory hook re-fires rather than breaking.
         let state: FiredState = serde_json::from_str(&contents).unwrap_or_default();
         Ok(state.fired.into_iter().collect())
     }
@@ -438,6 +452,20 @@ mod tests {
         // Never written yet.
         store.reset().unwrap();
         assert!(store.read_fired().unwrap().is_empty());
+    }
+
+    #[test]
+    fn mark_survivors_empty_input_does_no_file_io() {
+        // Hot-path invariant: a no-match check (empty `matched`) must NOT create,
+        // open, or lock the fired-state file. Most prompts match nothing, so this
+        // keeps the common case zero-IO and avoids littering an empty file.
+        let (_dir, store) = temp_store();
+        let survivors = store.mark_survivors(&[]).unwrap();
+        assert!(survivors.is_empty());
+        assert!(
+            !store.path.exists(),
+            "empty mark_survivors must not create the fired-state file"
+        );
     }
 
     #[test]

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1379,6 +1379,9 @@ mod tests {
             fn list_all(&self, _ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>> {
                 unreachable!()
             }
+            fn list_with_triggers(&self, _ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
             fn count(&self) -> Result<usize> {
                 unreachable!()
             }

--- a/tests/trigger_check.rs
+++ b/tests/trigger_check.rs
@@ -135,6 +135,29 @@ fn dry_run_does_not_create_or_modify_fired_state() {
 }
 
 #[test]
+fn no_match_real_check_does_not_create_fired_state() {
+    let dir = TempDir::new().unwrap();
+    let fired = dir.path().join("fired.json");
+    // A REAL (non-dry-run) trigger-check that matches nothing must do ZERO file
+    // IO on the hot path: no empty fired-state file should be created/flocked.
+    // This is the no-match case that the short-circuit in mark_survivors covers.
+    let out = mx(
+        &dir,
+        &["memory", "trigger-check", "an unremarkable message"],
+        None,
+    );
+    assert!(
+        out.status.success(),
+        "no-match must be success (exit 0); stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !fired.exists(),
+        "no-match real trigger-check must not create the fired-state file"
+    );
+}
+
+#[test]
 fn trigger_reset_removes_fired_state_file() {
     let dir = TempDir::new().unwrap();
     let fired = dir.path().join("fired.json");

--- a/tests/trigger_check.rs
+++ b/tests/trigger_check.rs
@@ -1,0 +1,174 @@
+//! CLI-level integration tests for `mx memory trigger-check` / `trigger-reset`
+//! (Issue #246, PR3).
+//!
+//! These drive the real binary (`CARGO_BIN_EXE_mx`) with an isolated SurrealDB
+//! (`MX_SURREAL_ROOT`) and an isolated fired-state file
+//! (`MX_TRIGGER_FIRED_PATH`), so they never touch the developer's real memory
+//! store or `/tmp/wonka-triggered-fired.json`.
+//!
+//! NOTE: the matcher / cap / dedup / visibility semantics are exercised
+//! exhaustively at the unit + store-integration layer (src/triggers.rs,
+//! src/surreal_db/tests.rs). Setting up TRIGGERED memories end-to-end through
+//! the CLI requires `mx memory add --triggers`, which lands in PR2 — so these
+//! CLI tests focus on the parts reachable without seeded triggers: input
+//! handling (arg vs stdin, exit codes), empty-on-no-match output contracts, and
+//! the fired-state file lifecycle (reset).
+
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+
+const MX: &str = env!("CARGO_BIN_EXE_mx");
+
+/// Run `mx` with isolated surreal root + fired-state path. `stdin` is optional.
+fn mx(dir: &TempDir, args: &[&str], stdin: Option<&str>) -> std::process::Output {
+    let mut cmd = Command::new(MX);
+    cmd.args(args)
+        .env("MX_CURRENT_AGENT", "test-agent")
+        .env("MX_SURREAL_ROOT", dir.path().join("surreal"))
+        .env("MX_TRIGGER_FIRED_PATH", dir.path().join("fired.json"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn mx");
+    if let Some(input) = stdin {
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(input.as_bytes())
+            .unwrap();
+    }
+    // Close stdin so a stdin-fallback read reaches EOF instead of blocking.
+    drop(child.stdin.take());
+    child.wait_with_output().expect("failed to wait on mx")
+}
+
+#[test]
+fn empty_message_arg_exits_4() {
+    let dir = TempDir::new().unwrap();
+    // Explicit empty-string arg, AND empty stdin -> invalid input -> exit 4.
+    let out = mx(&dir, &["memory", "trigger-check", ""], Some(""));
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "empty message must exit 4; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn empty_stdin_no_arg_exits_4() {
+    let dir = TempDir::new().unwrap();
+    // No positional arg; empty stdin -> exit 4.
+    let out = mx(&dir, &["memory", "trigger-check"], Some("   \n  "));
+    assert_eq!(out.status.code(), Some(4));
+}
+
+#[test]
+fn no_match_is_success_with_empty_stdout() {
+    let dir = TempDir::new().unwrap();
+    // Fresh empty store: nothing can match. Firing nothing is SUCCESS (exit 0)
+    // and stdout must be empty (caller injects nothing).
+    let out = mx(
+        &dir,
+        &["memory", "trigger-check", "an unremarkable message"],
+        None,
+    );
+    assert!(
+        out.status.success(),
+        "no-match must be success (exit 0); stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "no-match context output must be empty, got: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn no_match_json_reports_empty_fired_and_zero_deferred() {
+    let dir = TempDir::new().unwrap();
+    let out = mx(
+        &dir,
+        &["memory", "trigger-check", "nothing here", "--json"],
+        None,
+    );
+    assert!(out.status.success());
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("trigger-check --json must emit valid JSON");
+    assert_eq!(v["fired"].as_array().unwrap().len(), 0);
+    assert_eq!(v["deferred_count"].as_i64().unwrap(), 0);
+}
+
+#[test]
+fn message_from_stdin_when_arg_absent() {
+    let dir = TempDir::new().unwrap();
+    // Arg absent, message supplied via stdin. No matches in an empty store, but
+    // the point is it must NOT exit 4 (stdin gave a non-empty message).
+    let out = mx(
+        &dir,
+        &["memory", "trigger-check"],
+        Some("a message from stdin"),
+    );
+    assert!(
+        out.status.success(),
+        "non-empty stdin message must be accepted (exit 0); stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn dry_run_does_not_create_or_modify_fired_state() {
+    let dir = TempDir::new().unwrap();
+    let fired = dir.path().join("fired.json");
+    // No matches, but --dry-run must never write the fired-state file regardless.
+    let out = mx(&dir, &["memory", "trigger-check", "msg", "--dry-run"], None);
+    assert!(out.status.success());
+    assert!(
+        !fired.exists(),
+        "--dry-run must not create the fired-state file"
+    );
+}
+
+#[test]
+fn trigger_reset_removes_fired_state_file() {
+    let dir = TempDir::new().unwrap();
+    let fired = dir.path().join("fired.json");
+    // Pre-seed a fired-state file as if a prior session marked some memories.
+    fs::write(&fired, r#"{"fired":["kn-aaaaaaaa","kn-bbbbbbbb"]}"#).unwrap();
+    assert!(fired.exists());
+
+    let out = mx(&dir, &["memory", "trigger-reset"], None);
+    assert!(
+        out.status.success(),
+        "trigger-reset must succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !fired.exists(),
+        "trigger-reset must remove the fired-state file"
+    );
+}
+
+#[test]
+fn trigger_reset_json_reports_path() {
+    let dir = TempDir::new().unwrap();
+    let out = mx(&dir, &["memory", "trigger-reset", "--json"], None);
+    assert!(out.status.success());
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("trigger-reset --json must emit valid JSON");
+    assert_eq!(v["reset"].as_bool(), Some(true));
+    assert!(v["path"].as_str().unwrap().contains("fired.json"));
+}
+
+#[test]
+fn trigger_reset_idempotent_when_no_file() {
+    let dir = TempDir::new().unwrap();
+    // No fired-state file exists yet; reset must still succeed.
+    let out = mx(&dir, &["memory", "trigger-reset"], None);
+    assert!(out.status.success());
+}


### PR DESCRIPTION
## PR 3 of 4 — Triggered Memories (matching engine + session dedup)

Part 3/4 of #246. This PR does **NOT** close #246 — PR 4/4 (hook integration) completes the feature.

The recursive heart of the feature: the trigger **matcher** and the session-scoped **one-shot dedup**, plus the `mx memory trigger-check` / `mx memory trigger-reset` CLI. Builds on PR1's `triggers` field + `normalize_trigger` helpers (#356); does not depend on PR2's `--triggers` add/update flags (in parallel).

### Matching pipeline (`src/triggers.rs`)
`normalize → tokenize → stem → contiguous-sequence match`, identical on both sides:

1. **normalize** — via the shared `normalize_trigger` (NFC + lowercase + whitespace-collapse). Both the message and each stored trigger go through it, so author-time and match-time canonicalize identically.
2. **tokenize** — split on Unicode word boundaries (runs of non-alphanumeric). This is what makes matching **word-boundary**: trigger `"ai"` tokenizes `"said"` as `["said"]`, so it never fires on "said"/"maintain", only on a whole `"ai"` token.
3. **stem** — Porter/Snowball English (`rust-stemmers`) on every token, both sides. `"diabetes"` fires on `"diabetic"`, `"run"` on `"running"`.
4. **contiguous match** — a trigger's stemmed token sequence must appear as a contiguous, in-order run in the message's stemmed stream. Single-word triggers = length-1 sequence. Phrase `"blood sugar"` fires on "his blood sugar today" but NOT "sugar in blood" (order) or "blood pressure and sugar" (contiguity).

### Fire cap + dedup
- **Cap 5, resonance desc.** More than 5 matches → top 5 by resonance fire, the overflow stays **unfired** and is eligible on a later turn (verified: the deferred one fires on the next check).
- **One-shot per session.** Survivors (matched AND not already fired) are appended to a flock-guarded JSON file `{"fired":[...]}` at `/tmp/wonka-triggered-fired.json` (override `MX_TRIGGER_FIRED_PATH`, mirrors `MX_KV_DATA`).

### Fired-state flock atomicity
`FiredStore::mark_survivors` does the whole read-modify-write inside ONE `flock(LOCK_EX)` critical section: `open(rw,create) → lock_exclusive → read → diff(survivors) → append → truncate+rewrite → flush+sync → unlock`. Because read and write share one lock, a concurrent `trigger-check` (two hooks racing) runs entirely before or after — it can never observe the file mid-update and double-fire a memory. The handler peeks the fired set to compute the cap/deferred count, then the authoritative mark re-checks under the lock, so the returned survivors are the set THIS invocation owns.

### Visibility
`trigger-check` loads candidates through a new `KnowledgeStore::list_with_triggers(ctx)` that uses the **same** `build_visibility_filter` every other read path uses (`visibility='public' OR (private AND owner=$current_agent)`). A private triggered memory only fires for its owner — tested: agent-b's check does not fire agent-a's private memory.

### CLI
- `mx memory trigger-check "<message>"` — positional arg with **stdin fallback** (empty/absent arg → read stdin to EOF). Default `--format context` renders `# title` + body per fired memory separated by `---`, **empty stdout when nothing fires**. `--json` → `{"fired":[{"id","title","triggers_matched":[...]}],"deferred_count":N}`. `--dry-run` reports without marking. Exit **0** = ran (firing nothing is success); exit **4** = empty message after stdin fallback.
- `mx memory trigger-reset [--json]` — clears the fired-state file (idempotent).

### NFC fix in the shared normalizer (Verdictia PR1 review)
`normalize_trigger` now NFC-canonicalizes before lowercasing, so precomposed "café" (U+00E9) and decomposed "café" (e + U+0301) match. Changed in the **shared** helper in `src/knowledge.rs` so BOTH stored triggers and message tokens fold identically. Test proves precomposed/decomposed match.

### Index honesty (Verdictia nit)
PR1's `DEFINE INDEX knowledge_triggers ON knowledge FIELDS triggers` is a **per-element** index over array contents — it accelerates `CONTAINS` lookups, **not** the `array::len(...) > 0` non-emptiness prefilter this query uses (full scan regardless). **It does not earn its keep for THIS query.** Kept deliberately for a future hook-side `CONTAINS` fast path; flagged in the schema comment as a removal candidate if that never lands.

### Surprise found & fixed (on-disk only)
The non-emptiness prefilter was originally `array::len(triggers) > 0`, which threw `Expected a array but found NONE` on an on-disk store: the read-path `IF triggers THEN ... ELSE [] END` coalesce lives only in the SELECT projection, **not** in WHERE, so a NONE-valued `triggers` reaches `array::len` and errors. Fixed to `array::len(triggers ?? []) > 0`. The in-memory round-trip tests never hit it (every test row is written, thus already an array); caught by smoking the real binary against an on-disk store. Comment warns against "simplifying" the `?? []` away.

### New deps
`rust-stemmers = "1"` (1.2.0), `unicode-normalization = "0.1"` (0.1.25), `fs2 = "0.4"` (0.4.3, portable file locking — the repo had no existing flock crate; KV uses tmp+rename, which is not cross-process-safe for this RMW).

### Tests (all green)
`cargo build` + `cargo test --bin mx` (**1075 passed**, +18) + `cargo test --test trigger_check` (**9 passed**) + `cargo clippy --bin mx --tests` (clean) + `cargo fmt`.
- Unit (`src/triggers.rs`): word-boundary (ai≠said/maintain, fires on "the ai is"), stemming (diabetes→diabetic, run→running), phrase contiguity (in-order fires, out-of-order/non-contiguous don't), NFC café, FiredStore mark/dedupe/reset.
- Store integration (`src/surreal_db/tests.rs`): `list_with_triggers` prefilter + visibility; private-memory cross-agent non-firing; cap-5-by-resonance with the deferred memory firing on a subsequent check.
- CLI integration (`tests/trigger_check.rs`): exit 4 on empty (arg + stdin), exit 0 + empty stdout on no-match, `--json` shape, stdin fallback, `--dry-run` writes nothing, `trigger-reset` removes file / json / idempotent.
- NFC test in `src/knowledge.rs`.

### Merge note
Touches `cli.rs`/`handlers/memory.rs` only for the new `TriggerCheck`/`TriggerReset` arms (localized, away from PR2's add/update). Whichever of PR2/PR3 merges first, the other rebases.
