### PR TITLE
feat(memory): triggers CLI add/update/show [2/4]

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -401,6 +401,10 @@ pub enum RecentSortOrder {
 }
 
 #[derive(Subcommand)]
+// The Add/Update variants carry many optional flags by design (clap arg structs);
+// boxing individual fields would fight the destructuring in handlers. Mirrors the
+// allow already on the top-level `Commands` enum above.
+#[allow(clippy::large_enum_variant)]
 pub enum MemoryCommands {
     /// Removed -- see follow-up for markdown ingest plans
     ///
@@ -601,6 +605,10 @@ pub enum MemoryCommands {
         #[arg(long)]
         wake_order: Option<i32>,
 
+        /// Triggers (comma-separated phrases that surface this memory; Issue #246)
+        #[arg(long)]
+        triggers: Option<String>,
+
         /// Anchors (comma-separated bloom IDs this connects to)
         #[arg(long)]
         anchors: Option<String>,
@@ -731,6 +739,18 @@ pub enum MemoryCommands {
         /// Remove a specific wake phrase
         #[arg(long, conflicts_with = "wake_phrases")]
         remove_wake_phrase: Option<String>,
+
+        /// Update triggers (comma-separated, replaces all; Issue #246)
+        #[arg(long, conflicts_with_all = ["add_trigger", "remove_trigger"])]
+        triggers: Option<String>,
+
+        /// Add a single trigger to existing triggers
+        #[arg(long, conflicts_with = "triggers")]
+        add_trigger: Option<String>,
+
+        /// Remove a specific trigger
+        #[arg(long, conflicts_with = "triggers")]
+        remove_trigger: Option<String>,
 
         /// Update wake order (use '-' to clear)
         #[arg(long)]

--- a/src/display.rs
+++ b/src/display.rs
@@ -66,6 +66,9 @@ pub(crate) fn format_entry_full(entry: &knowledge::KnowledgeEntry) -> String {
     if !entry.wake_phrases.is_empty() {
         let _ = writeln!(out, "Wake Phrases: {}", entry.wake_phrases.join(", "));
     }
+    if !entry.triggers.is_empty() {
+        let _ = writeln!(out, "Triggers: {}", entry.triggers.join(", "));
+    }
     if let Some(path) = &entry.file_path {
         let _ = writeln!(out, "File:     {}", path);
     }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -464,6 +464,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             wake_phrase,
             wake_phrases,
             wake_order,
+            triggers,
             anchors,
             r#type,
             session,
@@ -504,6 +505,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             {
                 bail!("--visibility must be 'public' or 'private'");
             }
+
+            // Parse triggers CSV (Issue #246): normalize + dedupe via the shared
+            // helper so author-time values match the PR3 matcher. Used by both the
+            // fact-routing path and the standard entry construction below.
+            let trigger_list: Vec<String> = triggers
+                .as_deref()
+                .map(|t| knowledge::normalize_triggers(t.split(',')))
+                .unwrap_or_default();
 
             // Handle fact type routing mode (--type flag)
             if let Some(ref fact_type) = r#type {
@@ -626,8 +635,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     decay_rate: 0.0,
                     anchors: vec![],
                     wake_phrases: vec![],
-                    // Issue #246: triggers wired through the CLI in PR2; default empty for now.
-                    triggers: vec![],
+                    // Issue #246: triggers from the --triggers CLI flag (PR2).
+                    triggers: trigger_list.clone(),
                     wake_order: None,
                     wake_phrase: None,
                     embedding: None,
@@ -799,8 +808,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 decay_rate: 0.0,
                 anchors: anchor_list,
                 wake_phrases: wake_phrase_list,
-                // Issue #246: triggers wired through the CLI in PR2; default empty for now.
-                triggers: vec![],
+                // Issue #246: triggers from the --triggers CLI flag (PR2).
+                triggers: trigger_list,
                 wake_order,
                 wake_phrase,
                 embedding: None,
@@ -856,6 +865,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         "anchors": entry.anchors,
                         "wake_phrase": entry.wake_phrase,
                         "wake_phrases": entry.wake_phrases,
+                        "triggers": entry.triggers,
                     }))?
                 );
             } else {
@@ -883,6 +893,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
                 if let Some(ref phrase) = entry.wake_phrase {
                     println!("  Wake Phrase: {}", phrase);
+                }
+                if !entry.triggers.is_empty() {
+                    println!("  Triggers: {}", entry.triggers.join(", "));
                 }
             }
         }
@@ -915,6 +928,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             wake_phrases,
             add_wake_phrase,
             remove_wake_phrase,
+            triggers,
+            add_trigger,
+            remove_trigger,
             wake_order,
             private,
             visibility,
