### PR TITLE
feat: add MX_SKIP_WRITE_ANCHOR to defer write-path auto-anchoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mx"
-version = "0.1.196"
+version = "0.1.197"
 edition = "2024"
 description = "A Swiss army knife for Claude Code and multi-agent toolkits"
 authors = ["Cory Zibell <cory@zibell.cloud>"]

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1160,6 +1160,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
+                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1724,6 +1725,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             {
                 auto_anchor(&id, db.as_ref(), removed)?;
             } else {
+                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1790,6 +1792,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
+                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1872,6 +1875,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
+                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1950,6 +1954,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
+                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -2065,6 +2070,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 {
                     auto_anchor(&id, db.as_ref(), None)?;
                 } else {
+                    commit_entry(&id, db.as_ref())?;
                     println!("  (auto-anchor skipped)");
                 }
 

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1151,7 +1151,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            if !no_auto_anchor {
+            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
+            // anchoring on the write path. The explicit `mx memory auto-anchor` command
+            // is never gated and always runs (nightly batch depends on it).
+            if !no_auto_anchor
+                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
+                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+            {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
                 println!("  (auto-anchor skipped)");
@@ -1709,7 +1715,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             } else {
                 Some(explicitly_removed_anchors.as_slice())
             };
-            if !no_auto_anchor {
+            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
+            // anchoring on the write path. The explicit `mx memory auto-anchor` command
+            // is never gated and always runs (nightly batch depends on it).
+            if !no_auto_anchor
+                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
+                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+            {
                 auto_anchor(&id, db.as_ref(), removed)?;
             } else {
                 println!("  (auto-anchor skipped)");
@@ -1769,7 +1781,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            if !no_auto_anchor {
+            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
+            // anchoring on the write path. The explicit `mx memory auto-anchor` command
+            // is never gated and always runs (nightly batch depends on it).
+            if !no_auto_anchor
+                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
+                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+            {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
                 println!("  (auto-anchor skipped)");
@@ -1845,7 +1863,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            if !no_auto_anchor {
+            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
+            // anchoring on the write path. The explicit `mx memory auto-anchor` command
+            // is never gated and always runs (nightly batch depends on it).
+            if !no_auto_anchor
+                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
+                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+            {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
                 println!("  (auto-anchor skipped)");
@@ -1917,7 +1941,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             auto_embed(&id, db.as_ref())?;
 
             // Auto-generate anchors if in network SurrealDB mode
-            if !no_auto_anchor {
+            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
+            // anchoring on the write path. The explicit `mx memory auto-anchor` command
+            // is never gated and always runs (nightly batch depends on it).
+            if !no_auto_anchor
+                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
+                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+            {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
                 println!("  (auto-anchor skipped)");
@@ -2026,7 +2056,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 // #3: update embeddings and anchors like all other mutation paths
                 auto_embed(&id, db.as_ref())?;
-                if !no_auto_anchor {
+                // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
+                // anchoring on the write path. The explicit `mx memory auto-anchor` command
+                // is never gated and always runs (nightly batch depends on it).
+                if !no_auto_anchor
+                    && !std::env::var("MX_SKIP_WRITE_ANCHOR")
+                        .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
+                {
                     auto_anchor(&id, db.as_ref(), None)?;
                 } else {
                     println!("  (auto-anchor skipped)");

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1150,17 +1150,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // Auto-generate embedding if in network SurrealDB mode
             auto_embed(&id, db.as_ref())?;
 
-            // Auto-generate anchors if in network SurrealDB mode
-            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
-            // anchoring on the write path. The explicit `mx memory auto-anchor` command
-            // is never gated and always runs (nightly batch depends on it).
-            if !no_auto_anchor
-                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
-                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
-            {
+            // Auto-generate anchors if in network SurrealDB mode.
+            // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
+            // write_anchor_enabled). The entry is already durable here, so
+            // skipping anchoring is safe; the explicit `mx memory auto-anchor`
+            // command is never gated and still anchors deferred writes.
+            if write_anchor_enabled(no_auto_anchor) {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
-                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1716,16 +1713,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             } else {
                 Some(explicitly_removed_anchors.as_slice())
             };
-            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
-            // anchoring on the write path. The explicit `mx memory auto-anchor` command
-            // is never gated and always runs (nightly batch depends on it).
-            if !no_auto_anchor
-                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
-                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
-            {
+            // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
+            // write_anchor_enabled). The entry is already durable here, so
+            // skipping anchoring is safe; the explicit `mx memory auto-anchor`
+            // command is never gated and still anchors deferred writes.
+            if write_anchor_enabled(no_auto_anchor) {
                 auto_anchor(&id, db.as_ref(), removed)?;
             } else {
-                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1782,17 +1776,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // Auto-generate embedding if in network SurrealDB mode
             auto_embed(&id, db.as_ref())?;
 
-            // Auto-generate anchors if in network SurrealDB mode
-            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
-            // anchoring on the write path. The explicit `mx memory auto-anchor` command
-            // is never gated and always runs (nightly batch depends on it).
-            if !no_auto_anchor
-                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
-                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
-            {
+            // Auto-generate anchors if in network SurrealDB mode.
+            // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
+            // write_anchor_enabled). The entry is already durable here, so
+            // skipping anchoring is safe; the explicit `mx memory auto-anchor`
+            // command is never gated and still anchors deferred writes.
+            if write_anchor_enabled(no_auto_anchor) {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
-                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1865,17 +1856,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // Auto-generate embedding if in network SurrealDB mode
             auto_embed(&id, db.as_ref())?;
 
-            // Auto-generate anchors if in network SurrealDB mode
-            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
-            // anchoring on the write path. The explicit `mx memory auto-anchor` command
-            // is never gated and always runs (nightly batch depends on it).
-            if !no_auto_anchor
-                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
-                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
-            {
+            // Auto-generate anchors if in network SurrealDB mode.
+            // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
+            // write_anchor_enabled). The entry is already durable here, so
+            // skipping anchoring is safe; the explicit `mx memory auto-anchor`
+            // command is never gated and still anchors deferred writes.
+            if write_anchor_enabled(no_auto_anchor) {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
-                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -1944,17 +1932,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // Auto-generate embedding if in network SurrealDB mode
             auto_embed(&id, db.as_ref())?;
 
-            // Auto-generate anchors if in network SurrealDB mode
-            // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
-            // anchoring on the write path. The explicit `mx memory auto-anchor` command
-            // is never gated and always runs (nightly batch depends on it).
-            if !no_auto_anchor
-                && !std::env::var("MX_SKIP_WRITE_ANCHOR")
-                    .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
-            {
+            // Auto-generate anchors if in network SurrealDB mode.
+            // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
+            // write_anchor_enabled). The entry is already durable here, so
+            // skipping anchoring is safe; the explicit `mx memory auto-anchor`
+            // command is never gated and still anchors deferred writes.
+            if write_anchor_enabled(no_auto_anchor) {
                 auto_anchor(&id, db.as_ref(), None)?;
             } else {
-                commit_entry(&id, db.as_ref())?;
                 println!("  (auto-anchor skipped)");
             }
 
@@ -2061,16 +2046,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 // #3: update embeddings and anchors like all other mutation paths
                 auto_embed(&id, db.as_ref())?;
-                // Gate: --no-auto-anchor flag OR MX_SKIP_WRITE_ANCHOR=1 disables automatic
-                // anchoring on the write path. The explicit `mx memory auto-anchor` command
-                // is never gated and always runs (nightly batch depends on it).
-                if !no_auto_anchor
-                    && !std::env::var("MX_SKIP_WRITE_ANCHOR")
-                        .is_ok_and(|v| v == "1" || v.to_lowercase() == "true")
-                {
+                // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
+                // write_anchor_enabled). The entry is already durable here, so
+                // skipping anchoring is safe; the explicit `mx memory
+                // auto-anchor` command is never gated and still anchors
+                // deferred writes.
+                if write_anchor_enabled(no_auto_anchor) {
                     auto_anchor(&id, db.as_ref(), None)?;
                 } else {
-                    commit_entry(&id, db.as_ref())?;
                     println!("  (auto-anchor skipped)");
                 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -302,31 +302,32 @@ pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Resu
     Ok(())
 }
 
-/// Durability commit: re-fetch and re-upsert an entry to ensure write
-/// persistence.
+/// Whether the write path should run `auto_anchor` synchronously after a
+/// mutation (Add/Update/Edit/Append/Prepend/Restore).
 ///
-/// When `auto_anchor` is skipped (via `--no-auto-anchor` or
-/// `MX_SKIP_WRITE_ANCHOR=1`), the write path loses the final
-/// `upsert_knowledge` call that `auto_anchor` would have made.  That
-/// trailing upsert carries a side-effect the storage layer depends on
-/// for durable commits (tag/applicability edge recreation, full-text
-/// index refresh).  This function provides that side-effect without the
-/// expensive cosine-similarity scan.
-pub(crate) fn commit_entry(entry_id: &str, db: &dyn store::KnowledgeStore) -> Result<()> {
-    let ctx = match std::env::var("MX_CURRENT_AGENT") {
-        Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
-        _ => store::AgentContext::public_only(),
-    };
-
-    let mut entry = match db.get(entry_id, &ctx)? {
-        Some(e) => e,
-        None => return Ok(()),
-    };
-
-    entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
-    db.upsert_knowledge(&entry)?;
-
-    Ok(())
+/// Anchoring on the write path is disabled when EITHER:
+///   - the caller passed `--no-auto-anchor` (`no_auto_anchor == true`), or
+///   - `MX_SKIP_WRITE_ANCHOR` is set to `1`/`true` (case-insensitive).
+///
+/// The env-var parsing mirrors the `MX_SKIP_SCHEMA` convention
+/// (`connection.rs`) so the project keeps one rule for boolean opt-out flags.
+///
+/// `MX_SKIP_WRITE_ANCHOR` is a future-facing opt-out: it lets a deployment
+/// defer anchoring entirely to the explicit `mx memory auto-anchor` batch
+/// command (e.g. a nightly cron), which is never gated by this flag.
+///
+/// Skipping anchoring does NOT affect durability. By the time this gate is
+/// evaluated the entry has already been `upsert_knowledge`d, read-back
+/// verified (the Add path `bail!`s if the row is absent), and re-upserted by
+/// `auto_embed` — so the write is provably durable before anchoring would
+/// ever run. `auto_anchor` itself returns early WITHOUT any upsert whenever
+/// an entry has no embedding or no in-band neighbours; its trailing upsert is
+/// an anchor update, not a load-bearing commit. Hence skipping it loses
+/// anchors-for-this-write, nothing else.
+pub(crate) fn write_anchor_enabled(no_auto_anchor: bool) -> bool {
+    let skip_via_env =
+        std::env::var("MX_SKIP_WRITE_ANCHOR").is_ok_and(|v| v == "1" || v.to_lowercase() == "true");
+    !no_auto_anchor && !skip_via_env
 }
 
 /// Auto-anchor a knowledge entry after add/update
@@ -1191,6 +1192,156 @@ mod auto_anchor_tests {
             got,
             vec!["kn-a".to_string(), "kn-b".to_string(), "kn-c".to_string()],
             "the three in-band anchors are selected from the initial top-K (no escalation needed)"
+        );
+    }
+
+    // =====================================================================
+    // MX_SKIP_WRITE_ANCHOR opt-out (PR #364)
+    //
+    // Two things under test:
+    //   1. write_anchor_enabled — the single source of truth for the gate.
+    //      Tested directly (not a re-implemented copy of the condition) for
+    //      every accepted value of the flag plus the --no-auto-anchor flag.
+    //   2. Durability — a write whose anchoring is skipped (flag ON) still
+    //      persists. Proven against a REAL file-backed store across a
+    //      drop+reopen, since an in-memory store cannot demonstrate
+    //      durability across a fresh connection.
+    //
+    // commit_entry was REMOVED in this PR: post-#362 the Add path upserts +
+    // read-back-verifies + auto_embeds (which upserts again) BEFORE the
+    // anchor step, so the entry is provably durable before auto_anchor would
+    // run. auto_anchor also returns early WITHOUT upserting whenever an entry
+    // has no embedding or no in-band neighbours, so its trailing upsert is an
+    // anchor update, not a load-bearing commit. The skip path therefore needs
+    // no extra upsert.
+    // =====================================================================
+
+    /// Save the current MX_SKIP_WRITE_ANCHOR value, set it (or clear it),
+    /// evaluate the gate, then restore — so the env state never leaks.
+    /// SAFETY: process-wide env mutation, serialized via `#[serial]`.
+    fn gate_with_env(value: Option<&str>, no_auto_anchor: bool) -> bool {
+        let prev = std::env::var("MX_SKIP_WRITE_ANCHOR").ok();
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var("MX_SKIP_WRITE_ANCHOR", v),
+                None => std::env::remove_var("MX_SKIP_WRITE_ANCHOR"),
+            }
+        }
+        let enabled = write_anchor_enabled(no_auto_anchor);
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_SKIP_WRITE_ANCHOR", v),
+                None => std::env::remove_var("MX_SKIP_WRITE_ANCHOR"),
+            }
+        }
+        enabled
+    }
+
+    #[test]
+    #[serial]
+    fn write_anchor_enabled_unset_flag_runs_anchoring() {
+        assert!(
+            gate_with_env(None, false),
+            "unset MX_SKIP_WRITE_ANCHOR must leave anchoring ON (default behavior preserved)"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn write_anchor_enabled_flag_1_skips_anchoring() {
+        assert!(
+            !gate_with_env(Some("1"), false),
+            "MX_SKIP_WRITE_ANCHOR=1 must turn write-path anchoring OFF"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn write_anchor_enabled_flag_true_skips_anchoring() {
+        assert!(
+            !gate_with_env(Some("true"), false),
+            "MX_SKIP_WRITE_ANCHOR=true must turn write-path anchoring OFF"
+        );
+        assert!(
+            !gate_with_env(Some("TRUE"), false),
+            "MX_SKIP_WRITE_ANCHOR is case-insensitive for 'true'"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn write_anchor_enabled_other_values_run_anchoring() {
+        // Only "1"/"true" opt out; anything else (incl. "0", "false", "yes")
+        // leaves anchoring on, matching the MX_SKIP_SCHEMA convention.
+        assert!(gate_with_env(Some("0"), false), "'0' must not opt out");
+        assert!(
+            gate_with_env(Some("false"), false),
+            "'false' must not opt out"
+        );
+        assert!(gate_with_env(Some(""), false), "empty must not opt out");
+    }
+
+    #[test]
+    #[serial]
+    fn write_anchor_enabled_cli_flag_always_skips() {
+        // --no-auto-anchor closes the gate regardless of the env var.
+        assert!(
+            !gate_with_env(None, true),
+            "--no-auto-anchor must skip anchoring even with the env flag unset"
+        );
+        assert!(
+            !gate_with_env(Some("0"), true),
+            "--no-auto-anchor must skip anchoring even when env flag would allow it"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn skipped_anchor_write_persists_across_reopen() {
+        // The honest durability test: with anchoring skipped (flag ON), a
+        // write must survive being dropped and re-opened from a REAL
+        // file-backed store. This is what the write path actually does —
+        // upsert_knowledge — minus the auto_anchor step the flag removes.
+        //
+        // An in-memory store cannot prove this (it dies with the handle), so
+        // we use SurrealDatabase::open against a tempdir path and reopen it.
+        clear_agent_env();
+        let prev = std::env::var("MX_SKIP_WRITE_ANCHOR").ok();
+        unsafe { std::env::set_var("MX_SKIP_WRITE_ANCHOR", "1") };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("durability.surreal");
+
+        // Precondition: the gate is closed, i.e. the handler would NOT call
+        // auto_anchor — only the plain write happens.
+        assert!(
+            !write_anchor_enabled(false),
+            "precondition: flag=1 must skip anchoring"
+        );
+
+        // Write phase: open, upsert, drop the handle (simulating process exit).
+        {
+            let db = SurrealDatabase::open(&db_path).unwrap();
+            let entry =
+                entry_with_embedding("kn-skip-durable", unit_query(), "public", None, vec![]);
+            db.upsert_knowledge(&entry).unwrap();
+        }
+
+        // Reopen phase: a brand-new connection to the same on-disk store.
+        let reopened = SurrealDatabase::open(&db_path).unwrap();
+        let ctx = AgentContext::public_only();
+        let got = reopened.get("kn-skip-durable", &ctx).unwrap();
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_SKIP_WRITE_ANCHOR", v),
+                None => std::env::remove_var("MX_SKIP_WRITE_ANCHOR"),
+            }
+        }
+
+        assert!(
+            got.is_some(),
+            "a write with anchoring skipped must persist across a drop+reopen (no commit_entry needed)"
         );
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -302,6 +302,33 @@ pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Resu
     Ok(())
 }
 
+/// Durability commit: re-fetch and re-upsert an entry to ensure write
+/// persistence.
+///
+/// When `auto_anchor` is skipped (via `--no-auto-anchor` or
+/// `MX_SKIP_WRITE_ANCHOR=1`), the write path loses the final
+/// `upsert_knowledge` call that `auto_anchor` would have made.  That
+/// trailing upsert carries a side-effect the storage layer depends on
+/// for durable commits (tag/applicability edge recreation, full-text
+/// index refresh).  This function provides that side-effect without the
+/// expensive cosine-similarity scan.
+pub(crate) fn commit_entry(entry_id: &str, db: &dyn store::KnowledgeStore) -> Result<()> {
+    let ctx = match std::env::var("MX_CURRENT_AGENT") {
+        Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
+        _ => store::AgentContext::public_only(),
+    };
+
+    let mut entry = match db.get(entry_id, &ctx)? {
+        Some(e) => e,
+        None => return Ok(()),
+    };
+
+    entry.updated_at = Some(chrono::Utc::now().to_rfc3339());
+    db.upsert_knowledge(&entry)?;
+
+    Ok(())
+}
+
 /// Auto-anchor a knowledge entry after add/update
 ///
 /// This silently finds similar entries and adds anchors for a single entry.


### PR DESCRIPTION
## Summary

Gates the 6 write-path `auto_anchor` calls (Add/Update/Edit/Append/Prepend/Restore) behind a new env flag `MX_SKIP_WRITE_ANCHOR`, as a clean, future-facing opt-out.

- **Default-on:** unset = current behavior, anchoring runs on every write. No config change required.
- **Opt-out:** `MX_SKIP_WRITE_ANCHOR=1` (or `true`, case-insensitive) skips synchronous write-path anchoring, deferring it to the explicit `mx memory auto-anchor` CLI command. That command is **never gated** and always anchors when invoked (a nightly cron can rely on it).
- Mirrors the existing `MX_SKIP_SCHEMA` env-parsing convention.

## Reworked after #362 (keep-with-changes)

This PR was originally based on pre-#362 main. It has been **rebased onto current main (incl. #362)**. The rebase kept both #362's `auto_anchor` rewrite (DB-side bounded candidate fetch) and this PR's flag. The only conflict was the trivial test-module tail in `helpers.rs`, resolved keeping both test modules.

Three changes were made versus the original PR:

### 1. `commit_entry` removed — the durability narrative was wrong

The original PR claimed gating `auto_anchor` "silently broke write durability (phantom writes)" and that `auto_anchor`'s trailing `upsert_knowledge` was a "load-bearing" durability side-effect, so it added `commit_entry()` (a 4th re-upsert) to the skip path.

That narrative does not hold up against the code:

- `upsert_knowledge` is a plain SurrealDB `UPSERT`. There is **no flush primitive** and no special durability side-effect — it is the same write the rest of the path already performs.
- The write paths upsert the entry, **read it back and `bail!` if it is absent**, then call `auto_embed` (which **upserts again**) — all **before** the anchor step. The entry is provably durable before `auto_anchor` would ever run.
- `auto_anchor` itself has two early `return Ok(())` paths (no embedding; no in-band neighbours and no stale anchors) that perform **zero upserts**. Entries persist fine in those cases. So the trailing upsert is an *anchor update*, not a load-bearing commit.

**Empirical confirmation:** with `MX_SKIP_WRITE_ANCHOR=1` and `commit_entry` removed, a canary entry added via `mx memory add` persists across a fresh process re-fetch, and a real file-backed store survives a drop+reopen. `commit_entry` was a redundant extra upsert solving a non-problem, so it has been **removed entirely**. The flagged path now simply skips anchoring and does nothing else.

### 2. Gate condition extracted into one helper

The six pasted copies of the gate condition are replaced by a single `write_anchor_enabled(no_auto_anchor: bool) -> bool` in `helpers.rs`. The env-parsing rule now lives in one place (matching the `MX_SKIP_SCHEMA` convention) and each write site reads in one line.

### 3. Honest tests

- Direct unit tests of `write_anchor_enabled` for every accepted value (`1`, `true`/`TRUE`, `0`/`false`/empty → run, `--no-auto-anchor` → skip) — testing the real helper, not a re-implemented copy of the condition.
- A **real file-backed** drop+reopen durability test (`skipped_anchor_write_persists_across_reopen`) proving a flag-on write persists across a fresh connection. (An in-memory store cannot demonstrate durability, so this uses `SurrealDatabase::open` against a tempdir.)
- #362's `auto_anchor` correctness tests are retained unchanged.

## What this actually buys you (post-#362)

Be honest about the value after #362: #362 already made the normal write-path `auto_anchor` fast by moving the candidate scan DB-side (bounded top-K fetch instead of a full-graph Rust cosine loop). The marginal per-write saving from *also* skipping anchoring entirely is now small — on the order of **~0.2s per write** (measured). 

So this is **not** a current performance win. It is a clean, low-risk **opt-out switch** for a possible future where anchoring/embedding load is decoupled from the write path (e.g. a deployment that runs anchoring purely as a scheduled batch). It introduces no schema changes, no migration, and no behavior change when unset.

## Test plan

- [x] Rebased onto current main (incl. #362); both changes coexist.
- [x] Default (`MX_SKIP_WRITE_ANCHOR` unset): all 6 write paths still call `auto_anchor`.
- [x] Opt-out (`=1` / `=true`): write-path anchoring skipped; entry still persists (verified across fresh process + real-store reopen).
- [x] Explicit `mx memory auto-anchor` still anchors with the flag set (ungated; anchored deferred writes in a live run).
- [x] `cargo build`, `cargo test --bin mx` (1104 passed, 0 failed), `cargo clippy --all-targets` (clean), `cargo fmt --check` — all green.
