### PR TITLE
perf(auto_anchor): DB-side candidate fetch, drop full-graph Rust scan

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -314,33 +314,53 @@ pub(crate) fn auto_anchor(
 
     let entry_embedding = entry.embedding.as_ref().unwrap();
 
-    // Get all entries with embeddings for similarity comparison
-    let all_candidates = db.list_all(&ctx)?;
-    let candidates: Vec<_> = all_candidates
-        .into_iter()
-        .filter(|e| e.embedding.is_some())
-        .collect();
-
-    // Calculate similarities
     let threshold = DEFAULT_ANCHOR_THRESHOLD;
     let max_anchors = 5;
-    let mut similarities: Vec<(String, f32)> = Vec::new();
-    let mut stale_anchors: Vec<String> = Vec::new();
 
-    for candidate in &candidates {
+    // ---- Candidate fetch (Issue #362) -----------------------------------
+    //
+    // Previously this hydrated the ENTIRE graph (`db.list_all`) and ran a Rust
+    // cosine loop over every embedded entry on every write — O(n) in the
+    // application layer, the dominant cost of a save (~15.6s of ~16s).
+    //
+    // Instead we ask the DB for the top-K most similar entries by cosine score,
+    // scored against this entry's own embedding (entry-level mean vector only —
+    // see `semantic_search_entries_scored`, which deliberately ignores
+    // chunk-level matching so anchoring keeps strict entry-level-mean semantics
+    // and selects the SAME anchors the old full scan would have). The band
+    // filter, privacy filter, self-exclusion and max_anchors cap below are
+    // applied unchanged — only the candidate SOURCE moved from full-scan to
+    // bounded DB query.
+    //
+    // Over-fetch factor: the band is [0.75, 0.95]. The top-K-by-score query
+    // returns the highest scores first, so the slots ahead of an in-band
+    // candidate can be consumed by: self (~1.0), near-duplicates (>0.95),
+    // existing anchors (re-handled separately below), and explicitly-removed
+    // anchors. Over-fetching 5x max_anchors (25) leaves ample headroom for that
+    // handful of high-scoring rejects before we run out of in-band candidates.
+    // Tradeoff: if a graph had MORE than (K - max_anchors) entries scoring
+    // above an in-band member (e.g. >20 near-duplicates of this entry), a band
+    // member ranked below K could be missed. At anchor scale (max 5) this is
+    // not a realistic configuration; the cap means we only ever keep the top
+    // max_anchors in-band anyway, so the highest-scoring band members — the
+    // ones we'd keep — are exactly the ones K surfaces first.
+    let candidate_fetch_k = max_anchors * 5;
+    let scored_candidates =
+        db.semantic_search_entries_scored(entry_embedding, &ctx, candidate_fetch_k)?;
+
+    let mut similarities: Vec<(String, f32)> = Vec::new();
+
+    for (candidate, similarity) in &scored_candidates {
         // Skip self
         if candidate.id == entry.id {
             continue;
         }
 
-        // Re-evaluate existing anchors for staleness
+        // Existing anchors are NOT considered as new candidates here. Their
+        // staleness is re-evaluated separately below (by-ID recompute) so we
+        // never depend on them appearing in the bounded top-K query.
         if entry.anchors.contains(&candidate.id) {
-            let candidate_embedding = candidate.embedding.as_ref().unwrap();
-            let similarity = cosine_similarity(entry_embedding, candidate_embedding);
-            if similarity < threshold || similarity > NEAR_DUPLICATE_CEILING {
-                stale_anchors.push(candidate.id.clone());
-            }
-            continue; // don't consider existing anchors as new candidates
+            continue;
         }
 
         // Skip anchors that the user explicitly removed via --anchors replacement.
@@ -371,13 +391,44 @@ pub(crate) fn auto_anchor(
             continue;
         }
 
-        // Calculate cosine similarity
-        let candidate_embedding = candidate.embedding.as_ref().unwrap();
-        let similarity = cosine_similarity(entry_embedding, candidate_embedding);
+        // Filter by threshold, skip near-duplicates. The score is the same cosine
+        // value the old Rust loop computed; we use the DB-computed score directly.
+        if *similarity >= threshold && *similarity <= NEAR_DUPLICATE_CEILING {
+            similarities.push((candidate.id.clone(), *similarity));
+        }
+    }
 
-        // Filter by threshold, skip near-duplicates
-        if similarity >= threshold && similarity <= NEAR_DUPLICATE_CEILING {
-            similarities.push((candidate.id.clone(), similarity));
+    // ---- #199 stale-anchor pruning --------------------------------------
+    //
+    // Re-evaluate EXISTING anchors and prune any that have dropped out of the
+    // band on the current embeddings. Existing anchors won't necessarily appear
+    // in the bounded top-K similarity query (they may now score below K, which
+    // is precisely why they're stale), so we fetch each existing anchor's
+    // embedding BY ID — a bounded handful — and recompute similarity directly
+    // with `cosine_similarity`, exactly as the old full-scan path did. This
+    // preserves #199 behavior with no dependency on the top-K candidate set.
+    let mut stale_anchors: Vec<String> = Vec::new();
+    for anchor_id in &entry.anchors {
+        // Skip a degenerate self-anchor: never treat the entry's own id as stale
+        // here (matches the old loop, which `continue`d on self before staleness).
+        if *anchor_id == entry.id {
+            continue;
+        }
+        let anchor_entry = match db.get(anchor_id, &ctx)? {
+            Some(e) => e,
+            // Anchor target no longer visible/exists: leave the existing
+            // behavior untouched (old code only saw it if list_all returned it;
+            // if it didn't, it wasn't pruned). Don't prune on absence.
+            None => continue,
+        };
+        let Some(anchor_embedding) = anchor_entry.embedding.as_ref() else {
+            // No embedding to compare against — old loop filtered these out of
+            // `candidates`, so it never marked them stale. Preserve that.
+            continue;
+        };
+        let similarity = cosine_similarity(entry_embedding, anchor_embedding);
+        if similarity < threshold || similarity > NEAR_DUPLICATE_CEILING {
+            stale_anchors.push(anchor_id.clone());
         }
     }
 
@@ -425,4 +476,482 @@ pub(crate) fn auto_anchor(
 pub(crate) fn open_surreal(config: &IndexConfig, verbose: bool) -> Result<SurrealDatabase> {
     let surreal_path = config.db_path.with_extension("surreal");
     SurrealDatabase::open_with_verbose(surreal_path, verbose)
+}
+
+#[cfg(test)]
+mod auto_anchor_tests {
+    //! Tests for `auto_anchor` after the Issue #362 rewrite (DB-side bounded
+    //! candidate fetch replacing `list_all` + full-graph Rust cosine loop).
+    //!
+    //! The headline guarantee these tests defend: anchoring CORRECTNESS is
+    //! unchanged — the band filter, privacy filter, self-exclusion, max_anchors
+    //! cap and #199 stale-anchor pruning all behave exactly as the old full
+    //! scan did; only the candidate SOURCE moved to the bounded DB query.
+    //!
+    //! Env-var sensitive (`MX_CURRENT_AGENT` drives the agent context), so these
+    //! are `#[serial]` and reset the var deterministically.
+
+    use super::*;
+    use crate::knowledge::KnowledgeEntry;
+    use crate::store::{AgentContext, KnowledgeStore};
+    use serial_test::serial;
+
+    /// A unit vector whose cosine similarity with the reference query vector
+    /// `unit_query()` is exactly `cos` (within f32 precision). Built as
+    /// `[cos, sin, 0, 0]`, which is unit-length, so cosine == dot product == cos.
+    fn unit_vec(cos: f32) -> Vec<f32> {
+        let sin = (1.0 - cos * cos).max(0.0).sqrt();
+        vec![cos, sin, 0.0, 0.0]
+    }
+
+    /// The reference/query direction: `[1, 0, 0, 0]`.
+    fn unit_query() -> Vec<f32> {
+        vec![1.0, 0.0, 0.0, 0.0]
+    }
+
+    fn entry_with_embedding(
+        id: &str,
+        embedding: Vec<f32>,
+        visibility: &str,
+        owner: Option<&str>,
+        anchors: Vec<String>,
+    ) -> KnowledgeEntry {
+        let now = chrono::Utc::now().to_rfc3339();
+        KnowledgeEntry {
+            id: id.to_string(),
+            category_id: "test".to_string(),
+            title: format!("Entry {id}"),
+            body: Some("body".to_string()),
+            summary: None,
+            applicability: vec![],
+            source_project_id: None,
+            source_agent_id: None,
+            file_path: None,
+            tags: vec![],
+            created_at: Some(now.clone()),
+            updated_at: Some(now.clone()),
+            content_hash: Some(format!("hash-{id}")),
+            source_type_id: Some("manual".to_string()),
+            entry_type_id: Some("primary".to_string()),
+            session_id: None,
+            ephemeral: false,
+            content_type_id: Some("text".to_string()),
+            owner: owner.map(|o| o.to_string()),
+            visibility: visibility.to_string(),
+            resonance: 5,
+            resonance_type: Some("ephemeral".to_string()),
+            last_activated: Some(now),
+            activation_count: 0,
+            decay_rate: 0.0,
+            anchors,
+            wake_phrases: vec![],
+            triggers: vec![],
+            wake_order: None,
+            wake_phrase: None,
+            embedding: Some(embedding),
+            embedding_model: Some("test-model".to_string()),
+            embedded_at: Some(chrono::Utc::now().to_rfc3339()),
+            chunk_count: 0,
+            format: "markdown".to_string(),
+            effective_resonance: None,
+        }
+    }
+
+    /// Clear `MX_CURRENT_AGENT` so `auto_anchor` uses `public_only` context.
+    /// SAFETY: process-wide env mutation, serialized via `#[serial]`.
+    fn clear_agent_env() {
+        unsafe {
+            std::env::remove_var("MX_CURRENT_AGENT");
+        }
+    }
+
+    /// Reference implementation of the OLD candidate selection: full scan over
+    /// every embedded entry, the band + privacy + self filters, sort-by-score,
+    /// take max_anchors. Returns the set of NEW anchor ids the old code would
+    /// have added (NOT including stale pruning — tested separately). Used to
+    /// prove the rewrite picks the same anchors.
+    fn reference_old_anchors(
+        target: &KnowledgeEntry,
+        all: &[KnowledgeEntry],
+        max_anchors: usize,
+    ) -> Vec<String> {
+        let threshold = DEFAULT_ANCHOR_THRESHOLD;
+        let target_emb = target.embedding.as_ref().unwrap();
+        let mut sims: Vec<(String, f32)> = Vec::new();
+        for cand in all {
+            if cand.id == target.id {
+                continue;
+            }
+            if target.anchors.contains(&cand.id) {
+                continue;
+            }
+            let Some(cand_emb) = cand.embedding.as_ref() else {
+                continue;
+            };
+            let can_anchor = if target.visibility == "private" {
+                cand.visibility == "public"
+                    || (cand.visibility == "private" && cand.owner == target.owner)
+            } else {
+                cand.visibility == "public"
+            };
+            if !can_anchor {
+                continue;
+            }
+            let sim = cosine_similarity(target_emb, cand_emb);
+            if sim >= threshold && sim <= NEAR_DUPLICATE_CEILING {
+                sims.push((cand.id.clone(), sim));
+            }
+        }
+        sims.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let mut ids: Vec<String> = sims
+            .into_iter()
+            .take(max_anchors)
+            .map(|(id, _)| id)
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    fn anchors_of(db: &dyn KnowledgeStore, id: &str) -> Vec<String> {
+        let ctx = AgentContext::public_only();
+        let mut a = db.get(id, &ctx).unwrap().unwrap().anchors;
+        a.sort();
+        a
+    }
+
+    #[test]
+    #[serial]
+    fn auto_anchor_picks_same_anchors_as_old_full_scan() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        // Seed a small graph spanning the whole similarity range relative to the
+        // target's [1,0,0,0] direction.
+        let target = entry_with_embedding("kn-target", unit_query(), "public", None, vec![]);
+        let graph = vec![
+            target.clone(),
+            entry_with_embedding("kn-a", unit_vec(0.90), "public", None, vec![]), // in band
+            entry_with_embedding("kn-b", unit_vec(0.85), "public", None, vec![]), // in band
+            entry_with_embedding("kn-c", unit_vec(0.80), "public", None, vec![]), // in band
+            entry_with_embedding("kn-d", unit_vec(0.78), "public", None, vec![]), // in band
+            entry_with_embedding("kn-e", unit_vec(0.76), "public", None, vec![]), // in band (6th -> capped out)
+            entry_with_embedding("kn-dup", unit_vec(0.97), "public", None, vec![]), // > ceiling
+            entry_with_embedding("kn-far", unit_vec(0.60), "public", None, vec![]), // < threshold
+        ];
+        for e in &graph {
+            db.upsert_knowledge(e).unwrap();
+        }
+
+        auto_anchor("kn-target", &db, None).unwrap();
+
+        let got = anchors_of(&db, "kn-target");
+        let expected = reference_old_anchors(&target, &graph, 5);
+
+        assert_eq!(
+            got, expected,
+            "rewrite must select the same anchors as the old full scan"
+        );
+        // Concretely: top 5 in-band by score, dup/far excluded, self excluded.
+        assert_eq!(
+            got,
+            vec![
+                "kn-a".to_string(),
+                "kn-b".to_string(),
+                "kn-c".to_string(),
+                "kn-d".to_string(),
+                "kn-e".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn band_filter_excludes_near_duplicates_and_below_threshold() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        let target = entry_with_embedding("kn-t", unit_query(), "public", None, vec![]);
+        db.upsert_knowledge(&target).unwrap();
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-dup",
+            unit_vec(0.99),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-low",
+            unit_vec(0.50),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-mid",
+            unit_vec(0.85),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+
+        auto_anchor("kn-t", &db, None).unwrap();
+        let got = anchors_of(&db, "kn-t");
+
+        assert_eq!(
+            got,
+            vec!["kn-mid".to_string()],
+            "only the in-band entry is anchored; near-dup (>0.95) and below-threshold (<0.75) excluded"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn max_anchors_cap_respected() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        let target = entry_with_embedding("kn-t", unit_query(), "public", None, vec![]);
+        db.upsert_knowledge(&target).unwrap();
+        // Seven in-band candidates with distinct, descending scores.
+        let scores = [0.94, 0.92, 0.90, 0.88, 0.86, 0.84, 0.82];
+        for (i, s) in scores.iter().enumerate() {
+            db.upsert_knowledge(&entry_with_embedding(
+                &format!("kn-c{i}"),
+                unit_vec(*s),
+                "public",
+                None,
+                vec![],
+            ))
+            .unwrap();
+        }
+
+        auto_anchor("kn-t", &db, None).unwrap();
+        let got = anchors_of(&db, "kn-t");
+
+        assert_eq!(got.len(), 5, "cap at max_anchors = 5");
+        // The 5 highest-scoring band members.
+        assert_eq!(
+            got,
+            vec![
+                "kn-c0".to_string(),
+                "kn-c1".to_string(),
+                "kn-c2".to_string(),
+                "kn-c3".to_string(),
+                "kn-c4".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn stale_anchor_pruned_via_by_id_recompute() {
+        // #199: an existing anchor that has drifted below threshold must be
+        // pruned even though it won't show up in the top-K similarity query.
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        // Existing anchor "kn-stale" now sits FAR from the target (cos 0.40),
+        // so it is below the 0.75 floor and must be pruned. Crucially we seed
+        // MANY closer entries so kn-stale ranks well below any top-K cutoff —
+        // proving the by-ID recompute (not the top-K query) is what prunes it.
+        let mut target = entry_with_embedding("kn-t", unit_query(), "public", None, vec![]);
+        target.anchors = vec!["kn-stale".to_string(), "kn-keep".to_string()];
+        db.upsert_knowledge(&target).unwrap();
+
+        // kn-keep is still in band -> must survive re-eval.
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-keep",
+            unit_vec(0.88),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+        // kn-stale drifted out of band -> must be pruned.
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-stale",
+            unit_vec(0.40),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+        // A pile of fresh in-band neighbors that crowd the top-K.
+        for i in 0..10 {
+            db.upsert_knowledge(&entry_with_embedding(
+                &format!("kn-n{i}"),
+                unit_vec(0.80 + i as f32 * 0.001),
+                "public",
+                None,
+                vec![],
+            ))
+            .unwrap();
+        }
+
+        auto_anchor("kn-t", &db, None).unwrap();
+        let got = anchors_of(&db, "kn-t");
+
+        assert!(
+            !got.contains(&"kn-stale".to_string()),
+            "stale anchor below threshold must be pruned (by-ID recompute)"
+        );
+        assert!(
+            got.contains(&"kn-keep".to_string()),
+            "in-band existing anchor must be preserved"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn near_duplicate_existing_anchor_is_pruned() {
+        // #199 also prunes existing anchors that drifted ABOVE the near-dup
+        // ceiling (band is closed on both ends).
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        let mut target = entry_with_embedding("kn-t", unit_query(), "public", None, vec![]);
+        target.anchors = vec!["kn-toodup".to_string()];
+        db.upsert_knowledge(&target).unwrap();
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-toodup",
+            unit_vec(0.98),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+
+        auto_anchor("kn-t", &db, None).unwrap();
+        let got = anchors_of(&db, "kn-t");
+        assert!(
+            !got.contains(&"kn-toodup".to_string()),
+            "existing anchor above the near-duplicate ceiling must be pruned"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn self_is_never_anchored() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        let target = entry_with_embedding("kn-solo", unit_query(), "public", None, vec![]);
+        db.upsert_knowledge(&target).unwrap();
+        // A single in-band neighbor so anchoring runs.
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-near",
+            unit_vec(0.85),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+
+        auto_anchor("kn-solo", &db, None).unwrap();
+        let got = anchors_of(&db, "kn-solo");
+        assert!(
+            !got.contains(&"kn-solo".to_string()),
+            "an entry must never anchor to itself (self-similarity ~1.0 excluded)"
+        );
+        assert_eq!(got, vec!["kn-near".to_string()]);
+    }
+
+    #[test]
+    #[serial]
+    fn public_entry_does_not_anchor_to_private() {
+        // Privacy preserved: a public entry must never anchor to a private one.
+        // Under public_only context the DB visibility filter drops the private
+        // row entirely, so it's not even a candidate.
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        let target = entry_with_embedding("kn-pub", unit_query(), "public", None, vec![]);
+        db.upsert_knowledge(&target).unwrap();
+        // Private candidate that WOULD be in-band by score.
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-priv",
+            unit_vec(0.90),
+            "private",
+            Some("agent-x"),
+            vec![],
+        ))
+        .unwrap();
+        // A public in-band candidate so the run produces something.
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-pub2",
+            unit_vec(0.85),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+
+        auto_anchor("kn-pub", &db, None).unwrap();
+        let got = anchors_of(&db, "kn-pub");
+        assert!(
+            !got.contains(&"kn-priv".to_string()),
+            "public entry must not anchor to a private entry"
+        );
+        assert_eq!(got, vec!["kn-pub2".to_string()]);
+    }
+
+    #[test]
+    #[serial]
+    fn explicitly_removed_anchor_not_readded() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        let target = entry_with_embedding("kn-t", unit_query(), "public", None, vec![]);
+        db.upsert_knowledge(&target).unwrap();
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-removed",
+            unit_vec(0.90),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-other",
+            unit_vec(0.85),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+
+        let removed = vec!["kn-removed".to_string()];
+        auto_anchor("kn-t", &db, Some(&removed)).unwrap();
+        let got = anchors_of(&db, "kn-t");
+        assert!(
+            !got.contains(&"kn-removed".to_string()),
+            "auto_anchor must not re-add an explicitly removed anchor"
+        );
+        assert_eq!(got, vec!["kn-other".to_string()]);
+    }
+
+    #[test]
+    #[serial]
+    fn no_embedding_skips_anchoring() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        // Build a target with NO embedding (simulates the opt-out / un-embedded
+        // path: auto_anchor returns early and never fetches candidates).
+        let mut target = entry_with_embedding("kn-noemb", unit_query(), "public", None, vec![]);
+        target.embedding = None;
+        db.upsert_knowledge(&target).unwrap();
+        db.upsert_knowledge(&entry_with_embedding(
+            "kn-x",
+            unit_vec(0.90),
+            "public",
+            None,
+            vec![],
+        ))
+        .unwrap();
+
+        auto_anchor("kn-noemb", &db, None).unwrap();
+        let got = anchors_of(&db, "kn-noemb");
+        assert!(got.is_empty(), "no embedding -> no anchoring");
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -176,6 +176,22 @@ pub(crate) const NEAR_DUPLICATE_CEILING: f32 = 0.95;
 /// Default minimum similarity for two entries to be considered anchor-worthy.
 pub(crate) const DEFAULT_ANCHOR_THRESHOLD: f32 = 0.75;
 
+/// Over-fetch factor for `auto_anchor`'s bounded candidate query (Issue #362):
+/// we fetch `MAX_ANCHORS * ANCHOR_CANDIDATE_OVERFETCH` rows by score, leaving
+/// headroom for the handful of high-scoring rows that get filtered out (self,
+/// near-duplicates above the ceiling, existing/removed anchors) before we run
+/// out of in-band candidates.
+pub(crate) const ANCHOR_CANDIDATE_OVERFETCH: usize = 5;
+
+/// Escalation cap for `auto_anchor`'s candidate query. When the normal
+/// over-fetch is *saturated* in a way that could truncate genuine in-band
+/// anchors (see the saturation signal at the call site, Issue #362 / PR #366),
+/// we re-query at this much larger bound so the selected anchors provably match
+/// the old exhaustive full-scan behavior. A single re-query at this cap is still
+/// far cheaper than the old per-write full hydrate + Rust cosine loop, and it
+/// only fires in the degenerate near-duplicate-flood case.
+pub(crate) const MAX_ANCHOR_CANDIDATES: usize = 500;
+
 /// Calculate cosine similarity between two vectors
 ///
 /// Returns a value between -1.0 and 1.0 (typically 0.0 to 1.0 for normalized embeddings)
@@ -338,15 +354,43 @@ pub(crate) fn auto_anchor(
     // existing anchors (re-handled separately below), and explicitly-removed
     // anchors. Over-fetching 5x max_anchors (25) leaves ample headroom for that
     // handful of high-scoring rejects before we run out of in-band candidates.
-    // Tradeoff: if a graph had MORE than (K - max_anchors) entries scoring
-    // above an in-band member (e.g. >20 near-duplicates of this entry), a band
-    // member ranked below K could be missed. At anchor scale (max 5) this is
-    // not a realistic configuration; the cap means we only ever keep the top
-    // max_anchors in-band anyway, so the highest-scoring band members — the
-    // ones we'd keep — are exactly the ones K surfaces first.
-    let candidate_fetch_k = max_anchors * 5;
-    let scored_candidates =
+    let candidate_fetch_k = max_anchors * ANCHOR_CANDIDATE_OVERFETCH;
+    let mut scored_candidates =
         db.semantic_search_entries_scored(entry_embedding, &ctx, candidate_fetch_k)?;
+
+    // ---- Saturation detection + escalation (PR #366, hardening #362) -----
+    //
+    // The bounded top-K fetch diverges from the old exhaustive scan in EXACTLY
+    // one degenerate case: if MORE than (K - max_anchors) rows score above an
+    // in-band member (e.g. >20 near-identical copies above the 0.95 ceiling),
+    // a legitimate in-band anchor could rank below K and be silently dropped —
+    // a behavior change vs. the old full scan.
+    //
+    // We detect this with an EXACT signal. We are only at risk of having
+    // truncated in-band rows when BOTH hold:
+    //   1. the result is K-saturated (`len == candidate_fetch_k`), i.e. the DB
+    //      had at least K candidates and the query hit its bound; AND
+    //   2. the lowest-scoring returned candidate still scores at/above the band
+    //      floor (>= threshold) — so scores had NOT yet dropped below 0.75 when
+    //      the bound cut us off, meaning additional in-band rows may exist past K.
+    //
+    // This is exact: if the lowest returned score is already below the floor,
+    // every row beyond K scores even lower (results are score-descending) and is
+    // therefore out-of-band — nothing the old scan would have kept was missed.
+    // Likewise, if the result is not saturated, the DB returned every candidate
+    // it had, identical to the full scan's candidate universe.
+    //
+    // On the saturated signal we ESCALATE: re-query at MAX_ANCHOR_CANDIDATES and
+    // proceed with that fuller set. This stays entirely on the bounded DB path
+    // (no per-write full hydrate) and only triggers in the degenerate flood.
+    let saturated = scored_candidates.len() == candidate_fetch_k
+        && scored_candidates
+            .last()
+            .is_some_and(|(_, score)| *score >= threshold);
+    if saturated {
+        scored_candidates =
+            db.semantic_search_entries_scored(entry_embedding, &ctx, MAX_ANCHOR_CANDIDATES)?;
+    }
 
     let mut similarities: Vec<(String, f32)> = Vec::new();
 
@@ -953,5 +997,173 @@ mod auto_anchor_tests {
         auto_anchor("kn-noemb", &db, None).unwrap();
         let got = anchors_of(&db, "kn-noemb");
         assert!(got.is_empty(), "no embedding -> no anchoring");
+    }
+
+    /// PR #366 hardening: the degenerate near-duplicate-flood case. When MORE
+    /// than (K - max_anchors) entries score above the band ceiling, the initial
+    /// bounded top-K (= max_anchors * ANCHOR_CANDIDATE_OVERFETCH = 25) is filled
+    /// almost entirely by out-of-band near-duplicates, pushing genuine in-band
+    /// anchors past slot K. Without escalation those in-band anchors would be
+    /// silently dropped vs. the old exhaustive scan. With saturation detection +
+    /// escalation to MAX_ANCHOR_CANDIDATES, auto_anchor must still select exactly
+    /// the in-band anchors the full-scan reference impl would.
+    #[test]
+    #[serial]
+    fn escalates_when_saturated_by_near_duplicate_flood() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        // Sanity: the over-fetch K used by auto_anchor.
+        let max_anchors = 5usize;
+        let k = max_anchors * ANCHOR_CANDIDATE_OVERFETCH; // 25
+
+        let target = entry_with_embedding("kn-target", unit_query(), "public", None, vec![]);
+        let mut graph = vec![target.clone()];
+
+        // Flood: K-1 (24) near-duplicates ABOVE the 0.95 ceiling. They are NOT
+        // anchorable (band-excluded), but they crowd the score-descending top-K,
+        // leaving only a single slot for an in-band member in the initial fetch.
+        let flood = k - 1; // 24 > (K - max_anchors) = 20
+        for i in 0..flood {
+            // Distinct scores in (0.95, 1.0) so ordering is deterministic and
+            // every one sits strictly above the ceiling.
+            let cos = 0.999 - (i as f32) * 0.0005;
+            graph.push(entry_with_embedding(
+                &format!("kn-dup{i:02}"),
+                unit_vec(cos),
+                "public",
+                None,
+                vec![],
+            ));
+        }
+
+        // Genuine in-band anchors, all scoring BELOW every duplicate (so they
+        // rank past slot K and would be truncated without escalation), but well
+        // inside the [0.75, 0.95] band and within MAX_ANCHOR_CANDIDATES.
+        let in_band = [
+            ("kn-real-a", 0.90f32),
+            ("kn-real-b", 0.87),
+            ("kn-real-c", 0.84),
+            ("kn-real-d", 0.81),
+            ("kn-real-e", 0.78),
+        ];
+        for (id, cos) in in_band {
+            graph.push(entry_with_embedding(
+                id,
+                unit_vec(cos),
+                "public",
+                None,
+                vec![],
+            ));
+        }
+
+        for e in &graph {
+            db.upsert_knowledge(e).unwrap();
+        }
+
+        // Confirm the precondition: the INITIAL bounded fetch is saturated AND
+        // its lowest returned score is still at/above the floor — i.e. it would
+        // have truncated in-band rows without escalation.
+        let ctx = AgentContext::public_only();
+        let initial = db
+            .semantic_search_entries_scored(target.embedding.as_ref().unwrap(), &ctx, k)
+            .unwrap();
+        assert_eq!(initial.len(), k, "initial fetch must be K-saturated");
+        assert!(
+            initial.last().unwrap().1 >= DEFAULT_ANCHOR_THRESHOLD,
+            "lowest returned score must still be >= floor (saturation signal fires)"
+        );
+
+        auto_anchor("kn-target", &db, None).unwrap();
+
+        let got = anchors_of(&db, "kn-target");
+        let expected = reference_old_anchors(&target, &graph, max_anchors);
+
+        // Escalation must recover the full in-band set, matching the exhaustive
+        // reference exactly.
+        assert_eq!(
+            got, expected,
+            "escalation must select the same in-band anchors as the old full scan"
+        );
+        assert_eq!(
+            got,
+            vec![
+                "kn-real-a".to_string(),
+                "kn-real-b".to_string(),
+                "kn-real-c".to_string(),
+                "kn-real-d".to_string(),
+                "kn-real-e".to_string(),
+            ],
+            "all five genuine in-band anchors recovered despite the near-duplicate flood"
+        );
+    }
+
+    /// PR #366: the saturation signal is EXACT — escalation must NOT fire when
+    /// the bounded fetch is full but its lowest returned score is already below
+    /// the band floor. In that case every row beyond K is out-of-band, so the
+    /// top-K already contains every anchor-worthy candidate; re-querying would be
+    /// wasted work and a perf regression in a common shape (many low-similarity
+    /// neighbors). We assert correctness is preserved without relying on the
+    /// escalation path.
+    #[test]
+    #[serial]
+    fn does_not_escalate_when_lowest_score_below_floor() {
+        clear_agent_env();
+        let db = SurrealDatabase::open_in_memory().unwrap();
+
+        let max_anchors = 5usize;
+        let k = max_anchors * ANCHOR_CANDIDATE_OVERFETCH; // 25
+
+        let target = entry_with_embedding("kn-target", unit_query(), "public", None, vec![]);
+        let mut graph = vec![target.clone()];
+
+        // A few in-band anchors at the top...
+        let in_band = [("kn-a", 0.90f32), ("kn-b", 0.85), ("kn-c", 0.80)];
+        for (id, cos) in in_band {
+            graph.push(entry_with_embedding(
+                id,
+                unit_vec(cos),
+                "public",
+                None,
+                vec![],
+            ));
+        }
+        // ...then MANY below-floor neighbors so the fetch is K-saturated but its
+        // tail has already dropped under 0.75. (K + a margin of below-floor rows.)
+        for i in 0..(k + 10) {
+            let cos = 0.70 - (i as f32) * 0.001; // all strictly below 0.75 floor
+            graph.push(entry_with_embedding(
+                &format!("kn-lo{i:02}"),
+                unit_vec(cos),
+                "public",
+                None,
+                vec![],
+            ));
+        }
+
+        for e in &graph {
+            db.upsert_knowledge(e).unwrap();
+        }
+
+        // Precondition: K-saturated, but lowest returned score is BELOW the floor
+        // -> the exact signal says "no truncation possible", escalation suppressed.
+        let ctx = AgentContext::public_only();
+        let initial = db
+            .semantic_search_entries_scored(target.embedding.as_ref().unwrap(), &ctx, k)
+            .unwrap();
+        assert_eq!(initial.len(), k, "fetch is K-saturated");
+        assert!(
+            initial.last().unwrap().1 < DEFAULT_ANCHOR_THRESHOLD,
+            "lowest returned score is below floor -> escalation must NOT fire"
+        );
+
+        auto_anchor("kn-target", &db, None).unwrap();
+
+        let got = anchors_of(&db, "kn-target");
+        assert_eq!(
+            got,
+            vec!["kn-a".to_string(), "kn-b".to_string(), "kn-c".to_string()],
+            "the three in-band anchors are selected from the initial top-K (no escalation needed)"
+        );
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -133,6 +133,31 @@ pub trait KnowledgeStore {
         limit: usize,
     ) -> Result<Vec<KnowledgeEntry>>;
 
+    /// Scored variant of [`semantic_search`](Self::semantic_search): same ranking
+    /// and filtering, but returns `(entry, score)` pairs so callers that need the
+    /// cosine similarity (e.g. `auto_anchor`, Issue #362) don't have to recompute
+    /// it. The plain `semantic_search` is just this with the score dropped.
+    fn semantic_search_scored(
+        &self,
+        query_embedding: &[f32],
+        ctx: &AgentContext,
+        filter: &KnowledgeFilter,
+        limit: usize,
+    ) -> Result<Vec<(KnowledgeEntry, f32)>>;
+
+    /// Entry-level-only scored vector search (Issue #362). Scores against the
+    /// mean-pooled `embedding` on the knowledge row ONLY (no chunk-level
+    /// matching), bounded to the top `limit` by score. Used by `auto_anchor` to
+    /// fetch candidates while preserving strict entry-level-mean semantics —
+    /// the same vectors the old `list_all` + Rust cosine loop compared against,
+    /// only now scored DB-side and bounded.
+    fn semantic_search_entries_scored(
+        &self,
+        query_embedding: &[f32],
+        ctx: &AgentContext,
+        limit: usize,
+    ) -> Result<Vec<(KnowledgeEntry, f32)>>;
+
     /// List entries by category
     fn list_by_category(
         &self,

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -848,7 +848,12 @@ impl SurrealDatabase {
         Ok(entries)
     }
 
-    /// Semantic search using vector similarity (brute force cosine)
+    /// Semantic search using vector similarity (brute force cosine).
+    ///
+    /// Public entry point used by `mx memory search`. Returns entries ordered by
+    /// descending similarity, with scores discarded. Behavior is unchanged: this
+    /// now delegates to [`semantic_search_knowledge_scored`] and drops the score,
+    /// so callers see byte-identical results.
     pub fn semantic_search_knowledge(
         &self,
         query_embedding: &[f32],
@@ -856,6 +861,29 @@ impl SurrealDatabase {
         filter: &crate::store::KnowledgeFilter,
         limit: usize,
     ) -> Result<Vec<KnowledgeEntry>> {
+        Ok(self
+            .semantic_search_knowledge_scored(query_embedding, ctx, filter, limit)?
+            .into_iter()
+            .map(|(entry, _score)| entry)
+            .collect())
+    }
+
+    /// Scored variant of [`semantic_search_knowledge`]: returns `(entry, score)`
+    /// pairs ordered by descending cosine similarity. This is the shared core
+    /// that the public, score-discarding method delegates to — exposing the
+    /// `score` that the SQL already computes (Issue #362) without changing the
+    /// public search contract.
+    ///
+    /// Like the public method, this matches at both the entry level (mean-pooled
+    /// `embedding`) and the chunk level (`embedding_chunk`), deduplicating to one
+    /// row per entry by taking the max score (Issue #346).
+    pub fn semantic_search_knowledge_scored(
+        &self,
+        query_embedding: &[f32],
+        ctx: &crate::store::AgentContext,
+        filter: &crate::store::KnowledgeFilter,
+        limit: usize,
+    ) -> Result<Vec<(KnowledgeEntry, f32)>> {
         Self::runtime().block_on(self.semantic_search_knowledge_async(
             query_embedding,
             ctx,
@@ -870,7 +898,7 @@ impl SurrealDatabase {
         ctx: &crate::store::AgentContext,
         filter: &crate::store::KnowledgeFilter,
         limit: usize,
-    ) -> Result<Vec<KnowledgeEntry>> {
+    ) -> Result<Vec<(KnowledgeEntry, f32)>> {
         let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
         let resonance_clause = Self::build_resonance_filter(filter);
         let category_clause = Self::build_category_filter(filter);
@@ -991,7 +1019,87 @@ impl SurrealDatabase {
         sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
         sorted.truncate(limit);
 
-        Ok(sorted.into_iter().map(|(_, entry)| entry).collect())
+        Ok(sorted
+            .into_iter()
+            .map(|(score, entry)| (entry, score))
+            .collect())
+    }
+
+    /// Entry-level scored vector search used by `auto_anchor` (Issue #362).
+    ///
+    /// Unlike [`semantic_search_knowledge_scored`], this scores ONLY against the
+    /// entry-level (mean-pooled) `embedding` column on the `knowledge` table and
+    /// does NOT consult `embedding_chunk`. It also imposes no `chunk_count`
+    /// restriction, so long (chunked) entries are scored on their mean vector
+    /// just like short ones.
+    ///
+    /// This exactly mirrors what the old `auto_anchor` did when it called
+    /// `list_all` and ran `cosine_similarity(entry.embedding, candidate.embedding)`
+    /// over every row — only now the cosine work runs DB-side and is bounded to
+    /// the top `limit` rows by score, instead of hydrating the whole graph and
+    /// looping in Rust. Anchoring therefore keeps strict entry-level-mean
+    /// semantics (no chunk-level matching leaks into anchor selection).
+    ///
+    /// Returns `(entry, score)` pairs ordered by descending cosine similarity.
+    pub fn semantic_search_entries_scored(
+        &self,
+        query_embedding: &[f32],
+        ctx: &crate::store::AgentContext,
+        limit: usize,
+    ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+        Self::runtime().block_on(self.semantic_search_entries_scored_async(
+            query_embedding,
+            ctx,
+            limit,
+        ))
+    }
+
+    async fn semantic_search_entries_scored_async(
+        &self,
+        query_embedding: &[f32],
+        ctx: &crate::store::AgentContext,
+        limit: usize,
+    ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+        let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
+
+        // Single-phase: score every embedded knowledge row on its entry-level
+        // vector, bounded to the top `limit` by score. Params are bound, never
+        // interpolated.
+        let sql = format!(
+            "SELECT {}, vector::similarity::cosine(embedding, $query_vec) AS score
+            FROM knowledge
+            WHERE embedding IS NOT NONE {}
+            ORDER BY score DESC
+            LIMIT $limit",
+            Self::knowledge_select_fields(),
+            visibility_clause,
+        );
+
+        let mut response = with_db!(self, db, {
+            let mut query_builder = db
+                .query(&sql)
+                .bind(("query_vec", query_embedding.to_vec()))
+                .bind(("limit", limit));
+            if let Some(agent) = current_agent.clone() {
+                query_builder = query_builder.bind(("current_agent", agent));
+            }
+            query_builder
+                .await
+                .context("Failed to execute entry-level scored search query")
+        })?;
+
+        let results: Vec<serde_json::Value> = response
+            .take(0)
+            .context("Failed to parse entry-level scored search results")?;
+
+        let mut scored = Vec::with_capacity(results.len());
+        for obj in results {
+            let score = obj["score"].as_f64().unwrap_or(0.0) as f32;
+            let entry = self.value_to_knowledge_entry(obj).await?;
+            scored.push((entry, score));
+        }
+
+        Ok(scored)
     }
 
     /// Helper: Convert SurrealDB query result to KnowledgeEntry

--- a/src/surreal_db/trait_impl.rs
+++ b/src/surreal_db/trait_impl.rs
@@ -46,6 +46,25 @@ impl KnowledgeStore for SurrealDatabase {
         self.semantic_search_knowledge(query_embedding, ctx, filter, limit)
     }
 
+    fn semantic_search_scored(
+        &self,
+        query_embedding: &[f32],
+        ctx: &crate::store::AgentContext,
+        filter: &crate::store::KnowledgeFilter,
+        limit: usize,
+    ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+        self.semantic_search_knowledge_scored(query_embedding, ctx, filter, limit)
+    }
+
+    fn semantic_search_entries_scored(
+        &self,
+        query_embedding: &[f32],
+        ctx: &crate::store::AgentContext,
+        limit: usize,
+    ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+        self.semantic_search_entries_scored(query_embedding, ctx, limit)
+    }
+
     fn list_by_category(
         &self,
         category: &str,

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1360,6 +1360,23 @@ mod tests {
             ) -> Result<Vec<KnowledgeEntry>> {
                 unreachable!()
             }
+            fn semantic_search_scored(
+                &self,
+                _emb: &[f32],
+                _ctx: &AgentContext,
+                _f: &KnowledgeFilter,
+                _l: usize,
+            ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+                unreachable!()
+            }
+            fn semantic_search_entries_scored(
+                &self,
+                _emb: &[f32],
+                _ctx: &AgentContext,
+                _l: usize,
+            ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+                unreachable!()
+            }
             fn list_by_category(
                 &self,
                 _c: &str,


### PR DESCRIPTION
Closes #362

## Problem

`auto_anchor` (`src/helpers.rs`) ran on every memory write (add/update/edit/append/prepend/restore) and hydrated the **entire** graph via `list_all`, then looped `cosine_similarity` in mx Rust over every embedded entry — O(n) in the application layer. Measured ~15.6s of a ~16s save was this loop.

## Change

Swap the `list_all` + full-graph Rust cosine loop for a **bounded DB-side scored vector search**. The cosine work moves to the DB and is capped at the top-K most similar rows instead of every row hydrated into Rust.

### Scored-variant addition (Req 1 — public search unchanged)
- New `SurrealDatabase::semantic_search_knowledge_scored(...) -> Vec<(KnowledgeEntry, f32)>` is now the shared core. The public `semantic_search_knowledge` delegates to it and drops the score, so `mx memory search` behavior is **byte-identical** (it already computed `score` and discarded it at the tail — we just stopped throwing it away).
- New `semantic_search_entries_scored(...)` does a single-phase, **entry-level-only** scored query (`vector::similarity::cosine(embedding,$q) AS score FROM knowledge WHERE embedding IS NOT NONE <visibility> ORDER BY score DESC LIMIT $k`). All params bound, no interpolation.
- Both exposed on the `KnowledgeStore` trait (`semantic_search_scored`, `semantic_search_entries_scored`) so `auto_anchor` can reach them through the `&dyn` store. `SurrealDatabase` impl wired; the `MockStore` in `wake_ritual.rs` gets `unreachable!()` stubs.

### auto_anchor candidate fetch (Req 2)
- Calls `semantic_search_entries_scored(entry.embedding, ctx, K)` with **K = max_anchors * 5 (25)** — over-fetch headroom so that after dropping self (~1.0), near-duplicates (>0.95), existing anchors, and explicitly-removed ids, ≥ max_anchors in-band candidates remain. Tradeoff documented inline: only fails if >20 entries out-score an in-band member (not realistic at anchor scale; the cap keeps only the top max_anchors in-band anyway, which K surfaces first).
- The **existing semantics are applied unchanged** on that bounded set: `[0.75, 0.95]` band filter, privacy/visibility filter, self-exclusion, max_anchors=5 cap. The score used is the DB-computed cosine (same value the old Rust loop produced).

### #199 stale-anchor pruning preserved (Req 2)
- Existing anchors are **not** assumed to appear in the top-K query (a stale anchor scores low — that's why it's stale). Instead each existing anchor's entry is fetched **by ID** (a bounded handful), and its similarity is recomputed directly with `cosine_similarity`, exactly as the old full scan did. Out-of-band (below 0.75 or above 0.95) → pruned. Visibility/absence handling matches the old `list_all`-gated behavior (a non-visible/missing anchor is not pruned, just as before).

### #346 interaction (Req 3) — deliberate decision
- `semantic_search_knowledge` (the public search) matches at chunk level and dedups by entry. For **anchoring** I deliberately scoped the candidate query to **entry-level vectors only** (`semantic_search_entries_scored`, which ignores `embedding_chunk` and imposes no `chunk_count` restriction). This **preserves strict entry-level-mean semantics** — the exact vectors the old `list_all` loop compared against — so anchoring picks the same anchors for long/chunked entries too, with **no chunk-level matching leaking into anchor selection**. Judged safer than introducing a behavior change to the anchor core; the public search path is untouched and still does chunk-level matching.

### Opt-out (Req 4)
- The #199 `--no-auto-anchor` gate lives in the callers (`if !no_auto_anchor { auto_anchor(...) }`), so when disabled `auto_anchor` never runs and none of this executes. Unchanged.

## Tests (`src/helpers.rs`, `auto_anchor_tests`, all `#[serial]`, `open_in_memory`)
- **same-anchors-as-before**: seeds a small graph, runs a local reference implementation of the OLD full-scan selection, asserts the new `auto_anchor` produces the identical anchor set.
- **band**: near-duplicate (>0.95) not anchored; below-threshold (<0.75) not anchored; in-band anchored.
- **max_anchors cap**: 7 in-band candidates → top 5 by score.
- **#199 stale pruning via by-ID recompute**: a drifted existing anchor is pruned even when crowded out of the top-K by fresh neighbors; an in-band existing anchor survives. Plus a near-duplicate existing anchor (>0.95) is pruned.
- **privacy / self-exclusion**: public entry never anchors to a private one; an entry never anchors to itself.
- **explicitly-removed not re-added**; **no-embedding → no anchoring** (early return, matching the disabled path).
- No remaining `list_all` call in `auto_anchor` (only mentioned in explanatory comments).

## Perf framing
Removes the application-layer O(n) hydrate + Rust cosine loop — the dominant cost. The residual DB-side cosine is still O(n) (brute force by design at this scale per #361, no vector index yet), but bounded to a top-K projection rather than full-graph hydration into Rust. Expect a large drop on large graphs; validated against the correctness suite rather than a fixed time target.

cargo build + `cargo test --bin mx` (1096 passed) + clippy (clean) + fmt all green.