@@ -1176,6 +1192,35 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             {
                 entry.wake_phrases.remove(pos);
                 changes.push(format!("wake_phrases: removed '{}'", phrase_to_remove));
+            }
+
+            // Update triggers (replaces all; Issue #246). Normalize + dedupe via the
+            // shared helper so values line up with the PR3 matcher.
+            if let Some(ref triggers_str) = triggers {
+                let trigger_list = knowledge::normalize_triggers(triggers_str.split(','));
+                changes.push(format!(
+                    "triggers: {:?} -> {:?}",
+                    entry.triggers, trigger_list
+                ));
+                entry.triggers = trigger_list;
+            }
+
+            // Add a single trigger (normalized; no-op if already present)
+            if let Some(ref raw_trigger) = add_trigger
+                && let Some(norm) = knowledge::normalize_trigger(raw_trigger)
+                && !entry.triggers.contains(&norm)
+            {
+                entry.triggers.push(norm.clone());
+                changes.push(format!("triggers: added '{}'", norm));
+            }
+
+            // Remove a specific trigger (compare normalized forms; clean no-op if absent)
+            if let Some(ref raw_trigger) = remove_trigger
+                && let Some(norm) = knowledge::normalize_trigger(raw_trigger)
+                && let Some(pos) = entry.triggers.iter().position(|t| *t == norm)
+            {
+                entry.triggers.remove(pos);
+                changes.push(format!("triggers: removed '{}'", norm));
             }
 
             // Update wake_order (use '-' to clear)

