### PR TITLE
fix: remove ORDER BY on aggregate alias in growth query

### DIFF
--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1158,8 +1158,7 @@ impl SurrealDatabase {
                         count() AS cnt
                     FROM knowledge
                     WHERE created_at > time::now() - duration::from::days(56)
-                    GROUP BY week_bucket
-                    ORDER BY week_bucket",
+                    GROUP BY week_bucket",
                 )
                 .await
                 .context("Failed to query growth sparkline")


### PR DESCRIPTION
SurrealDB 2.6.1 can reject ordering by computed aliases in GROUP BY queries. The BTreeMap at line 1171 already sorts results by key, making the SQL `ORDER BY week_bucket` redundant. Removing it prevents the query from failing on newer SurrealDB versions.