### PR TITLE
fix(embeddings): isolate file-backed store tests from live DB + skip dim-mismatched vectors in cosine scans

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1304,7 +1304,15 @@ mod auto_anchor_tests {
         // upsert_knowledge — minus the auto_anchor step the flag removes.
         //
         // An in-memory store cannot prove this (it dies with the handle), so
-        // we use SurrealDatabase::open against a tempdir path and reopen it.
+        // we use a file-backed store against a tempdir path and reopen it.
+        //
+        // CRITICAL: we go through `open_file_backed_for_test`, NOT the plain
+        // `SurrealDatabase::open`. `open` reads `MX_SURREAL_*` env, and if the
+        // ambient shell sets `MX_SURREAL_MODE=network` the explicit tempdir
+        // path is ignored and the write lands on the LIVE database — which is
+        // exactly how a dim-4 fixture once poisoned every production cosine
+        // scan. `open_file_backed_for_test` forces an embedded store at the
+        // tempdir and asserts the endpoint is local before any write.
         clear_agent_env();
         let prev = std::env::var("MX_SKIP_WRITE_ANCHOR").ok();
         unsafe { std::env::set_var("MX_SKIP_WRITE_ANCHOR", "1") };
@@ -1321,14 +1329,14 @@ mod auto_anchor_tests {
 
         // Write phase: open, upsert, drop the handle (simulating process exit).
         {
-            let db = SurrealDatabase::open(&db_path).unwrap();
+            let db = SurrealDatabase::open_file_backed_for_test(&db_path).unwrap();
             let entry =
                 entry_with_embedding("kn-skip-durable", unit_query(), "public", None, vec![]);
             db.upsert_knowledge(&entry).unwrap();
         }
 
         // Reopen phase: a brand-new connection to the same on-disk store.
-        let reopened = SurrealDatabase::open(&db_path).unwrap();
+        let reopened = SurrealDatabase::open_file_backed_for_test(&db_path).unwrap();
         let ctx = AgentContext::public_only();
         let got = reopened.get("kn-skip-durable", &ctx).unwrap();
 

--- a/src/surreal_db/connection.rs
+++ b/src/surreal_db/connection.rs
@@ -499,6 +499,47 @@ impl SurrealDatabase {
         Self::connect(temp_dir.path(), &config)
     }
 
+    /// Test helper - open a *file-backed* store at an explicit `path`,
+    /// guaranteed local regardless of ambient `MX_SURREAL_*` env.
+    ///
+    /// This is the safe replacement for `SurrealDatabase::open(<tempdir>)`
+    /// in tests. `open()` reads `SurrealConfig::from_env()`, so when the
+    /// surrounding shell has `MX_SURREAL_MODE=network` (as a live/CI shell
+    /// often does) the explicit `path` is IGNORED and the connection lands
+    /// on the *live* network endpoint — which is exactly how a dim-4 test
+    /// fixture once leaked into the production graph and poisoned every
+    /// cosine scan.
+    ///
+    /// Here we force `SurrealConfig::default()` (always `Embedded`) and
+    /// assert the resolved endpoint is the local file path before handing
+    /// back the handle, so a future regression fails loudly instead of
+    /// silently writing to prod. Unlike `open_in_memory`, this persists to
+    /// disk at `path`, so a test can drop the handle and reopen the same
+    /// store to prove durability.
+    #[cfg(test)]
+    pub fn open_file_backed_for_test<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let config = SurrealConfig::default(); // always Embedded, never network
+
+        // Loudly refuse to proceed if anything ever flips this to a network
+        // endpoint — a test must NEVER be able to reach the live DB.
+        assert!(
+            !config.is_network(),
+            "open_file_backed_for_test must use an embedded (file-backed) store, \
+             never a network endpoint — refusing to risk a write to the live DB"
+        );
+        // The resolved endpoint is the explicit local path we were handed,
+        // not an env-configured one. Make that contract explicit.
+        assert_eq!(
+            config.mode,
+            SurrealMode::Embedded,
+            "test store must be file-backed at {}",
+            path.display()
+        );
+
+        Self::connect(path, &config)
+    }
+
     /// Apply the embedded schema to the connected database.
     ///
     /// All statements use `IF NOT EXISTS`, so this is idempotent and safe

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -903,11 +903,21 @@ impl SurrealDatabase {
         let resonance_clause = Self::build_resonance_filter(filter);
         let category_clause = Self::build_category_filter(filter);
 
+        // Dimension guard ($dim, bound below): SurrealDB's
+        // vector::similarity::cosine ABORTS THE ENTIRE SCAN when it hits any
+        // row whose embedding dimension differs from the query vector. One
+        // off-dim row (e.g. a leaked dim-4 test fixture) therefore breaks ALL
+        // search. Skip such rows defensively by requiring the stored embedding
+        // length to match the query length BEFORE the cosine is scored. Real
+        // rows are 768 and the query is 768, so normal search is unaffected;
+        // only mismatched rows are filtered out instead of aborting the scan.
+        let query_dim = query_embedding.len();
+
         // Phase 1a: Search unchunked entries (chunk_count <= 0 or absent)
         let unchunked_sql = format!(
             "SELECT {}, vector::similarity::cosine(embedding, $query_vec) AS score
             FROM knowledge
-            WHERE embedding IS NOT NONE AND (chunk_count IS NONE OR chunk_count <= 0) {} {} {}
+            WHERE embedding IS NOT NONE AND array::len(embedding) = $dim AND (chunk_count IS NONE OR chunk_count <= 0) {} {} {}
             ORDER BY score DESC
             LIMIT $limit",
             Self::knowledge_select_fields(),
@@ -916,10 +926,12 @@ impl SurrealDatabase {
             category_clause
         );
 
-        // Phase 1b: Search chunks (no visibility filter — applied after dedup)
+        // Phase 1b: Search chunks (no visibility filter — applied after dedup).
+        // Same dimension guard so an off-dim chunk embedding can't abort the scan.
         let chunk_sql =
             "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
             FROM embedding_chunk
+            WHERE array::len(embedding) = $dim
             ORDER BY score DESC
             LIMIT $chunk_limit";
 
@@ -930,6 +942,7 @@ impl SurrealDatabase {
                 .query(&unchunked_sql)
                 .query(chunk_sql)
                 .bind(("query_vec", query_embedding.to_vec()))
+                .bind(("dim", query_dim))
                 .bind(("limit", limit))
                 .bind(("chunk_limit", chunk_limit));
             if let Some(agent) = current_agent.clone() {
@@ -1062,13 +1075,19 @@ impl SurrealDatabase {
     ) -> Result<Vec<(KnowledgeEntry, f32)>> {
         let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
 
+        // Dimension guard ($dim): see semantic_search_knowledge_async — a single
+        // off-dim row otherwise aborts the whole cosine scan, breaking auto_anchor
+        // (#362) entirely. Require the stored embedding length to match the query
+        // length before scoring; real 768-dim rows pass, mismatches are skipped.
+        let query_dim = query_embedding.len();
+
         // Single-phase: score every embedded knowledge row on its entry-level
         // vector, bounded to the top `limit` by score. Params are bound, never
         // interpolated.
         let sql = format!(
             "SELECT {}, vector::similarity::cosine(embedding, $query_vec) AS score
             FROM knowledge
-            WHERE embedding IS NOT NONE {}
+            WHERE embedding IS NOT NONE AND array::len(embedding) = $dim {}
             ORDER BY score DESC
             LIMIT $limit",
             Self::knowledge_select_fields(),
@@ -1079,6 +1098,7 @@ impl SurrealDatabase {
             let mut query_builder = db
                 .query(&sql)
                 .bind(("query_vec", query_embedding.to_vec()))
+                .bind(("dim", query_dim))
                 .bind(("limit", limit));
             if let Some(agent) = current_agent.clone() {
                 query_builder = query_builder.bind(("current_agent", agent));
@@ -1327,14 +1347,21 @@ impl SurrealDatabase {
         query_embedding: &[f32],
         limit: usize,
     ) -> Result<Vec<(String, f32)>> {
+        // Dimension guard ($dim): see semantic_search_knowledge_async — a single
+        // off-dim chunk embedding otherwise aborts the entire cosine scan. Require
+        // the stored embedding length to match the query length before scoring.
+        let query_dim = query_embedding.len();
+
         let sql = "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
             FROM embedding_chunk
+            WHERE array::len(embedding) = $dim
             ORDER BY score DESC
             LIMIT $limit";
 
         let mut response = with_db!(self, db, {
             db.query(sql)
                 .bind(("query_vec", query_embedding.to_vec()))
+                .bind(("dim", query_dim))
                 .bind(("limit", limit))
                 .await
                 .context("Failed to search embedding chunks")

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -17,19 +17,18 @@ fn test_schema_applies_without_error() {
 
 #[test]
 fn test_embedded_connect_creates_directory() {
-    use super::connection::SurrealConfig;
     use tempfile::tempdir;
 
     let temp_dir = tempdir().unwrap();
     let db_path = temp_dir.path().join("test.surreal");
 
-    // Use connect() with default config to force embedded mode, same as
-    // open_in_memory(). The public open() reads MX_SURREAL_MODE from the
-    // environment, which may route to a network backend that never creates
-    // a local directory -- making the exists()/is_dir() assertions flaky
-    // on hosts where the factory runs in network mode.
-    let config = SurrealConfig::default(); // always Embedded
-    let _db = SurrealDatabase::connect(&db_path, &config).unwrap();
+    // Route through the guarded file-backed test constructor, which forces
+    // embedded mode regardless of MX_SURREAL_*. The public open() reads
+    // MX_SURREAL_MODE from the environment, which may route to a network
+    // backend that never creates a local directory -- making the
+    // exists()/is_dir() assertions flaky on hosts where the factory runs in
+    // network mode (and, worse, could write to the live DB).
+    let _db = SurrealDatabase::open_file_backed_for_test(&db_path).unwrap();
 
     // Verify directory was created
     assert!(db_path.exists());
@@ -2981,4 +2980,97 @@ fn test_trigger_check_cap_and_deferred_fires_next_turn() {
     // Third check: everything fired -> nothing new.
     let fired3 = run_check(&store);
     assert!(fired3.is_empty(), "all memories already fired this session");
+}
+
+// =========================================================================
+// Dimension-mismatch cosine guard regression (production incident).
+//
+// SurrealDB's `vector::similarity::cosine` ABORTS THE ENTIRE SCAN when it
+// encounters any row whose embedding dimension differs from the query
+// vector. A single off-dimension row (famously, a dim-4 unit-test fixture
+// that leaked into the live graph) therefore broke add-dedup, auto_anchor
+// (#362), semantic search, and trigger-check (#246) all at once.
+//
+// The fix adds `AND array::len(embedding) = $dim` to every cosine query so a
+// mismatched row is SKIPPED rather than aborting the scan. These tests would
+// have caught the production breakage: a store containing one off-dim row
+// alongside good rows must still return the good rows WITHOUT erroring.
+//
+// Isolation: uses `open_in_memory()` (forced embedded tempdir), so it can
+// never touch the live DB even if MX_SURREAL_* is set in the environment.
+// =========================================================================
+
+/// Build a knowledge entry carrying an embedding of an arbitrary dimension.
+/// Lets us seed both good (matching) and poisoned (mismatched) rows.
+fn entry_with_dim_embedding(id: &str, embedding: Vec<f32>) -> crate::knowledge::KnowledgeEntry {
+    let mut e = make_test_entry(id, 5, 0.0);
+    e.content_hash = Some(format!("hash-{id}"));
+    e.embedding = Some(embedding);
+    e.embedding_model = Some("test-model".to_string());
+    e.embedded_at = Some(chrono::Utc::now().to_rfc3339());
+    e
+}
+
+#[test]
+fn off_dim_row_does_not_abort_cosine_scan() {
+    use crate::store::{AgentContext, KnowledgeStore};
+
+    // Isolated, never-live store.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Two GOOD rows at the query dimension (N = 8).
+    const N: usize = 8;
+    let mut good_a = vec![0.0f32; N];
+    good_a[0] = 1.0; // unit vector aligned with the query
+    let mut good_b = vec![0.0f32; N];
+    good_b[1] = 1.0; // orthogonal-ish, still dim N
+    db.upsert_knowledge(&entry_with_dim_embedding("kn-good-a", good_a.clone()))
+        .unwrap();
+    db.upsert_knowledge(&entry_with_dim_embedding("kn-good-b", good_b))
+        .unwrap();
+
+    // One POISONED row: a dim-4 embedding (the exact shape of the leaked
+    // fixture). Before the guard, this row made cosine abort the whole scan.
+    db.upsert_knowledge(&entry_with_dim_embedding(
+        "kn-poison-dim4",
+        vec![1.0, 0.0, 0.0, 0.0],
+    ))
+    .unwrap();
+
+    let ctx = AgentContext::public_only();
+    let filter = crate::store::KnowledgeFilter::default();
+    // Query vector at dimension N, aligned with kn-good-a.
+    let query = good_a;
+
+    // Two-phase semantic search must NOT error and must return the good rows.
+    let results = db
+        .semantic_search(&query, &ctx, &filter, 10)
+        .expect("semantic_search must skip the off-dim row, not abort the scan");
+    let ids: Vec<&str> = results.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        ids.contains(&"kn-good-a"),
+        "the matching good row must be returned; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"kn-good-b"),
+        "the second good row must be returned; got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"kn-poison-dim4"),
+        "the off-dim row must be skipped by the guard; got {ids:?}"
+    );
+
+    // Entry-level scored search (the auto_anchor #362 path) must also survive.
+    let scored = db
+        .semantic_search_entries_scored(&query, &ctx, 10)
+        .expect("entries-scored search must skip the off-dim row, not abort the scan");
+    let scored_ids: Vec<&str> = scored.iter().map(|(e, _)| e.id.as_str()).collect();
+    assert!(
+        scored_ids.contains(&"kn-good-a") && scored_ids.contains(&"kn-good-b"),
+        "entry-level scored search must return the good rows; got {scored_ids:?}"
+    );
+    assert!(
+        !scored_ids.contains(&"kn-poison-dim4"),
+        "entry-level scored search must skip the off-dim row; got {scored_ids:?}"
+    );
 }


### PR DESCRIPTION
## The disease and the symptom

A leaked test fixture poisoned every cosine scan on the live graph. Two defects had to line up:

### Defect A — a test could write to the live DB (root cause)

`SurrealDatabase::open(path)` calls `SurrealConfig::from_env()`. When the surrounding shell has `MX_SURREAL_MODE=network` (as a live/CI shell often does), `open()` **ignores the explicit `path`** and connects to the env-configured network endpoint instead. The durability test `skipped_anchor_write_persists_across_reopen` used `SurrealDatabase::open(<tempdir>)` and so wrote its **dim-4** `unit_query()` fixture (`[1,0,0,0]`) straight into the **live** SurrealDB rather than its tempdir.

### Defect B — one off-dim vector aborts the whole scan

SurrealDB's `vector::similarity::cosine` **aborts the entire scan** when it hits any row whose embedding dimension differs from the query vector. So that single dim-4 row broke add-dedup, `auto_anchor` (#362), semantic search, and trigger-check (#246) all at once.

Fixing only B would hide the leak; fixing only A leaves the engine brittle. Both are fixed.

## Fix A — test isolation (the real fix)

Added a guarded `#[cfg(test)]` constructor `SurrealDatabase::open_file_backed_for_test(path)` in `src/surreal_db/connection.rs` that:
- forces `SurrealConfig::default()` (always `Embedded`, never network) regardless of ambient `MX_SURREAL_*`;
- **asserts** `!config.is_network()` and `mode == Embedded` before connecting, so the resolved endpoint is provably the local file path — a future regression fails loudly in CI instead of silently polluting prod;
- persists to disk at `path` (unlike `open_in_memory`), so the durability test can still drop the handle and reopen the same store.

Routed `skipped_anchor_write_persists_across_reopen` and `test_embedded_connect_creates_directory` through it. Scanned all other `open*(path)` / `connect(...)` callers: the remaining ones are production entry points (`store.rs`, `main.rs`, `helpers.rs::open_surreal_db`) that are correctly env-driven; no other test resolves to a path-based `open()`.

**Verified:** the isolation tests pass even when run with `MX_SURREAL_MODE=network MX_SURREAL_URL=ws://127.0.0.1:59999` exported — they never attempt a network connection (finish in ~0.4s), proving they target local/temp only.

## Fix B — defensive cosine guard (defense-in-depth)

Added a bound dimension filter to all four cosine query sites in `src/surreal_db/knowledge.rs`. The `WHERE` clause gains (before the cosine is scored):

```sql
AND array::len(embedding) = $dim
```

with `$dim` bound as a parameter (never interpolated):

```rust
let query_dim = query_embedding.len();
... .bind(("dim", query_dim))
```

Sites:
- `semantic_search_knowledge_async` **Phase 1a** (`knowledge.embedding`)
- `semantic_search_knowledge_async` **Phase 1b** (`embedding_chunk.embedding`)
- `semantic_search_entries_scored_async` (the `auto_anchor` #362 path)
- `semantic_search_chunks_async`

Real rows are 768-dim and the query is 768-dim, so they all pass — normal search is unaffected. Only mismatched rows are skipped instead of aborting the scan (abort → skip).

## Regression tests

- **`off_dim_row_does_not_abort_cosine_scan`** (`src/surreal_db/tests.rs`): seeds a store with two good dim-N rows plus one poisoned **dim-4** row, then runs both `semantic_search` (two-phase) and `semantic_search_entries_scored`. Asserts the good rows come back, the off-dim row is skipped, and **neither call errors**. This is the test that would have caught the production breakage. Uses `open_in_memory()`, so it can never touch the live DB.
- **The isolation guard** inside `open_file_backed_for_test` asserts the store is local before any write.

## Results
- `cargo build`: green
- `cargo test --bin mx`: **1107 passed, 0 failed**, 3 ignored
- isolation tests rerun with `MX_SURREAL_MODE=network` set: still pass, still local
- `cargo clippy --bin mx --all-targets`: clean
- `cargo fmt --check`: clean

## References
Operational findings: `kn-fdb1aecb` / `kn-56a678a0` (dim-4 test-fixture leak poisons all cosine scans) and `kn-ccb6c4aa` (tests reading prod env vars flake on prod hosts). Internal finding — no issue to close.

Do not merge — Verdictia reviews.