### PR TITLE
docs: clarify that bare `mx commit` does not auto-stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ Requires Rust 2024 edition. The binary is named `mx`.
 
 `mx commit` wraps `git commit` but encodes the message using [base-d](https://crates.io/crates/base-d). The commit title is hashed and the body is compressed, each encoded through a randomly selected dictionary. The result looks like hieroglyphs in `git log` but decodes cleanly with `mx log`.
 
+Like plain `git commit`, `mx commit` does **not** stage changes on its own — it only commits what is already staged, and errors with `No staged changes to commit` if nothing is staged. Pass `-a` / `--all` to stage all changes (tracked and untracked) before committing.
+
 ```bash
+# Commit only what is already staged (no auto-staging)
+mx commit "fix already-staged typo"
+
 # Stage all and commit with an encoded message
 mx commit "fix session export crash on empty JSONL" -a
 

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -164,9 +164,14 @@ echo "hello" > test.txt
 mx commit "add test file" -a
 ```
 
-The `-a` flag stages all changes before committing, just like
-`git commit -a`. You will see a footer line showing which algorithms and
-dictionaries were used, something like `[sha256:ocean|zstd:forest]`.
+The `-a` flag stages all changes (tracked **and** untracked, via
+`git add -A`) before committing. Without `-a`, `mx commit` behaves like
+plain `git commit`: it commits only what is already staged and exits
+with `No staged changes to
+commit` if nothing is staged -- it does not auto-stage your working
+tree. After a successful commit you will see a footer line showing which
+algorithms and dictionaries were used, something like
+`[sha256:ocean|zstd:forest]`.
 
 ### Read it back
 

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -39,9 +39,12 @@ echo "hello" > test.txt
 mx commit "add test file" -a
 ```
 
-The `-a` flag stages all changes before committing, just like `git commit -a`.
-You will see a footer line showing which algorithms and dictionaries were used,
-something like `[sha256:ocean|zstd:forest]`.
+The `-a` flag stages all changes (tracked *and* untracked, via `git add -A`)
+before committing. Without `-a`, `mx commit` behaves like plain `git commit`:
+it commits only what is already staged and exits with `No staged changes to
+commit` if nothing is staged -- it does not auto-stage your working tree. After
+a successful commit you will see a footer line showing which algorithms and
+dictionaries were used, something like `[sha256:ocean|zstd:forest]`.
 
 === Read it back
 


### PR DESCRIPTION
## What

Make the docs accurate about `mx commit` staging behavior.

## Confirmed behavior (mx 0.1.200)

Bare `mx commit "msg"` does **not** auto-stage. It commits only what is already staged, and errors with `No staged changes to commit` on an unstaged dirty tree. The `-a`/`--all` flag stages all changes first (via `git add -A`, so tracked *and* untracked). Verified against `commit::upload_commit` in `src/commit.rs` (staging happens only when the `--all` flag is set; otherwise `has_staged_changes()` gates the commit and bails).

## Why

On 2026-06-09 an agent was misled by docs that imply `mx commit` (wrapping `git commit`) stages for you, and hit `No staged changes to commit`. The CLI help (`-a`: "Stage all changes before committing") was already accurate; the prose just never stated the *default* (no auto-stage) explicitly.

## Changes (docs only — no behavior change)

- **README.md** — added a sentence stating the no-auto-stage default + a bare-commit example.
- **docs/src/getting-started.typ** — tightened the `-a` explanation to state the default behavior and the exact error, and noted `-a` uses `git add -A` (includes untracked).

Generated HTML under `docs/out/` is a build artifact and is intentionally not hand-edited here.