### PR TITLE
fix(schema): cold-upgrade backfill for triggers/chunk_count on populated graphs

### DIFF
--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -112,16 +112,29 @@ DEFINE FIELD IF NOT EXISTS entry_type ON knowledge TYPE record<entry_type>;
 DEFINE FIELD IF NOT EXISTS content_type ON knowledge TYPE record<content_type> DEFAULT content_type:text;
 DEFINE FIELD IF NOT EXISTS session ON knowledge TYPE option<record<session>>;
 
--- Resonance fields for wake-up cascade
-DEFINE FIELD IF NOT EXISTS resonance ON knowledge TYPE int DEFAULT 0;
+-- Resonance fields for wake-up cascade.
+-- The `knowledge` table first shipped without these; they were added AFTER rows
+-- already existed (the wake-up cascade / "atomic facts" feature). So on any
+-- graph that predates the cascade, every legacy row holds NONE for resonance,
+-- activation_count, and decay_rate → the SAME cold-upgrade stranding hazard as
+-- triggers/wake_phrases/chunk_count/format (Issue #360). Required + legacy-added
+-- ⇒ loosen → backfill → OVERWRITE-tighten. The read path already coalesces these
+-- (IF resonance THEN resonance ELSE 0 END, etc. in knowledge_select_fields()),
+-- so reads survive — but the next WRITE touching a stranded row aborts
+-- whole-record validation with `Found NONE for field 'activation_count' ...
+-- but expected a int`, taking the all-or-nothing apply_schema down with it.
+-- OVERWRITE (not IF NOT EXISTS): loosen unconditionally so an upgrade from a
+-- prior version where the field was strict actually loosens. Backfilled to their
+-- DEFAULTs (0 / 0 / 0.0) and tightened in the COLD-UPGRADE BACKFILL block below.
+DEFINE FIELD OVERWRITE resonance ON knowledge TYPE option<int>;
 -- Note: 'session' was added to resonance_type allowed values as part of the session resonance
 -- type feature (PR #148), not the tag query feature. It appears here because both changes
 -- landed in the same schema file update.
 DEFINE FIELD IF NOT EXISTS resonance_type ON knowledge TYPE option<string>
   ASSERT $value IN [null, 'foundational', 'transformative', 'relational', 'operational', 'ephemeral', 'session'];
 DEFINE FIELD IF NOT EXISTS last_activated ON knowledge TYPE option<datetime>;
-DEFINE FIELD IF NOT EXISTS activation_count ON knowledge TYPE int DEFAULT 0;
-DEFINE FIELD IF NOT EXISTS decay_rate ON knowledge TYPE float DEFAULT 0.0;
+DEFINE FIELD OVERWRITE activation_count ON knowledge TYPE option<int>;
+DEFINE FIELD OVERWRITE decay_rate ON knowledge TYPE option<float>;
 DEFINE FIELD IF NOT EXISTS anchors ON knowledge TYPE option<array<string>>;
 
 -- Issue #72: Multiple wake phrases for ritual variety.
@@ -453,7 +466,7 @@ UPSERT applicability_type:cli SET description = 'Command-line tools', scope = 'd
 UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 
 -- =============================================================================
--- COLD-UPGRADE BACKFILL (Issues #72, #73, #122, #352, #360)
+-- COLD-UPGRADE BACKFILL (Issues #72, #73, #122, #352, #360 + resonance cascade)
 -- =============================================================================
 --
 -- WHY THIS SECTION EXISTS
@@ -478,7 +491,8 @@ UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 --   * the backfill UPDATE is ITSELF the first write touching legacy rows, and
 --   * a SCHEMAFULL write validates EVERY required field at once — so the very
 --     first backfill UPDATE (historically the wake_phrases migration) aborts
---     because triggers/chunk_count/format are still NONE on that same row.
+--     because triggers/chunk_count/format AND the resonance-cascade ints
+--     (resonance/activation_count/decay_rate) are still NONE on that same row.
 --   * apply_schema sends the whole file through one `db.query` and uses
 --     `take_errors()` (all-or-nothing), so one stranded row fails every connect.
 -- Reported by the hearth federation (Soren/Geoff) on a ~5,283-row graph; the
@@ -495,14 +509,20 @@ UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 --
 -- THE WORKING SEQUENCE (option → backfill → OVERWRITE-tighten):
 --   1. Each required, legacy-added field is LOOSENED to `option<...>` at its
---      site above (triggers, wake_phrases, chunk_count, format) with
---      `DEFINE FIELD OVERWRITE` — OVERWRITE, not IF NOT EXISTS, because on an
---      upgrade the field already exists as the strict type and IF NOT EXISTS
---      would skip, leaving it strict. Loosening lets a write touch the row
---      while the field is still NONE.
+--      site above — the full set is triggers, wake_phrases, chunk_count, format,
+--      resonance, activation_count, decay_rate (every REQUIRED knowledge field
+--      that the read path coalesces in knowledge_select_fields(), i.e. every one
+--      that can be NONE on a legacy row) — with `DEFINE FIELD OVERWRITE`:
+--      OVERWRITE, not IF NOT EXISTS, because on an upgrade the field already
+--      exists as the strict type and IF NOT EXISTS would skip, leaving it
+--      strict. Loosening lets a write touch the row while the field is NONE.
 --   2. Backfill ALL of them here, while every one is still loose. Because all
---      four are option<> at this point, these UPDATEs pass whole-record
+--      seven are option<> at this point, these UPDATEs pass whole-record
 --      validation even though the others have not been set yet on that row.
+--      ORDERING INVARIANT: every strand-hazard field is loosened (step 1, above
+--      the SEED DATA) before ANY write touches a knowledge row — the seed
+--      UPSERTs write only lookup tables, and the first knowledge-row write is
+--      the backfill block here, by which point all seven are loose.
 --   3. THEN tighten each back to its strict type with `DEFINE FIELD OVERWRITE`
 --      (NOT `IF NOT EXISTS`, which would skip). After the backfill no row holds
 --      NONE, so the strict type — enforced on the next write — is satisfied.
@@ -522,12 +542,11 @@ UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 -- `option<>` at its site (OVERWRITE so an upgrade from a strict prior version
 -- actually loosens), then add a `WHERE <field> IS NONE` backfill in THIS block,
 -- then a paired `DEFINE FIELD OVERWRITE ... TYPE <strict> DEFAULT <d>` tighten
--- here. Never
--- leave a field permanently `option<>` just to dodge this — downstream code
--- assumes presence; backfill + tighten is the correct fix. If the backfill
--- COMPUTES a value (not a constant), add a test that exercises the non-empty
--- case — assert the computed value matches the real count, not just that the
--- statement runs. Issue #352 is the cautionary tale: a chunk_count backfill
+-- here. Never leave a field permanently `option<>` just to dodge this —
+-- downstream code assumes presence; backfill + tighten is the correct fix. If
+-- the backfill COMPUTES a value (not a constant), add a test that exercises the
+-- non-empty case — assert the computed value matches the real count, not just
+-- that the statement runs. Issue #352 is the cautionary tale: a chunk_count backfill
 -- shipped relying on a non-obvious SurrealDB sub-select quirk with only a
 -- throwaway probe; the permanent test (test_backfill_chunk_count_* in
 -- src/surreal_db/tests.rs) now guards it. Issue #360 is the second cautionary
@@ -548,6 +567,13 @@ UPDATE knowledge SET triggers = [] WHERE triggers IS NONE;
 
 -- Issue #122: backfill format field for existing entries.
 UPDATE knowledge SET format = 'markdown' WHERE format IS NONE;
+
+-- Resonance cascade fields: legacy rows that predate the wake-up cascade hold
+-- NONE for these required ints/float. Backfill to their DEFAULTs while loose.
+-- (Same #360 hazard as the four above — see the field-site comment.)
+UPDATE knowledge SET resonance = 0 WHERE resonance IS NONE;
+UPDATE knowledge SET activation_count = 0 WHERE activation_count IS NONE;
+UPDATE knowledge SET decay_rate = 0.0 WHERE decay_rate IS NONE;
 
 -- Issue #352: backfill chunk_count for entries that predate chunking (Issue #346).
 -- chunk_count is `int DEFAULT 0` (required); rows that predate it are stranded
@@ -582,6 +608,11 @@ DEFINE FIELD OVERWRITE triggers ON knowledge TYPE array<string> DEFAULT [];
 DEFINE FIELD OVERWRITE format ON knowledge TYPE string DEFAULT 'markdown'
   ASSERT $value IN ['markdown', 'json', 'stele:markdown', 'stele:ascii', 'stele:light', 'stele:full'];
 DEFINE FIELD OVERWRITE chunk_count ON knowledge TYPE int DEFAULT 0;
+-- Resonance cascade fields (legacy-added, Issue #360 cohort): tighten back to
+-- their strict required types now that no row holds NONE.
+DEFINE FIELD OVERWRITE resonance ON knowledge TYPE int DEFAULT 0;
+DEFINE FIELD OVERWRITE activation_count ON knowledge TYPE int DEFAULT 0;
+DEFINE FIELD OVERWRITE decay_rate ON knowledge TYPE float DEFAULT 0.0;
 
 -- STEP 4 — define the triggers element index now that `triggers` is strict
 -- `array<string>` again.

--- a/schema/surrealdb-schema.surql
+++ b/schema/surrealdb-schema.surql
@@ -124,40 +124,69 @@ DEFINE FIELD IF NOT EXISTS activation_count ON knowledge TYPE int DEFAULT 0;
 DEFINE FIELD IF NOT EXISTS decay_rate ON knowledge TYPE float DEFAULT 0.0;
 DEFINE FIELD IF NOT EXISTS anchors ON knowledge TYPE option<array<string>>;
 
--- Issue #72: Multiple wake phrases for ritual variety
-DEFINE FIELD IF NOT EXISTS wake_phrases ON knowledge TYPE array<string> DEFAULT [];
+-- Issue #72: Multiple wake phrases for ritual variety.
+-- Required field added after rows existed → cold-upgrade hazard (Issue #360).
+-- Defined as option<...> here; backfilled + tightened to strict array<string>
+-- in the COLD-UPGRADE BACKFILL block below. See the triggers comment for why.
+-- OVERWRITE (not IF NOT EXISTS): loosen unconditionally so an upgrade from a
+-- prior version where the field was strict actually loosens (Issue #360).
+DEFINE FIELD OVERWRITE wake_phrases ON knowledge TYPE option<array<string>>;
 
 -- Issue #73: Custom wake order (separate from resonance)
 DEFINE FIELD IF NOT EXISTS wake_order ON knowledge TYPE option<int>;
 DEFINE INDEX IF NOT EXISTS knowledge_wake_order ON knowledge FIELDS wake_order;
 
 -- Issue #246: Trigger keywords for reactive memory injection.
--- Mirrors the wake_phrases field exactly: `array<string> DEFAULT []`.
+-- Mirrors the wake_phrases field: `array<string> DEFAULT []`.
 --
--- NO BACKFILL IS NEEDED HERE (and a future reader should NOT add one).
--- The stranding bug documented in the BACKFILL section below only afflicts
--- REQUIRED SCALAR fields (e.g. `int DEFAULT 0`): when such a field is added to
--- a SCHEMAFULL table, pre-existing rows hold NONE and the next write throws
--- "Found NONE for field X". `array<string> DEFAULT []` is the safe pattern and
--- is immune for two reasons working together:
---   1. READ PATH coalesce: knowledge_select_fields() projects
---      `IF triggers THEN triggers ELSE [] END`, so any pre-existing row whose
---      `triggers` is NONE reads back as `[]` -- never observed as NONE.
---   2. WRITE PATH always binds: upsert_knowledge_async always sets
---      `triggers = $triggers` (bound, never NONE), so the moment any row is
---      written it gets a concrete array. No row is ever left stranded with NONE.
--- Because both halves hold, there is no window in which a row needs a backfill.
-DEFINE FIELD IF NOT EXISTS triggers ON knowledge TYPE array<string> DEFAULT [];
--- INDEX HONESTY (Issue #246, PR3): this is a per-ELEMENT index over the array
--- contents. It accelerates equality/CONTAINS lookups (e.g.
--- `WHERE triggers CONTAINS 'brad'`), NOT the `array::len(triggers ?? []) > 0`
--- non-emptiness prefilter that `mx memory trigger-check` currently uses (that
--- resolves via full scan regardless). It is kept deliberately: the actual
--- matching is word-boundary + stemmed and happens in Rust (it cannot be pushed
--- into a SurrealDB index), but a future hook-side fast path / "which memory owns
--- trigger X" lookup will want CONTAINS, which this index serves. If those never
--- materialize, this index is a candidate for removal.
-DEFINE INDEX IF NOT EXISTS knowledge_triggers ON knowledge FIELDS triggers;
+-- COLD-UPGRADE BACKFILL REQUIRED (Issue #360 — corrects an earlier claim here).
+-- ---------------------------------------------------------------------------
+-- An earlier version of this comment asserted "no backfill is needed" for
+-- `triggers`, on the theory that read-path coalescing + write-path binding
+-- meant no row was ever stranded. That reasoning is WRONG for a populated
+-- pre-existing graph (Issue #360, ~5,283-row graph reported via the hearth
+-- federation, Soren/Geoff). Here is the real write path:
+--
+--   * `DEFINE FIELD ... TYPE array<string>` does NOT validate at define-time.
+--     The strict type is only enforced on the NEXT WRITE that touches a row.
+--   * On a SCHEMAFULL table, SurrealDB validates the ENTIRE record on ANY
+--     write. So when ANY backfill/seed/upsert below first writes a legacy row,
+--     the validator inspects every required field — including `triggers`.
+--   * Legacy rows that predate this field hold NONE for it (absent == NONE on
+--     disk in SurrealDB 2.6.x). The write therefore aborts with
+--     "Found NONE for field 'triggers' ... but expected a array<string>", and
+--     because apply_schema runs the whole file through one `db.query` with
+--     `take_errors()` (all-or-nothing), the entire connect fails.
+--   * A bare `UPDATE ... SET triggers = [] WHERE triggers IS NONE` placed AFTER
+--     the strict DEFINE does not help: that UPDATE is itself the failing write.
+--   * Backfilling BEFORE the DEFINE on a SCHEMAFULL table is silently DROPPED
+--     (you cannot `SET` an undefined field on a SCHEMAFULL table).
+--
+-- THE WORKING SEQUENCE (used here and for every required field added after
+-- rows already exist — see "THE RULE" in the BACKFILL section): define the
+-- field as `option<...>` first, backfill legacy NONE rows to the default, then
+-- tighten to the strict required type with `DEFINE FIELD OVERWRITE`. The
+-- tighten MUST use OVERWRITE: `IF NOT EXISTS` silently SKIPS because the field
+-- already exists, leaving it loose (`option<...>`) forever.
+--
+-- ORDERING NOTE: the backfill UPDATE and the OVERWRITE-tighten for this field
+-- live together with the other cold-upgrade fields in the COLD-UPGRADE
+-- BACKFILL block lower down (just before the SEED DATA), NOT here. The reason
+-- is whole-record validation: a backfill UPDATE only succeeds once EVERY
+-- required legacy-added field on the row is non-NONE, so all such fields must
+-- be defined as `option<...>` first (here, at their natural sites), then
+-- backfilled together, then tightened together — no write may happen while any
+-- one of them is still NONE.
+--
+-- This loosen MUST be OVERWRITE, not IF NOT EXISTS: on an upgrade from a prior
+-- mx version the field ALREADY EXISTS as the strict `array<string>`, so
+-- IF NOT EXISTS would silently skip and the field would stay strict — the
+-- backfill below would then die exactly as in #360. OVERWRITE loosens
+-- unconditionally (and creates it on a fresh graph).
+DEFINE FIELD OVERWRITE triggers ON knowledge TYPE option<array<string>>;
+-- NOTE: `knowledge_triggers` INDEX is defined in the COLD-UPGRADE BACKFILL
+-- block below, AFTER `triggers` is tightened back to the strict
+-- `array<string>` — index definitions must see the field in its final type.
 
 -- DEPRECATED: Kept for backward compatibility during migration
 DEFINE FIELD IF NOT EXISTS wake_phrase ON knowledge TYPE option<string>;
@@ -204,12 +233,21 @@ DEFINE FIELD IF NOT EXISTS embedding ON knowledge TYPE option<array<float>>;
 DEFINE FIELD IF NOT EXISTS embedding_model ON knowledge TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS embedded_at ON knowledge TYPE option<datetime>;
 
--- Embedding chunk count (Issue #346)
-DEFINE FIELD IF NOT EXISTS chunk_count ON knowledge TYPE int DEFAULT 0;
+-- Embedding chunk count (Issue #346).
+-- Required field added after rows existed → cold-upgrade hazard (Issue #360).
+-- Defined as option<int> here; backfilled to the per-entry chunk count +
+-- tightened to strict `int DEFAULT 0` in the COLD-UPGRADE BACKFILL block below.
+-- OVERWRITE (not IF NOT EXISTS): loosen unconditionally so an upgrade from a
+-- prior version where the field was strict actually loosens (Issue #360).
+DEFINE FIELD OVERWRITE chunk_count ON knowledge TYPE option<int>;
 
--- Issue #122: Stele encoding format
-DEFINE FIELD IF NOT EXISTS format ON knowledge TYPE string DEFAULT 'markdown'
-  ASSERT $value IN ['markdown', 'json', 'stele:markdown', 'stele:ascii', 'stele:light', 'stele:full'];
+-- Issue #122: Stele encoding format.
+-- Required field added after rows existed → cold-upgrade hazard (Issue #360).
+-- Defined as option<string> here; backfilled to 'markdown' + tightened to the
+-- strict asserted `string DEFAULT 'markdown'` in the COLD-UPGRADE block below.
+-- OVERWRITE (not IF NOT EXISTS): loosen unconditionally so an upgrade from a
+-- prior version where the field was strict actually loosens (Issue #360).
+DEFINE FIELD OVERWRITE format ON knowledge TYPE option<string>;
 
 -- Indexes for common queries
 DEFINE INDEX IF NOT EXISTS knowledge_category ON knowledge FIELDS category;
@@ -415,7 +453,7 @@ UPSERT applicability_type:cli SET description = 'Command-line tools', scope = 'd
 UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 
 -- =============================================================================
--- BACKFILL (Issues #72, #73, #122, #352)
+-- COLD-UPGRADE BACKFILL (Issues #72, #73, #122, #352, #360)
 -- =============================================================================
 --
 -- WHY THIS SECTION EXISTS
@@ -431,36 +469,89 @@ UPSERT applicability_type:api SET description = 'API design', scope = 'domain';
 -- that touches such a row throws
 -- `Found NONE for field X ... but expected a <type>`.
 --
+-- ISSUE #360 — THE COLD-UPGRADE TRAP (why this whole section was rewritten)
+-- ------------------------------------------------------------------------
+-- A `DEFINE FIELD ... TYPE <strict>` does NOT validate at define-time. The
+-- strict type is enforced only on the next WRITE touching a row. So the OLD
+-- ordering (strict DEFINE above, then a bare `UPDATE ... WHERE X IS NONE`
+-- backfill here) does not actually work on a populated pre-existing graph:
+--   * the backfill UPDATE is ITSELF the first write touching legacy rows, and
+--   * a SCHEMAFULL write validates EVERY required field at once — so the very
+--     first backfill UPDATE (historically the wake_phrases migration) aborts
+--     because triggers/chunk_count/format are still NONE on that same row.
+--   * apply_schema sends the whole file through one `db.query` and uses
+--     `take_errors()` (all-or-nothing), so one stranded row fails every connect.
+-- Reported by the hearth federation (Soren/Geoff) on a ~5,283-row graph; the
+-- interim workaround was MX_SKIP_SCHEMA=1.
+--
+-- WHAT DOESN'T WORK (do not relitigate — all tried, all fail):
+--   * DEFAULT [] / DEFAULT 0 — fires only on create, never backfills.
+--   * backfill placed AFTER the strict DEFINE — the backfill is the write that
+--     dies.
+--   * backfill placed BEFORE the DEFINE on a SCHEMAFULL table — `SET` of an
+--     undefined field is SILENTLY DROPPED, so the row is never conformed.
+--   * option<>-first then tighten with `IF NOT EXISTS` — the tighten is SKIPPED
+--     because the field already exists, leaving it loose forever.
+--
+-- THE WORKING SEQUENCE (option → backfill → OVERWRITE-tighten):
+--   1. Each required, legacy-added field is LOOSENED to `option<...>` at its
+--      site above (triggers, wake_phrases, chunk_count, format) with
+--      `DEFINE FIELD OVERWRITE` — OVERWRITE, not IF NOT EXISTS, because on an
+--      upgrade the field already exists as the strict type and IF NOT EXISTS
+--      would skip, leaving it strict. Loosening lets a write touch the row
+--      while the field is still NONE.
+--   2. Backfill ALL of them here, while every one is still loose. Because all
+--      four are option<> at this point, these UPDATEs pass whole-record
+--      validation even though the others have not been set yet on that row.
+--   3. THEN tighten each back to its strict type with `DEFINE FIELD OVERWRITE`
+--      (NOT `IF NOT EXISTS`, which would skip). After the backfill no row holds
+--      NONE, so the strict type — enforced on the next write — is satisfied.
+--   4. Define `triggers`' element index last, once `triggers` is strict again.
+--
 -- This file is replayed on EVERY connection (embedded AND network — see
--- connection.rs apply_schema) and on every `mx migrate`. The DEFINE statements
--- above are idempotent via `IF NOT EXISTS`; the statements below must be
--- idempotent too.
+-- connection.rs apply_schema) and on every `mx migrate`. IDEMPOTENCY: the
+-- `WHERE <f> IS NONE` backfills are no-ops on a healthy graph (nothing is NONE),
+-- and `DEFINE FIELD OVERWRITE` re-applies the same definition cleanly. A second
+-- full apply succeeds and changes nothing.
 --
 -- THE RULE (read this before adding a required field)
 -- ---------------------------------------------------
--- Whenever you add a new REQUIRED field to an existing table, add a PAIRED
--- backfill statement here. Each statement MUST be a no-op once applied —
--- always guard with `WHERE <field> IS NONE` so re-running over already-fixed
--- rows changes nothing. Never make a field `option<>` just to dodge this;
--- backfill is the correct fix because downstream code assumes presence.
--- If the backfill COMPUTES a value (not a constant), add a test that exercises
--- the non-empty case — assert the computed value matches the real count, not
--- just that the statement runs. Issue #352 is the cautionary tale: a chunk_count
--- backfill shipped relying on a non-obvious SurrealDB sub-select quirk with only
--- a throwaway probe; the permanent test (test_backfill_chunk_count_* in
--- src/surreal_db/tests.rs) now guards it.
+-- Whenever you add a new REQUIRED (non-`option<>`) field to an existing table,
+-- DO NOT just write `DEFINE FIELD ... TYPE <strict> DEFAULT <d>` above. Use the
+-- three-step cold-upgrade pattern: `DEFINE FIELD OVERWRITE` the field as
+-- `option<>` at its site (OVERWRITE so an upgrade from a strict prior version
+-- actually loosens), then add a `WHERE <field> IS NONE` backfill in THIS block,
+-- then a paired `DEFINE FIELD OVERWRITE ... TYPE <strict> DEFAULT <d>` tighten
+-- here. Never
+-- leave a field permanently `option<>` just to dodge this — downstream code
+-- assumes presence; backfill + tighten is the correct fix. If the backfill
+-- COMPUTES a value (not a constant), add a test that exercises the non-empty
+-- case — assert the computed value matches the real count, not just that the
+-- statement runs. Issue #352 is the cautionary tale: a chunk_count backfill
+-- shipped relying on a non-obvious SurrealDB sub-select quirk with only a
+-- throwaway probe; the permanent test (test_backfill_chunk_count_* in
+-- src/surreal_db/tests.rs) now guards it. Issue #360 is the second cautionary
+-- tale: the end-to-end apply_schema replay test (test_cold_upgrade_* in the
+-- same file) now guards the ordering itself.
+
+-- STEP 2 — backfill every legacy-added required field while all are still
+-- option<> (so each UPDATE passes whole-record validation regardless of the
+-- others still being NONE on the same row).
 
 -- Issues #72/#73: migrate single wake_phrase to wake_phrases array.
 -- Guard: only rows where wake_phrases was never set.
 UPDATE knowledge SET wake_phrases = IF wake_phrase != NONE THEN [wake_phrase] ELSE [] END
 WHERE wake_phrases IS NONE;
 
+-- Issue #246: triggers has no legacy value to recover — default empty.
+UPDATE knowledge SET triggers = [] WHERE triggers IS NONE;
+
 -- Issue #122: backfill format field for existing entries.
 UPDATE knowledge SET format = 'markdown' WHERE format IS NONE;
 
 -- Issue #352: backfill chunk_count for entries that predate chunking (Issue #346).
--- chunk_count is `int DEFAULT 0` (required); 340/368 rows predate it and are
--- stranded with NONE — broken on next write.
+-- chunk_count is `int DEFAULT 0` (required); rows that predate it are stranded
+-- with NONE — broken on next write.
 --
 -- The correct value is the actual number of embedding_chunk rows for the entry.
 -- ID MISMATCH: a knowledge record id is `knowledge:<hex>`, but
@@ -482,3 +573,25 @@ UPDATE knowledge SET chunk_count = array::len(
     WHERE entry_id = string::concat('kn-', meta::id($parent.id))
 )
 WHERE chunk_count IS NONE;
+
+-- STEP 3 — tighten each field back to its strict required type now that no row
+-- holds NONE. MUST be OVERWRITE: IF NOT EXISTS would silently skip and leave
+-- the field loose (option<>) forever (Issue #360).
+DEFINE FIELD OVERWRITE wake_phrases ON knowledge TYPE array<string> DEFAULT [];
+DEFINE FIELD OVERWRITE triggers ON knowledge TYPE array<string> DEFAULT [];
+DEFINE FIELD OVERWRITE format ON knowledge TYPE string DEFAULT 'markdown'
+  ASSERT $value IN ['markdown', 'json', 'stele:markdown', 'stele:ascii', 'stele:light', 'stele:full'];
+DEFINE FIELD OVERWRITE chunk_count ON knowledge TYPE int DEFAULT 0;
+
+-- STEP 4 — define the triggers element index now that `triggers` is strict
+-- `array<string>` again.
+-- INDEX HONESTY (Issue #246, PR3): this is a per-ELEMENT index over the array
+-- contents. It accelerates equality/CONTAINS lookups (e.g.
+-- `WHERE triggers CONTAINS 'brad'`), NOT the `array::len(triggers ?? []) > 0`
+-- non-emptiness prefilter that `mx memory trigger-check` currently uses (that
+-- resolves via full scan regardless). It is kept deliberately: the actual
+-- matching is word-boundary + stemmed and happens in Rust (it cannot be pushed
+-- into a SurrealDB index), but a future hook-side fast path / "which memory owns
+-- trigger X" lookup will want CONTAINS, which this index serves. If those never
+-- materialize, this index is a candidate for removal.
+DEFINE INDEX IF NOT EXISTS knowledge_triggers ON knowledge FIELDS triggers;

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -2499,6 +2499,171 @@ fn test_backfill_chunk_count_idempotent() {
 }
 
 // =========================================================================
+// Issue #360 — cold-upgrade backfill, END-TO-END through apply_schema.
+//
+// THE CI BLIND SPOT THIS CLOSES: test_backfill_chunk_count_* (above) only run
+// the ISOLATED backfill UPDATE against a row whose chunk_count is already NONE.
+// They never replay the full SCHEMA const through the real apply path, so they
+// could not catch the production failure in #360: on a populated pre-existing
+// graph, the strict `DEFINE FIELD` leaves legacy rows holding NONE, and the
+// FIRST write in the schema's backfill block (the wake_phrases migration) then
+// aborts whole-record validation — taking the entire all-or-nothing
+// `db.query(SCHEMA)` (take_errors) down with it. These tests reproduce that by
+// stranding the legacy-added required fields as genuinely-NONE, replaying the
+// ACTUAL SCHEMA through apply_schema_explicit end-to-end, and asserting both
+// that apply succeeds AND that an ordinary subsequent write to a legacy row
+// succeeds (the exact production failure mode).
+//
+// Backing store: open_in_memory() uses the real embedded SurrealKV engine (not
+// a mock), so SCHEMAFULL strict-DEFINE whole-record validation reproduces
+// faithfully — the same mechanics as `surreal start memory`.
+// =========================================================================
+
+/// Strand a knowledge row so the four legacy-added required fields
+/// (`triggers`, `wake_phrases`, `chunk_count`, `format`) are genuinely NONE —
+/// the exact production state of a row that predates each field. We can't just
+/// `SET x = NONE` while the field is strict (SurrealDB rejects NONE for a
+/// required field), so for each field we reproduce the real history: drop the
+/// field constraint, set the value to NONE, then re-DEFINE the field as it
+/// existed in the PRE-#360 schema (strict). This leaves the row holding NONE
+/// under a strict definition — precisely the cold-upgrade trap. Replaying the
+/// (fixed) SCHEMA must then heal it via option → backfill → OVERWRITE.
+fn strand_cold_upgrade_fields(db: &SurrealDatabase, record: &str) {
+    // (field name, the strict pre-#360 DEFINE to restore)
+    let fields: [(&str, &str); 4] = [
+        (
+            "triggers",
+            "DEFINE FIELD triggers ON knowledge TYPE array<string> DEFAULT []",
+        ),
+        (
+            "wake_phrases",
+            "DEFINE FIELD wake_phrases ON knowledge TYPE array<string> DEFAULT []",
+        ),
+        (
+            "chunk_count",
+            "DEFINE FIELD chunk_count ON knowledge TYPE int DEFAULT 0",
+        ),
+        (
+            "format",
+            "DEFINE FIELD format ON knowledge TYPE string DEFAULT 'markdown' \
+             ASSERT $value IN ['markdown', 'json', 'stele:markdown', 'stele:ascii', \
+             'stele:light', 'stele:full']",
+        ),
+    ];
+
+    // 1. Drop ALL four field constraints first. We cannot strand them one at a
+    //    time: re-DEFINEing one as strict before the others are set to NONE
+    //    would make the NEXT `SET <other> = NONE` write fail whole-record
+    //    validation on the just-tightened field (that is literally the #360
+    //    trap). So unconstrain everything, THEN null everything, THEN restore
+    //    the strict defs last (pure DDL — no row write to validate).
+    for (name, _) in fields {
+        db.test_exec(&format!("REMOVE FIELD IF EXISTS {} ON knowledge", name))
+            .unwrap();
+    }
+    // 2. Null all four in a single write (no strict field is in the way now).
+    db.test_exec(&format!(
+        "UPDATE {} SET triggers = NONE, wake_phrases = NONE, chunk_count = NONE, format = NONE",
+        record
+    ))
+    .unwrap();
+    // 3. Restore the strict pre-#360 definitions. The row keeps NONE under a
+    //    strict definition — the exact cold-upgrade stranded state.
+    for (_, strict_define) in fields {
+        db.test_exec(strict_define).unwrap();
+    }
+}
+
+/// Read the raw stored value of a knowledge field WITHOUT read-coalescing,
+/// returning the JSON value (`null` == NONE on disk).
+fn raw_field(db: &SurrealDatabase, record: &str, field: &str) -> serde_json::Value {
+    let sql = format!("SELECT {0} FROM {1}", field, record);
+    // test_exec swallows results; use a tiny inline query via the same runtime.
+    SurrealDatabase::runtime().block_on(async {
+        let mut response = with_db!(db, db, { db.query(&sql).await.unwrap() });
+        let rows: Vec<serde_json::Value> = response.take(0).unwrap();
+        rows.into_iter()
+            .next()
+            .and_then(|r| r.get(field).cloned())
+            .unwrap_or(serde_json::Value::Null)
+    })
+}
+
+#[test]
+fn test_cold_upgrade_apply_schema_heals_stranded_legacy_rows() {
+    // A populated pre-existing graph: a real knowledge row exists, then loses
+    // the four legacy-added required fields to NONE (predating them).
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let entry = make_test_entry("kn-legacy360", 5, 0.0);
+    db.upsert_knowledge(&entry).unwrap();
+
+    strand_cold_upgrade_fields(&db, "knowledge:legacy360");
+
+    // Precondition: the fields are genuinely NONE on disk (null), exactly the
+    // production stranded state.
+    assert!(
+        raw_field(&db, "knowledge:legacy360", "triggers").is_null(),
+        "precondition: triggers must be NONE before re-apply"
+    );
+    assert!(
+        raw_field(&db, "knowledge:legacy360", "chunk_count").is_null(),
+        "precondition: chunk_count must be NONE before re-apply"
+    );
+
+    // ACT: replay the FULL SCHEMA const through the real apply path,
+    // end-to-end. On the OLD ordering this aborts (the backfill UPDATE block is
+    // the failing write); on the fixed ordering option→backfill→OVERWRITE heals
+    // the rows first.
+    db.apply_schema_explicit(false)
+        .expect("apply_schema must succeed on a populated pre-existing graph (Issue #360)");
+
+    // ASSERT (a): the stranded fields were backfilled to their defaults.
+    assert_eq!(
+        raw_field(&db, "knowledge:legacy360", "triggers"),
+        serde_json::json!([]),
+        "triggers must be backfilled to []"
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:legacy360", "chunk_count"),
+        serde_json::json!(0),
+        "chunk_count must be backfilled to 0 (no chunks for this entry)"
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:legacy360", "format"),
+        serde_json::json!("markdown"),
+        "format must be backfilled to 'markdown'"
+    );
+
+    // ASSERT (b): the EXACT production failure mode — an ordinary subsequent
+    // write to the (formerly) legacy row must succeed. update_activations does
+    // a partial `SET`, which still triggers SCHEMAFULL whole-record validation.
+    db.update_activations(&["kn-legacy360".to_string()])
+        .expect("ordinary write to a healed legacy row must succeed (Issue #360)");
+}
+
+#[test]
+fn test_cold_upgrade_apply_schema_idempotent_on_healthy_graph() {
+    // A second full apply over an already-healthy graph must succeed and not
+    // thrash: the WHERE <f> IS NONE backfills are no-ops and the OVERWRITE
+    // tightens re-apply cleanly.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let entry = make_test_entry("kn-healthy360", 5, 0.0);
+    db.upsert_knowledge(&entry).unwrap();
+
+    // Re-apply twice more (schema already applied once on open).
+    db.apply_schema_explicit(false).unwrap();
+    db.apply_schema_explicit(false).unwrap();
+
+    // Field stays strict + correct, and ordinary writes still work.
+    assert_eq!(
+        raw_field(&db, "knowledge:healthy360", "chunk_count"),
+        serde_json::json!(0)
+    );
+    db.update_activations(&["kn-healthy360".to_string()])
+        .expect("ordinary write after idempotent re-apply must succeed");
+}
+
+// =========================================================================
 // TRIGGERS (Issue #246, PR 1/4 -- data layer)
 // =========================================================================
 

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -2519,18 +2519,29 @@ fn test_backfill_chunk_count_idempotent() {
 // faithfully — the same mechanics as `surreal start memory`.
 // =========================================================================
 
-/// Strand a knowledge row so the four legacy-added required fields
-/// (`triggers`, `wake_phrases`, `chunk_count`, `format`) are genuinely NONE —
-/// the exact production state of a row that predates each field. We can't just
-/// `SET x = NONE` while the field is strict (SurrealDB rejects NONE for a
-/// required field), so for each field we reproduce the real history: drop the
-/// field constraint, set the value to NONE, then re-DEFINE the field as it
-/// existed in the PRE-#360 schema (strict). This leaves the row holding NONE
+/// Strand a knowledge row so EVERY legacy-added required field is genuinely
+/// NONE — the exact production state of a row that predates each field. This is
+/// the COMPLETE post-release required-field set on `knowledge` (every required,
+/// non-`option<>` field the read path coalesces in knowledge_select_fields(),
+/// i.e. every one that can be NONE on a legacy row):
+///
+/// * triggers, wake_phrases, chunk_count, format  (Issue #360, PR #367)
+/// * resonance, activation_count, decay_rate      (wake-up cascade cohort)
+///
+/// Stranding the WHOLE set (not just the first four) is deliberate: it makes
+/// this helper structurally catch the entire class going forward. Add a row to
+/// the array here whenever a new required field is added after the table's first
+/// release, and the end-to-end test below will fail until the schema heals it.
+///
+/// We can't just `SET x = NONE` while the field is strict (SurrealDB rejects
+/// NONE for a required field), so for each field we reproduce the real history:
+/// drop the field constraint, set the value to NONE, then re-DEFINE the field as
+/// it existed in the PRE-fix schema (strict). This leaves the row holding NONE
 /// under a strict definition — precisely the cold-upgrade trap. Replaying the
 /// (fixed) SCHEMA must then heal it via option → backfill → OVERWRITE.
 fn strand_cold_upgrade_fields(db: &SurrealDatabase, record: &str) {
-    // (field name, the strict pre-#360 DEFINE to restore)
-    let fields: [(&str, &str); 4] = [
+    // (field name, the strict pre-fix DEFINE to restore)
+    let fields: [(&str, &str); 7] = [
         (
             "triggers",
             "DEFINE FIELD triggers ON knowledge TYPE array<string> DEFAULT []",
@@ -2549,9 +2560,21 @@ fn strand_cold_upgrade_fields(db: &SurrealDatabase, record: &str) {
              ASSERT $value IN ['markdown', 'json', 'stele:markdown', 'stele:ascii', \
              'stele:light', 'stele:full']",
         ),
+        (
+            "resonance",
+            "DEFINE FIELD resonance ON knowledge TYPE int DEFAULT 0",
+        ),
+        (
+            "activation_count",
+            "DEFINE FIELD activation_count ON knowledge TYPE int DEFAULT 0",
+        ),
+        (
+            "decay_rate",
+            "DEFINE FIELD decay_rate ON knowledge TYPE float DEFAULT 0.0",
+        ),
     ];
 
-    // 1. Drop ALL four field constraints first. We cannot strand them one at a
+    // 1. Drop ALL field constraints first. We cannot strand them one at a
     //    time: re-DEFINEing one as strict before the others are set to NONE
     //    would make the NEXT `SET <other> = NONE` write fail whole-record
     //    validation on the just-tightened field (that is literally the #360
@@ -2561,13 +2584,15 @@ fn strand_cold_upgrade_fields(db: &SurrealDatabase, record: &str) {
         db.test_exec(&format!("REMOVE FIELD IF EXISTS {} ON knowledge", name))
             .unwrap();
     }
-    // 2. Null all four in a single write (no strict field is in the way now).
-    db.test_exec(&format!(
-        "UPDATE {} SET triggers = NONE, wake_phrases = NONE, chunk_count = NONE, format = NONE",
-        record
-    ))
-    .unwrap();
-    // 3. Restore the strict pre-#360 definitions. The row keeps NONE under a
+    // 2. Null all of them in a single write (no strict field is in the way now).
+    let set_clause = fields
+        .iter()
+        .map(|(name, _)| format!("{} = NONE", name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    db.test_exec(&format!("UPDATE {} SET {}", record, set_clause))
+        .unwrap();
+    // 3. Restore the strict pre-fix definitions. The row keeps NONE under a
     //    strict definition — the exact cold-upgrade stranded state.
     for (_, strict_define) in fields {
         db.test_exec(strict_define).unwrap();
@@ -2592,7 +2617,9 @@ fn raw_field(db: &SurrealDatabase, record: &str, field: &str) -> serde_json::Val
 #[test]
 fn test_cold_upgrade_apply_schema_heals_stranded_legacy_rows() {
     // A populated pre-existing graph: a real knowledge row exists, then loses
-    // the four legacy-added required fields to NONE (predating them).
+    // EVERY legacy-added required field to NONE (predating them) — the full
+    // post-release required-field set, including the resonance cascade cohort
+    // (resonance/activation_count/decay_rate) that the original #360 fix missed.
     let db = SurrealDatabase::open_in_memory().unwrap();
     let entry = make_test_entry("kn-legacy360", 5, 0.0);
     db.upsert_knowledge(&entry).unwrap();
@@ -2608,6 +2635,21 @@ fn test_cold_upgrade_apply_schema_heals_stranded_legacy_rows() {
     assert!(
         raw_field(&db, "knowledge:legacy360", "chunk_count").is_null(),
         "precondition: chunk_count must be NONE before re-apply"
+    );
+    // The resonance cascade cohort — the regression Verdictia proved strands the
+    // PR #367 head: apply ABORTS with `FieldCheck { value: "NONE", field:
+    // activation_count, check: "int" }` until these are treated too.
+    assert!(
+        raw_field(&db, "knowledge:legacy360", "resonance").is_null(),
+        "precondition: resonance must be NONE before re-apply"
+    );
+    assert!(
+        raw_field(&db, "knowledge:legacy360", "activation_count").is_null(),
+        "precondition: activation_count must be NONE before re-apply"
+    );
+    assert!(
+        raw_field(&db, "knowledge:legacy360", "decay_rate").is_null(),
+        "precondition: decay_rate must be NONE before re-apply"
     );
 
     // ACT: replay the FULL SCHEMA const through the real apply path,
@@ -2633,6 +2675,22 @@ fn test_cold_upgrade_apply_schema_heals_stranded_legacy_rows() {
         serde_json::json!("markdown"),
         "format must be backfilled to 'markdown'"
     );
+    // The resonance cascade cohort backfills to its strict DEFAULTs (0/0/0.0).
+    assert_eq!(
+        raw_field(&db, "knowledge:legacy360", "resonance"),
+        serde_json::json!(0),
+        "resonance must be backfilled to 0"
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:legacy360", "activation_count"),
+        serde_json::json!(0),
+        "activation_count must be backfilled to 0"
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:legacy360", "decay_rate"),
+        serde_json::json!(0.0),
+        "decay_rate must be backfilled to 0.0"
+    );
 
     // ASSERT (b): the EXACT production failure mode — an ordinary subsequent
     // write to the (formerly) legacy row must succeed. update_activations does
@@ -2654,10 +2712,35 @@ fn test_cold_upgrade_apply_schema_idempotent_on_healthy_graph() {
     db.apply_schema_explicit(false).unwrap();
     db.apply_schema_explicit(false).unwrap();
 
-    // Field stays strict + correct, and ordinary writes still work.
+    // Fields stay strict + correct across the expanded set, and ordinary writes
+    // still work. Covers both the original #360 four and the resonance cohort.
     assert_eq!(
         raw_field(&db, "knowledge:healthy360", "chunk_count"),
         serde_json::json!(0)
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:healthy360", "triggers"),
+        serde_json::json!([])
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:healthy360", "format"),
+        serde_json::json!("markdown")
+    );
+    // OVERWRITE preserves real data on a healthy row: make_test_entry set
+    // resonance=5, decay_rate=0.0; activation_count defaults to 0. The IS NONE
+    // backfills must NOT clobber the live resonance value.
+    assert_eq!(
+        raw_field(&db, "knowledge:healthy360", "resonance"),
+        serde_json::json!(5),
+        "idempotent re-apply must NOT reset a healthy resonance to its default"
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:healthy360", "activation_count"),
+        serde_json::json!(0)
+    );
+    assert_eq!(
+        raw_field(&db, "knowledge:healthy360", "decay_rate"),
+        serde_json::json!(0.0)
     );
     db.update_activations(&["kn-healthy360".to_string()])
         .expect("ordinary write after idempotent re-apply must succeed");


### PR DESCRIPTION
Closes #360

## The bug

Schema auto-apply (#351) aborts on connect against a populated pre-existing graph (Geoff's ~5,283-row graph, reported via the hearth federation — thanks Soren/Geoff). The `triggers` (`array<string>`) and `chunk_count` (`int`) required fields are genuinely absent on legacy rows that predate them, and the apply fails with `Found NONE for field 'triggers' ... but expected a array<string>`. Interim workaround was `MX_SKIP_SCHEMA=1`.

## Mechanism (why every prior attempt failed identically)

- **`DEFINE FIELD TYPE` does NOT validate at define-time.** The strict type is enforced only on the *next WRITE* touching a row. So the strict DEFINE never fails by itself — the failing statement is the first write in the BACKFILL block.
- **SCHEMAFULL validates the ENTIRE record on ANY write** (full UPSERT or partial `SET`). On a legacy row, the first backfill `UPDATE` (historically the `wake_phrases` migration) trips validation on `triggers`/`chunk_count`/`format`, all still NONE on that same row.
- **`absent == NONE` on disk** in SurrealDB 2.6.x — no distinction, so `DEFAULT` (which only fires on create) never conforms legacy rows.
- **Backfilling BEFORE the DEFINE on a SCHEMAFULL table is silently DROPPED** — `SET <undefined field>` is a no-op.
- `apply_schema` sends the whole file through one `db.query(SCHEMA)` and uses `take_errors()` (**all-or-nothing**), so one stranded row fails every connect.

## The fix: option → backfill → OVERWRITE, reordered

For every required field added *after* rows already existed, the field is now:
1. **Loosened** to `option<...>` at its define site — with `DEFINE FIELD OVERWRITE`, **not** `IF NOT EXISTS`. On an upgrade the field already exists strict, and `IF NOT EXISTS` would silently skip and leave it strict (the non-obvious part: the loosen *and* the tighten both need OVERWRITE).
2. **Backfilled** in the COLD-UPGRADE block — all such fields backfilled together *while all are still loose*, so each `UPDATE ... WHERE <f> IS NONE` passes whole-record validation even though the others are still NONE on the same row.
3. **Tightened** back to the strict type with `DEFINE FIELD OVERWRITE ... DEFAULT <d>`. `IF NOT EXISTS` here would silently skip and leave it loose forever.
4. `knowledge_triggers` index defined last, once `triggers` is strict `array<string>` again.

### Fields treated (hazard scan)

Wriggle named `triggers` and `chunk_count`. Scanning for the same hazard — required (non-`option<>`) `knowledge` fields added after rows existed — surfaced two more that already had bare post-DEFINE backfills (themselves failing writes in the same block): **`wake_phrases`** (#72) and **`format`** (#122). All four are now handled consistently via the same sequence; `wake_phrases` keeps its `wake_phrase`→`[wake_phrase]` migration value and `chunk_count` keeps its computed per-entry count.

## Idempotency

Confirmed: the `WHERE <f> IS NONE` backfills are no-ops on a healthy graph, and `DEFINE FIELD OVERWRITE` re-applies the same definition cleanly. A second full apply succeeds and changes nothing (`test_cold_upgrade_apply_schema_idempotent_on_healthy_graph`).

## Corrected comment

The `triggers` comment previously asserted "NO BACKFILL IS NEEDED HERE" (relying on read-coalesce + write-binding). That reasoning is wrong for a populated cold upgrade — the next write to a stranded legacy row fails whole-record validation regardless. The comment now documents the real cold-upgrade write path and ties the option→backfill→OVERWRITE pattern to the BACKFILL convention (#352) as a durable rule for future required fields.

## Closing the CI blind spot (the end-to-end test)

The existing `test_backfill_chunk_count_*` tests only run the **isolated** backfill statement against an already-NONE row — they never replay the full SCHEMA through the real apply path, which is exactly why CI was green while the migration failed in the field.

New tests (`test_cold_upgrade_*` in `src/surreal_db/tests.rs`) reproduce the REAL failure:
- Build a `knowledge` row, then strand all four legacy-added required fields as genuinely-NONE (via the `REMOVE FIELD` → null → re-DEFINE-strict technique, mirroring the production pre-#360 state).
- Replay the **actual** `SCHEMA` const through `apply_schema_explicit` **end-to-end** (not the isolated statement).
- Assert (a) apply returns Ok, and (b) an ordinary subsequent write (`update_activations`, a partial `SET`) to the legacy row succeeds — the exact production failure mode.

Runs against the **real embedded SurrealKV engine** (`open_in_memory`), so SCHEMAFULL strict-DEFINE whole-record validation reproduces faithfully (same mechanics as `surreal start memory`).

**Fail-before / pass-after:** with the old schema ordering, the new heal test fails with `FieldCheck { value: "NONE", field: chunk_count/format }` — the exact production abort. With the fix it passes. Full suite: 1100 passed / 0 failed; clippy `-D warnings` clean; fmt clean.


---

## Addendum — expanded field coverage (Verdictia re-review)

The original hazard scan was **incomplete**. The four fields above (`triggers`, `chunk_count`, `wake_phrases`, `format`) are correct, but three MORE required scalar fields carry the identical stranding hazard and were missed: **`resonance`** (`int DEFAULT 0`), **`activation_count`** (`int DEFAULT 0`), **`decay_rate`** (`float DEFAULT 0.0`). The `knowledge` table first shipped in v0.1.31; these three were added in v0.1.32 (the wake-up cascade) *after* rows existed. On a v0.1.31-origin graph they are NONE, and the all-or-nothing `take_errors()` masked them — fixing only the first four just surfaced `activation_count` as the **next** abort (`FieldCheck { value: "NONE", field: activation_count, check: "int" }`).

All three now get the same **loosen → backfill → OVERWRITE-tighten** treatment. **Coverage is now 7 fields** (was 4).

### Complete required-field scan (no whack-a-mole)

The authoritative "can-be-NONE-on-a-legacy-row" set is exactly the required (non-`option<>`) `knowledge` fields that the read path **coalesces** in `knowledge_select_fields()` (`IF <f> THEN <f> ELSE <default> END`) — that coalescing exists precisely because those fields may be absent on legacy rows. That set:

- **Treated (7):** `triggers`, `wake_phrases`, `chunk_count`, `format`, `resonance`, `activation_count`, `decay_rate`.
- **Left, with reason:** `title`, `content_hash`, `created_at`, `category`, `source_type`, `entry_type`, `content_type`, `ephemeral`, `visibility` — all projected **raw** (not coalesced) in `knowledge_select_fields()`, i.e. present since the table's first definition; no legacy row can lack them. (`title`/`content_hash`/`category`/`source_type`/`entry_type` also have no constant DEFAULT and cannot be synthesized.)

**Ordering invariant** holds for the full set: all 7 strand-hazard fields are loosened to `option<...>` in the table-definition section (above the SEED DATA), before any write touches a `knowledge` row — the seed UPSERTs write only lookup tables, and the first knowledge-row write is the backfill block, by which point all 7 are loose. Tightened together afterward.

### Widened heal test (catches the whole class)

`strand_cold_upgrade_fields` now strands the **full** post-release required-field set (7 fields, not 4) — structurally catching any future required field added to the array. The end-to-end test replays the real `SCHEMA` const and asserts apply Ok + backfilled defaults + a subsequent partial-`SET` write to the legacy row succeeds.

**Fail-before / pass-after (resonance cohort regression):** on the PR #367 head (the original four-field schema) the widened test aborts with `FieldCheck { value: "NONE", field: activation_count, check: "int" }` — Verdictia's exact probe. With this commit it passes. Idempotency test extended to the full set and strengthened to assert OVERWRITE **preserves** a live `resonance=5` rather than clobbering it to the default.

Full suite: 1100 passed / 0 failed; clippy clean; fmt clean. Also fixed the awkward mid-sentence line-wrap in the `THE RULE` comment block (cosmetic).