--- a/tests/triggers_cli.rs
+++ b/tests/triggers_cli.rs
@@ -1,0 +1,314 @@
+//! Integration tests for the triggers CLI surface (Issue #246, PR 2/4).
+//!
+//! Exercises `mx memory add/update/show` against a real temp database via the
+//! built binary, mirroring the harness style in `tests/update_pressure.rs`.
+//! Triggers normalize + dedupe through `crate::knowledge::normalize_trigger(s)`,
+//! so these tests assert on the normalized/deduped forms.
+
+use std::process::Command;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use tempfile::TempDir;
+
+const MX: &str = env!("CARGO_BIN_EXE_mx");
+
+/// Each test spins up a full SurrealDB + embedding engine under its own temp
+/// MX_HOME. Running them concurrently exhausts the (shared) model cache and DB
+/// resources, so serialize the heavyweight binary invocations through one lock.
+fn test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Holds the serialization guard for the lifetime of the test alongside its
+/// isolated MX_HOME.
+struct Env {
+    dir: TempDir,
+    _guard: MutexGuard<'static, ()>,
+}
+
+/// Fresh isolated MX_HOME, serialized against other tests in this binary.
+fn setup() -> Env {
+    let guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
+    Env {
+        dir: TempDir::new().unwrap(),
+        _guard: guard,
+    }
+}
+
+fn mx(env: &Env, args: &[&str]) -> std::process::Output {
+    Command::new(MX)
+        .args(args)
+        .env("MX_HOME", env.dir.path())
+        .env("MX_CURRENT_AGENT", "test")
+        .output()
+        .expect("failed to run mx")
+}
+
+/// Add an entry with the given `--triggers` flag value; returns its `kn-` id and
+/// the normalized triggers the binary reported via `--json`.
+fn add_with_triggers(dir: &Env, triggers: &str) -> (String, Vec<String>) {
+    let out = mx(
+        dir,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Trig Test",
+            "--content",
+            "body",
+            "--triggers",
+            triggers,
+            "--json",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("add --json output should parse");
+    let id = v["id"].as_str().expect("id present").to_string();
+    let triggers = json_triggers(&v);
+    (id, triggers)
+}
+
+/// Add a plain entry with no triggers; returns its id.
+fn add_plain(dir: &Env) -> String {
+    let out = mx(
+        dir,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Plain",
+            "--content",
+            "body",
+            "--json",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    v["id"].as_str().unwrap().to_string()
+}
+
+/// Read the current triggers off an entry via `memory show --json`.
+fn show_triggers(dir: &Env, id: &str) -> Vec<String> {
+    let out = mx(dir, &["memory", "show", id, "--json"]);
+    assert!(
+        out.status.success(),
+        "show failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("show --json output should parse");
+    json_triggers(&v)
+}
+
+fn json_triggers(v: &serde_json::Value) -> Vec<String> {
+    v["triggers"]
+        .as_array()
+        .expect("triggers array present")
+        .iter()
+        .map(|t| t.as_str().unwrap().to_string())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// add
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_stores_triggers_normalized_and_deduped() {
+    let dir = setup();
+    // Mixed case, internal whitespace runs, and a duplicate ("brad").
+    let (id, triggers) = add_with_triggers(&dir, "Blood   Sugar, brad, BRAD");
+    assert_eq!(
+        triggers,
+        vec!["blood sugar".to_string(), "brad".to_string()],
+        "triggers should be lowercased, whitespace-collapsed, and deduped"
+    );
+    // And the same normalized set is persisted (round-trips through show).
+    assert_eq!(show_triggers(&dir, &id), triggers);
+}
+
+#[test]
+fn add_without_triggers_is_empty() {
+    let dir = setup();
+    let id = add_plain(&dir);
+    assert!(show_triggers(&dir, &id).is_empty());
+}
+
+#[test]
+fn show_renders_triggers_line() {
+    let dir = setup();
+    let (id, _) = add_with_triggers(&dir, "Alpha, Beta");
+    let out = mx(&dir, &["memory", "show", &id]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Triggers: alpha, beta"),
+        "show output should render a Triggers line: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// update --triggers (replace whole set)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn update_triggers_replaces_full_set() {
+    let dir = setup();
+    let (id, _) = add_with_triggers(&dir, "old one, old two");
+    let out = mx(
+        &dir,
+        &[
+            "memory",
+            "update",
+            &id,
+            "--triggers",
+            "X One, x one, Foo Bar",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "update failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Replaced wholesale, normalized + deduped ("X One"/"x one" collapse to one).
+    assert_eq!(
+        show_triggers(&dir, &id),
+        vec!["x one".to_string(), "foo bar".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// update --add-trigger (append-if-absent)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_trigger_appends_normalized() {
+    let dir = setup();
+    let (id, _) = add_with_triggers(&dir, "alpha");
+    let out = mx(
+        &dir,
+        &["memory", "update", &id, "--add-trigger", "Beta Gamma"],
+    );
+    assert!(out.status.success());
+    assert_eq!(
+        show_triggers(&dir, &id),
+        vec!["alpha".to_string(), "beta gamma".to_string()]
+    );
+}
+
+#[test]
+fn add_trigger_existing_is_noop() {
+    let dir = setup();
+    let (id, _) = add_with_triggers(&dir, "alpha, beta");
+    // Re-adding an existing trigger (different casing) must not duplicate it.
+    let out = mx(&dir, &["memory", "update", &id, "--add-trigger", "ALPHA"]);
+    assert!(out.status.success());
+    assert_eq!(
+        show_triggers(&dir, &id),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "adding an existing trigger should be a no-op (no dupes)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// update --remove-trigger
+// ---------------------------------------------------------------------------
+
+#[test]
+fn remove_trigger_removes_by_normalized_form() {
+    let dir = setup();
+    let (id, _) = add_with_triggers(&dir, "alpha, beta, gamma");
+    // Removal compares normalized forms: "Beta " (trailing space) matches "beta".
+    let out = mx(
+        &dir,
+        &["memory", "update", &id, "--remove-trigger", "Beta "],
+    );
+    assert!(out.status.success());
+    assert_eq!(
+        show_triggers(&dir, &id),
+        vec!["alpha".to_string(), "gamma".to_string()]
+    );
+}
+
+#[test]
+fn remove_trigger_absent_is_clean_noop() {
+    let dir = setup();
+    let (id, _) = add_with_triggers(&dir, "alpha, beta");
+    let out = mx(&dir, &["memory", "update", &id, "--remove-trigger", "nope"]);
+    // Removing a non-present trigger succeeds and changes nothing.
+    assert!(
+        out.status.success(),
+        "removing an absent trigger should be a clean success: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        show_triggers(&dir, &id),
+        vec!["alpha".to_string(), "beta".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// clap conflicts_with
+// ---------------------------------------------------------------------------
+
+#[test]
+fn triggers_conflicts_with_add_trigger() {
+    let dir = setup();
+    let id = add_plain(&dir);
+    let out = mx(
+        &dir,
+        &[
+            "memory",
+            "update",
+            &id,
+            "--triggers",
+            "a",
+            "--add-trigger",
+            "b",
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "--triggers + --add-trigger must be rejected by clap"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("cannot be used with") || stderr.to_lowercase().contains("usage"),
+        "expected a clap conflict error: {stderr}"
+    );
+}
+
+#[test]
+fn triggers_conflicts_with_remove_trigger() {
+    let dir = setup();
+    let id = add_plain(&dir);
+    let out = mx(
+        &dir,
+        &[
+            "memory",
+            "update",
+            &id,
+            "--triggers",
+            "a",
+            "--remove-trigger",
+            "b",
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "--triggers + --remove-trigger must be rejected by clap"
+    );
+}


### PR DESCRIPTION
Part 2/4 of #246 (triggered memories) — the triggers CLI surface.

## What this adds
- `mx memory add --triggers` — set trigger phrases at creation time.
- `mx memory update --triggers / --add-trigger / --remove-trigger` — full replace or incremental add/remove of triggers on an existing memory.
- Triggers display in `mx memory show`.

## How it fits
- Built on PR 1/4 (#356, merged) which landed the schema/storage foundation.
- Uses the shared normalize helpers for consistent trigger formatting.
- Reuses the existing `wake_phrases` read-modify-write pattern for the update path, so the incremental add/remove semantics match what's already in the codebase.

## Scope note
Does NOT close #246 — that is completed by PR 4/4.

(Re-created against coryzibell/mx after an accidental cross-fork PR against gabaum10/mx was closed.)