### PR TITLE
kv: introduce 'kv schema' subcommand suite (list/add/drop/update); fold in 'kv keys' (#363)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,13 @@ mx kv set context --json '{"goal":"done","phase":"writing"}'
 mx kv set mytensor --json '[0.4, 0.6, 0.5]'
 echo '{"goal":"done"}' | mx kv set context --json -
 
-# Auto-create a key in the schema and push in one step
+# Schema management: define, list, edit, and remove keys
+mx kv schema add puns --type history --max-entries 500
+mx kv schema list                              # replaces 'kv keys'
+mx kv schema update puns --description "the good ones"
+mx kv schema drop puns --force                 # removes definition + data
+
+# Auto-create a key in the schema and push in one step (inline shortcut)
 mx kv push puns "the joke" --create history
 mx kv push ideas "wild thought" --create list --max-entries 500
 
@@ -182,7 +188,8 @@ mx kv migrate projects --dry-run
 mx kv migrate projects --prune
 
 # Rename a key (preserves all entries, IDs, and data)
-mx kv rename old_decisions archived_decisions
+mx kv schema update old_decisions --name archived_decisions
+# (the top-level 'mx kv rename' still works but is deprecated)
 
 # Per-entry memory links (bridge KV entries to the knowledge graph)
 mx kv push decisions "adopted memory links" --memory kn-abc123

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -2878,14 +2878,19 @@ Schema fields:
 
 Keys can be added to the schema on the fly with `mx kv push --create`.
 When a key does not exist in the schema, `--create history` or
-`--create list` appends a new `[keys.<name>]` block to the TOML file and
-reloads the in-memory schema. This avoids manual schema editing for
-simple cases. See push for details and validation rules.
+`--create list` defines it and reloads the in-memory schema. This avoids
+manual schema editing for simple cases. See push for details and
+validation rules.
 
 For defining keys of **any** type up front (not just `history`/`list`),
 and for removing or editing existing definitions, use the `mx kv schema`
-subcommands. `push --create` is an inline shortcut that routes through
-the same engine path as `schema add`.
+subcommands. `push --create` is an inline shortcut whose user-facing
+surface stays limited to `history`/`list`, but it routes through the
+**same** engine path as `schema add` (the shared `add_key_def` method).
+One consequence: like every `schema` write, the create rewrites the
+schema file by round-tripping the TOML, which drops comments and custom
+formatting. If you hand-annotate your schema, expect those annotations
+to be lost when a key is created via `--create`.
 
 ### Agent keying
 
@@ -3260,8 +3265,10 @@ requires `--create` and has no effect if the key already exists.
 
 Key names are validated on creation: alphanumeric characters,
 underscores, and hyphens only, maximum 128 characters. Dots are rejected
-because they conflict with TOML key quoting. The new key block is
-appended to the schema file without reformatting existing content.
+because they conflict with TOML key quoting. Creation shares the
+`schema add` engine path, so it persists by round-tripping the schema
+TOML -- comments and custom formatting in the schema file are dropped,
+the same as any other `schema` write.
 
 ### Flags
 
@@ -4224,21 +4231,28 @@ The key name is validated the same way as elsewhere: alphanumeric,
 underscores, and hyphens only; maximum 128 characters; no dots. Defining
 a key that already exists is an error.
 
+Options are **type-appropriate**: passing an option that does not apply
+to the declared `--type` is rejected (exit code 4) rather than silently
+persisted. The valid pairings are: `--max-entries` (history, list);
+`--default` (counter, string, state); `--min` / `--max` (counter);
+`--fields` (state); `--data` (state, list). `--description` applies to
+every type.
+
 Only the schema file is written -- no data entry is created until the
 key is first written to.
 
 ### Flags
 
   **Flag**                          **Type**   **Description**
-  --------------------------------- ---------- --------------------------------------------------------------------------------------------------------------
+  --------------------------------- ---------- ----------------------------------------------------------------------------------------------------------------------------------
   `--type <type>`                   enum       Required. One of `counter`, `history`, `state`, `string`, `list`.
   `--max-entries <n>`               int        Cap for history/list keys; oldest entries drop when exceeded.
-  `--default <v>`                   str        Initial value for counter/string keys.
+  `--default <v>`                   str        Initial value for counter/string/state keys.
   `--min <n>`                       int        Minimum value for counters (clamped). Accepts negatives.
   `--max <n>`                       int        Maximum value for counters (clamped). Accepts negatives.
-  `--description <text>`            str        Human-readable description, shown by `schema list`.
+  `--description <text>`            str        Human-readable description, shown by `schema list`. Applies to all types.
   `--fields <a,b,c>`                list       Valid field names for a state key (comma-separated or repeatable).
-  `--data <name:type[:required]>`   str        Typed data-field definition (repeatable). `type` is one of `string`, `number`, `boolean`, `array`, `object`.
+  `--data <name:type[:required]>`   str        Typed data-field definition for state/list keys (repeatable). `type` is one of `string`, `number`, `boolean`, `array`, `object`.
 
 ### Examples
 
@@ -4315,6 +4329,17 @@ scope and any `--type` argument errors and points you at
 (deprecated) top-level `mx kv rename`. All entries, IDs, timestamps,
 structured data, and memory links are preserved.
 
+Options are **type-appropriate**, gated against the key's **existing**
+type: `--max-entries` (history, list); `--min` / `--max` (counter);
+`--add-field` (state, list). `--description` applies to any type.
+Passing an inapplicable option is rejected (exit code 4) rather than
+silently persisted -- you cannot, for example, bolt a data field onto a
+counter.
+
+A **no-op** update (no `--name` and no metadata flags set) is rejected
+with a notice (exit code 4) instead of needlessly rewriting the schema
+file -- which would drop comments for no benefit.
+
 Like `schema add`/`drop`, this round-trips the schema TOML (dropping
 comments). When only metadata changes (no `--name`), only the schema
 file is written, and the in-memory mutation is rolled back if that write
@@ -4323,13 +4348,13 @@ fails.
 ### Flags
 
   **Flag**                    **Type**   **Description**
-  --------------------------- ---------- -------------------------------------------------
+  --------------------------- ---------- ----------------------------------------------------------------------
   `--name <new>`              str        Rename the key (shares the `rename` path).
-  `--description <text>`      str        Replace the description; pass `""` to clear it.
+  `--description <text>`      str        Replace the description; pass `""` to clear it. Applies to any type.
   `--max-entries <n>`         int        New cap for history/list keys.
   `--min <n>`                 int        New minimum for counters. Accepts negatives.
   `--max <n>`                 int        New maximum for counters. Accepts negatives.
-  `--add-field <name:type>`   str        Add a new **optional** data field to the key.
+  `--add-field <name:type>`   str        Add a new **optional** data field to a state/list key.
 
 ### Examples
 
@@ -7801,18 +7826,29 @@ on `KvStore` (which holds a `schema_path` field alongside the existing
 `data_path`). The legacy top-level `kv keys` and `kv rename` verbs
 survive as deprecated aliases.
 
-The `add_key_to_schema()` method validates the key name (alphanumeric,
-underscores, hyphens; max 128 chars; no dots), appends a `[keys.<name>]`
-block to the TOML file without reformatting existing content, and
-re-parses the file to update the in-memory `Schema`. It handles
-`history`/`list` only and backs the `push --create <type>` inline
-shortcut. If the key already exists, the method is a no-op.
+The `add_key_def()` method is the single creation path, shared by both
+`kv schema add` and the `push --create <type>` inline shortcut. It
+validates the key name (alphanumeric, underscores, hyphens; max 128
+chars; no dots), accepts a fully-formed `KeyDef` so all five
+`ValueType`s can be declared with their type-appropriate options,
+inserts it in-memory, and persists via `save_schema()` (which
+round-trips the TOML, dropping comments). Duplicate or invalid names
+error. `push --create` constructs a history/list `KeyDef` and calls the
+same method -- its user-facing surface stays limited to those two types,
+but the engine path is unified (363 acceptance criterion).
 
-The `add_key_def()` method backs `kv schema add` and is the general
-path: it accepts a fully-formed `KeyDef` so all five `ValueType`s can be
-declared with their type-appropriate options, inserts it in-memory, and
-persists via `save_schema()` (which round-trips the TOML, dropping
-comments). Duplicate or invalid names error.
+Type-appropriate options are enforced at the CLI layer for both
+`schema add` and `schema update`: a `validate_type_options` gate rejects
+options that do not apply to the declared/existing `ValueType` (e.g.
+`--min` on a history key, `--add-field` on a counter) with exit code 4,
+before any persist. A no-op `schema update` (no flags set) is likewise
+rejected rather than rewriting the schema file.
+
+A legacy `add_key_to_schema()` method still exists as a standalone
+engine helper -- it appends a `[keys.<name>]` block to the TOML without
+reformatting, preserving comments, for `history`/`list` only. It is no
+longer wired to any CLI verb (it formerly backed `push --create`); it is
+retained for its existing tests and as an append-based alternative.
 
 The `drop_key()` method backs `kv schema drop`: it removes both the
 schema definition and the stored data entry. It follows the `rename_key`

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -271,7 +271,13 @@ mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
 mx kv get decisions --id kv-A3fB              # look up by entry ID
 
-# Auto-create a key in the schema and push in one step
+# Define, list, edit, and remove keys with the schema subcommands
+mx kv schema add puns --type history --max-entries 500
+mx kv schema list                             # (replaces 'kv keys')
+mx kv schema update puns --description "the good ones"
+mx kv schema drop puns --force                # removes definition + data
+
+# Auto-create a key in the schema and push in one step (inline shortcut)
 mx kv push puns "the joke" --create history
 mx kv push ideas "wild thought" --create list --max-entries 500
 
@@ -301,7 +307,7 @@ mx kv migrate projects --dry-run
 mx kv migrate projects --prune
 
 # Rename a key (preserves all entries and data)
-mx kv rename old_decisions archived_decisions
+mx kv schema update old_decisions --name archived_decisions
 
 # JSON output for scripting and jq piping
 mx kv last projects --count 5 --json | jq '.[].data.status'
@@ -2861,7 +2867,7 @@ Schema fields:
 `description`
 
 :   Optional. Human-readable description of the key's purpose. Displayed
-    as a third column by `mx kv keys`.
+    as a third column by `mx kv schema list`.
 
 `fields`
 
@@ -2875,6 +2881,11 @@ When a key does not exist in the schema, `--create history` or
 `--create list` appends a new `[keys.<name>]` block to the TOML file and
 reloads the in-memory schema. This avoids manual schema editing for
 simple cases. See push for details and validation rules.
+
+For defining keys of **any** type up front (not just `history`/`list`),
+and for removing or editing existing definitions, use the `mx kv schema`
+subcommands. `push --create` is an inline shortcut that routes through
+the same engine path as `schema add`.
 
 ### Agent keying
 
@@ -3127,6 +3138,11 @@ mx kv set decisions --id 17 --memory ""
 ```
 
 ## `mx kv keys`
+
+**Deprecated.** A thin alias for `mx kv schema list`. Output on stdout
+is unchanged (so existing scripts keep working), but a one-line
+deprecation notice is printed to stderr. Use `mx kv schema list`
+instead.
 
 List all keys defined in the schema with their types. Output is two
 columns: key name (left-aligned, 30 chars) and type. When a key has a
@@ -4135,6 +4151,11 @@ mx kv reset context
 
 ## `mx kv rename <old-key> <new-key>`
 
+**Deprecated.** Use `mx kv schema update <key> --name <new>` instead,
+which shares the exact same rename path. The top-level `mx kv rename`
+verb still works and prints a one-line deprecation notice to stderr; it
+is slated for removal in a future major version.
+
 Rename a key, preserving all entries and data. The old key is removed
 from both the schema (TOML) and data (JSON) files, and all its content
 -- type definition, constraints, entries, timestamps, structured data,
@@ -4157,6 +4178,179 @@ mx kv rename session_goal current_goal
 
 ``` bash
 mx kv rename old_decisions archived_decisions
+```
+
+## Schema management {#schema}
+
+All schema lifecycle operations -- listing, defining, removing, and
+editing key definitions -- live under the `mx kv schema` namespace. This
+consolidates what used to be scattered across `kv keys`,
+`kv push --create`, and `kv rename` (the latter two remain as ergonomic
+/ deprecated aliases).
+
+::: {.admonition .note}
+**NOTE:** Schema writes via `schema add`, `schema drop`, and
+`schema update` round-trip the TOML schema file through the serializer,
+which **drops comments and custom formatting**. This matches the
+existing behavior of `push --create`. If you hand-annotate your schema
+file, expect those annotations to be lost on the next schema-mutating
+command.
+:::
+
+### schema list
+
+## `mx kv schema list`
+
+List every key in the schema with its type and optional description.
+Output is identical to the (deprecated) `mx kv keys`: two columns -- key
+name (left-aligned, 30 chars) and type -- with the `description` shown
+as a third column when present.
+
+### Examples
+
+``` bash
+mx kv schema list
+```
+
+### schema add
+
+## `mx kv schema add <key> --type <type>`
+
+Define a new key of any of the five types. This is the first-class
+replacement for the buried `push --create` flag, which is retained as an
+inline shortcut and routes through the same engine path.
+
+The key name is validated the same way as elsewhere: alphanumeric,
+underscores, and hyphens only; maximum 128 characters; no dots. Defining
+a key that already exists is an error.
+
+Only the schema file is written -- no data entry is created until the
+key is first written to.
+
+### Flags
+
+  **Flag**                          **Type**   **Description**
+  --------------------------------- ---------- --------------------------------------------------------------------------------------------------------------
+  `--type <type>`                   enum       Required. One of `counter`, `history`, `state`, `string`, `list`.
+  `--max-entries <n>`               int        Cap for history/list keys; oldest entries drop when exceeded.
+  `--default <v>`                   str        Initial value for counter/string keys.
+  `--min <n>`                       int        Minimum value for counters (clamped). Accepts negatives.
+  `--max <n>`                       int        Maximum value for counters (clamped). Accepts negatives.
+  `--description <text>`            str        Human-readable description, shown by `schema list`.
+  `--fields <a,b,c>`                list       Valid field names for a state key (comma-separated or repeatable).
+  `--data <name:type[:required]>`   str        Typed data-field definition (repeatable). `type` is one of `string`, `number`, `boolean`, `array`, `object`.
+
+### Examples
+
+``` bash
+mx kv schema add builds --type counter --default 0 --min 0
+```
+
+``` bash
+mx kv schema add decisions --type history --max-entries 50
+```
+
+``` bash
+mx kv schema add context --type state --fields task,phase,blocker
+```
+
+``` bash
+mx kv schema add session_goal --type string --default "ship the docs"
+```
+
+``` bash
+mx kv schema add todos --type list --data "done:boolean"
+```
+
+### schema drop
+
+## `mx kv schema drop <key>`
+
+Remove a key's schema definition **and** its stored data entries in one
+operation (unlike `remove`, which only clears entries but leaves the key
+registered). This closes the orphaned-key gap: previously there was no
+way to fully delete a key short of hand-editing the TOML.
+
+`--force` is required when the key has stored entries; it is silently
+allowed for empty or never-written keys. Dropping an unregistered key is
+an error (exit code 1, key-not-found -- consistent with every other
+verb).
+
+Any `--memory` (`kn-`) links the key carried are outbound pointers with
+no reverse reference from the memory store, so dropping the key simply
+discards them. Nothing in the memory store is touched.
+
+Persistence follows the same transaction pattern as `rename`: the data
+file is written first, then the schema; in-memory state is rolled back
+if the data write fails.
+
+### Flags
+
+  **Flag**    **Type**   **Description**
+  ----------- ---------- -------------------------------------------------
+  `--force`   flag       Required to drop a key that has stored entries.
+
+### Examples
+
+``` bash
+mx kv schema drop scratch_key
+```
+
+``` bash
+mx kv schema drop old_decisions --force
+```
+
+### schema update
+
+## `mx kv schema update <key>`
+
+Apply **safe** metadata changes to an existing key's definition. Scoped
+to non-destructive edits.
+
+Changing a key's `--type` is **forbidden** -- type changes are out of
+scope and any `--type` argument errors and points you at
+`mx kv migrate`. There is no `--force` override.
+
+`--name` renames the key, delegating to the exact same path as the
+(deprecated) top-level `mx kv rename`. All entries, IDs, timestamps,
+structured data, and memory links are preserved.
+
+Like `schema add`/`drop`, this round-trips the schema TOML (dropping
+comments). When only metadata changes (no `--name`), only the schema
+file is written, and the in-memory mutation is rolled back if that write
+fails.
+
+### Flags
+
+  **Flag**                    **Type**   **Description**
+  --------------------------- ---------- -------------------------------------------------
+  `--name <new>`              str        Rename the key (shares the `rename` path).
+  `--description <text>`      str        Replace the description; pass `""` to clear it.
+  `--max-entries <n>`         int        New cap for history/list keys.
+  `--min <n>`                 int        New minimum for counters. Accepts negatives.
+  `--max <n>`                 int        New maximum for counters. Accepts negatives.
+  `--add-field <name:type>`   str        Add a new **optional** data field to the key.
+
+### Examples
+
+``` bash
+mx kv schema update builds --description "successful CI builds"
+```
+
+``` bash
+mx kv schema update decisions --max-entries 100
+```
+
+``` bash
+mx kv schema update warmth --min -10 --max 100
+```
+
+``` bash
+mx kv schema update decisions --add-field "author:string"
+```
+
+``` bash
+mx kv schema update session_goal --name current_goal
 ```
 
 ## Memory linking
@@ -7601,14 +7795,38 @@ back-filled on first load (IDs are generated, data and memory default to
 
 ### Schema mutation
 
-The `KvStore` struct holds a `schema_path` field alongside the existing
-`data_path`. The `add_key_to_schema()` method validates the key name
-(alphanumeric, underscores, hyphens; max 128 chars; no dots), appends a
-`[keys.<name>]` block to the TOML file without reformatting existing
-content, and re-parses the file to update the in-memory `Schema`. This
-is exposed through `push --create <type>` at the CLI layer, where the
-handler calls `add_key_to_schema` before the normal push path. If the
-key already exists, the method is a no-op.
+Schema lifecycle operations are exposed at the CLI layer under the
+`mx kv schema [list | add | drop | update]` namespace, backed by methods
+on `KvStore` (which holds a `schema_path` field alongside the existing
+`data_path`). The legacy top-level `kv keys` and `kv rename` verbs
+survive as deprecated aliases.
+
+The `add_key_to_schema()` method validates the key name (alphanumeric,
+underscores, hyphens; max 128 chars; no dots), appends a `[keys.<name>]`
+block to the TOML file without reformatting existing content, and
+re-parses the file to update the in-memory `Schema`. It handles
+`history`/`list` only and backs the `push --create <type>` inline
+shortcut. If the key already exists, the method is a no-op.
+
+The `add_key_def()` method backs `kv schema add` and is the general
+path: it accepts a fully-formed `KeyDef` so all five `ValueType`s can be
+declared with their type-appropriate options, inserts it in-memory, and
+persists via `save_schema()` (which round-trips the TOML, dropping
+comments). Duplicate or invalid names error.
+
+The `drop_key()` method backs `kv schema drop`: it removes both the
+schema definition and the stored data entry. It follows the `rename_key`
+transaction pattern -- mutate in-memory fully, persist data first then
+schema, roll back on data-write failure. The handler enforces `--force`
+for keys with stored content (`key_has_content()`) and returns
+`KeyNotFound` for unregistered keys. Outbound `kn-` memory links are
+simply discarded; the memory store is never touched.
+
+The `update_key_meta()` method backs `kv schema update` for **safe**
+metadata edits (description, `max_entries`, `min`/`max`, adding an
+optional data field). Type changes are not representable here -- they
+are forbidden and routed to `kv migrate` at the CLI layer, with no
+override. A `--name` argument instead delegates to `rename_key`.
 
 The `rename_key()` method moves a key from one name to another in both
 the schema and data files. It validates the new name, checks that the
@@ -7617,7 +7835,8 @@ in-memory entries before persisting. Data is written first (higher-value
 file), then schema. If the data write fails, in-memory mutations are
 rolled back. Entry IDs are stable across renames -- they were hashed
 from the original key name at creation time and are never regenerated.
-This is exposed through `mx kv rename <old> <new>` at the CLI layer.
+It is shared by both `mx kv schema update <key> --name <new>` and the
+deprecated `mx kv rename <old> <new>`.
 
 ### Per-agent keying
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -766,18 +766,28 @@ Schema lifecycle operations are exposed at the CLI layer under the
 `data_path`). The legacy top-level `kv keys` and `kv rename` verbs survive as
 deprecated aliases.
 
-The `add_key_to_schema()` method validates the key name (alphanumeric,
-underscores, hyphens; max 128 chars; no dots), appends a `[keys.<name>]` block
-to the TOML file without reformatting existing content, and re-parses the file
-to update the in-memory `Schema`. It handles `history`/`list` only and backs
-the `push --create <type>` inline shortcut. If the key already exists, the
-method is a no-op.
-
-The `add_key_def()` method backs `kv schema add` and is the general path: it
+The `add_key_def()` method is the single creation path, shared by both
+`kv schema add` and the `push --create <type>` inline shortcut. It validates
+the key name (alphanumeric, underscores, hyphens; max 128 chars; no dots),
 accepts a fully-formed `KeyDef` so all five `ValueType`s can be declared with
 their type-appropriate options, inserts it in-memory, and persists via
 `save_schema()` (which round-trips the TOML, dropping comments). Duplicate or
-invalid names error.
+invalid names error. `push --create` constructs a history/list `KeyDef` and
+calls the same method -- its user-facing surface stays limited to those two
+types, but the engine path is unified (#363 acceptance criterion).
+
+Type-appropriate options are enforced at the CLI layer for both `schema add`
+and `schema update`: a `validate_type_options` gate rejects options that do
+not apply to the declared/existing `ValueType` (e.g. `--min` on a history key,
+`--add-field` on a counter) with exit code 4, before any persist. A no-op
+`schema update` (no flags set) is likewise rejected rather than rewriting the
+schema file.
+
+A legacy `add_key_to_schema()` method still exists as a standalone engine
+helper -- it appends a `[keys.<name>]` block to the TOML without reformatting,
+preserving comments, for `history`/`list` only. It is no longer wired to any
+CLI verb (it formerly backed `push --create`); it is retained for its existing
+tests and as an append-based alternative.
 
 The `drop_key()` method backs `kv schema drop`: it removes both the schema
 definition and the stored data entry. It follows the `rename_key` transaction

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -760,14 +760,37 @@ back-filled on first load (IDs are generated, data and memory default to
 
 === Schema mutation
 
-The `KvStore` struct holds a `schema_path` field alongside the existing
-`data_path`. The `add_key_to_schema()` method validates the key name
-(alphanumeric, underscores, hyphens; max 128 chars; no dots), appends a
-`[keys.<name>]` block to the TOML file without reformatting existing
-content, and re-parses the file to update the in-memory `Schema`. This is
-exposed through `push --create <type>` at the CLI layer, where the handler
-calls `add_key_to_schema` before the normal push path. If the key already
-exists, the method is a no-op.
+Schema lifecycle operations are exposed at the CLI layer under the
+`mx kv schema [list | add | drop | update]` namespace, backed by methods on
+`KvStore` (which holds a `schema_path` field alongside the existing
+`data_path`). The legacy top-level `kv keys` and `kv rename` verbs survive as
+deprecated aliases.
+
+The `add_key_to_schema()` method validates the key name (alphanumeric,
+underscores, hyphens; max 128 chars; no dots), appends a `[keys.<name>]` block
+to the TOML file without reformatting existing content, and re-parses the file
+to update the in-memory `Schema`. It handles `history`/`list` only and backs
+the `push --create <type>` inline shortcut. If the key already exists, the
+method is a no-op.
+
+The `add_key_def()` method backs `kv schema add` and is the general path: it
+accepts a fully-formed `KeyDef` so all five `ValueType`s can be declared with
+their type-appropriate options, inserts it in-memory, and persists via
+`save_schema()` (which round-trips the TOML, dropping comments). Duplicate or
+invalid names error.
+
+The `drop_key()` method backs `kv schema drop`: it removes both the schema
+definition and the stored data entry. It follows the `rename_key` transaction
+pattern -- mutate in-memory fully, persist data first then schema, roll back on
+data-write failure. The handler enforces `--force` for keys with stored content
+(`key_has_content()`) and returns `KeyNotFound` for unregistered keys. Outbound
+`kn-` memory links are simply discarded; the memory store is never touched.
+
+The `update_key_meta()` method backs `kv schema update` for *safe* metadata
+edits (description, `max_entries`, `min`/`max`, adding an optional data field).
+Type changes are not representable here -- they are forbidden and routed to
+`kv migrate` at the CLI layer, with no override. A `--name` argument instead
+delegates to `rename_key`.
 
 The `rename_key()` method moves a key from one name to another in both the
 schema and data files. It validates the new name, checks that the old key
@@ -775,8 +798,9 @@ exists and the new key does not, then atomically swaps the in-memory
 entries before persisting. Data is written first (higher-value file), then
 schema. If the data write fails, in-memory mutations are rolled back. Entry
 IDs are stable across renames -- they were hashed from the original key
-name at creation time and are never regenerated. This is exposed through
-`mx kv rename <old> <new>` at the CLI layer.
+name at creation time and are never regenerated. It is shared by both
+`mx kv schema update <key> --name <new>` and the deprecated
+`mx kv rename <old> <new>`.
 
 === Per-agent keying
 

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -141,7 +141,13 @@ mx kv last decisions --since 1w
 mx kv count decisions --day 2026-05-07
 mx kv get decisions --id kv-A3fB              # look up by entry ID
 
-# Auto-create a key in the schema and push in one step
+# Define, list, edit, and remove keys with the schema subcommands
+mx kv schema add puns --type history --max-entries 500
+mx kv schema list                             # (replaces 'kv keys')
+mx kv schema update puns --description "the good ones"
+mx kv schema drop puns --force                # removes definition + data
+
+# Auto-create a key in the schema and push in one step (inline shortcut)
 mx kv push puns "the joke" --create history
 mx kv push ideas "wild thought" --create list --max-entries 500
 
@@ -171,7 +177,7 @@ mx kv migrate projects --dry-run
 mx kv migrate projects --prune
 
 # Rename a key (preserves all entries and data)
-mx kv rename old_decisions archived_decisions
+mx kv schema update old_decisions --name archived_decisions
 
 # JSON output for scripting and jq piping
 mx kv last projects --count 5 --json | jq '.[].data.status'

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -92,14 +92,19 @@ Schema fields:
 
 Keys can be added to the schema on the fly with `mx kv push --create`.
 When a key does not exist in the schema, `--create history` or
-`--create list` appends a new `[keys.<name>]` block to the TOML file
-and reloads the in-memory schema. This avoids manual schema editing for
-simple cases. See #link(<push>)[push] for details and validation rules.
+`--create list` defines it and reloads the in-memory schema. This avoids
+manual schema editing for simple cases. See #link(<push>)[push] for
+details and validation rules.
 
 For defining keys of *any* type up front (not just `history`/`list`), and
 for removing or editing existing definitions, use the
 #link(<schema>)[`mx kv schema`] subcommands. `push --create` is an inline
-shortcut that routes through the same engine path as `schema add`.
+shortcut whose user-facing surface stays limited to `history`/`list`, but
+it routes through the *same* engine path as `schema add` (the shared
+`add_key_def` method). One consequence: like every `schema` write, the
+create rewrites the schema file by round-tripping the TOML, which drops
+comments and custom formatting. If you hand-annotate your schema, expect
+those annotations to be lost when a key is created via `--create`.
 
 === Agent keying
 
@@ -325,8 +330,10 @@ filtering (`--where` on queries). Only lists support `pop`. Only history support
 
   Key names are validated on creation: alphanumeric characters, underscores,
   and hyphens only, maximum 128 characters. Dots are rejected because they
-  conflict with TOML key quoting. The new key block is appended to the
-  schema file without reformatting existing content.],
+  conflict with TOML key quoting. Creation shares the `schema add` engine
+  path, so it persists by round-tripping the schema TOML -- comments and
+  custom formatting in the schema file are dropped, the same as any other
+  `schema` write.],
   flags: (
     ([`--data <json>`], [string], [Attach a JSON object to the entry. Must be a valid JSON object (not an array, string, or other type).]),
     ([`--memory <kn-id>`], [string], [Link this entry to a memory knowledge node (e.g. `kn-abc123`). Resolved when `--memory` is passed on read commands.]),
@@ -1009,17 +1016,23 @@ annotations to be lost on the next schema-mutating command.]
   underscores, and hyphens only; maximum 128 characters; no dots. Defining a
   key that already exists is an error.
 
+  Options are *type-appropriate*: passing an option that does not apply to the
+  declared `--type` is rejected (exit code 4) rather than silently persisted.
+  The valid pairings are: `--max-entries` (history, list); `--default`
+  (counter, string, state); `--min` / `--max` (counter); `--fields` (state);
+  `--data` (state, list). `--description` applies to every type.
+
   Only the schema file is written -- no data entry is created until the key is
   first written to.],
   flags: (
     ([`--type <type>`], [enum], [Required. One of `counter`, `history`, `state`, `string`, `list`.]),
     ([`--max-entries <n>`], [int], [Cap for history/list keys; oldest entries drop when exceeded.]),
-    ([`--default <v>`], [str], [Initial value for counter/string keys.]),
+    ([`--default <v>`], [str], [Initial value for counter/string/state keys.]),
     ([`--min <n>`], [int], [Minimum value for counters (clamped). Accepts negatives.]),
     ([`--max <n>`], [int], [Maximum value for counters (clamped). Accepts negatives.]),
-    ([`--description <text>`], [str], [Human-readable description, shown by `schema list`.]),
+    ([`--description <text>`], [str], [Human-readable description, shown by `schema list`. Applies to all types.]),
     ([`--fields <a,b,c>`], [list], [Valid field names for a state key (comma-separated or repeatable).]),
-    ([`--data <name:type[:required]>`], [str], [Typed data-field definition (repeatable). `type` is one of `string`, `number`, `boolean`, `array`, `object`.]),
+    ([`--data <name:type[:required]>`], [str], [Typed data-field definition for state/list keys (repeatable). `type` is one of `string`, `number`, `boolean`, `array`, `object`.]),
   ),
   examples: (
     "mx kv schema add builds --type counter --default 0 --min 0",
@@ -1074,16 +1087,26 @@ annotations to be lost on the next schema-mutating command.]
   (deprecated) top-level `mx kv rename`. All entries, IDs, timestamps,
   structured data, and memory links are preserved.
 
+  Options are *type-appropriate*, gated against the key's *existing* type:
+  `--max-entries` (history, list); `--min` / `--max` (counter); `--add-field`
+  (state, list). `--description` applies to any type. Passing an inapplicable
+  option is rejected (exit code 4) rather than silently persisted -- you cannot,
+  for example, bolt a data field onto a counter.
+
+  A *no-op* update (no `--name` and no metadata flags set) is rejected with a
+  notice (exit code 4) instead of needlessly rewriting the schema file -- which
+  would drop comments for no benefit.
+
   Like `schema add`/`drop`, this round-trips the schema TOML (dropping
   comments). When only metadata changes (no `--name`), only the schema file is
   written, and the in-memory mutation is rolled back if that write fails.],
   flags: (
     ([`--name <new>`], [str], [Rename the key (shares the `rename` path).]),
-    ([`--description <text>`], [str], [Replace the description; pass `""` to clear it.]),
+    ([`--description <text>`], [str], [Replace the description; pass `""` to clear it. Applies to any type.]),
     ([`--max-entries <n>`], [int], [New cap for history/list keys.]),
     ([`--min <n>`], [int], [New minimum for counters. Accepts negatives.]),
     ([`--max <n>`], [int], [New maximum for counters. Accepts negatives.]),
-    ([`--add-field <name:type>`], [str], [Add a new *optional* data field to the key.]),
+    ([`--add-field <name:type>`], [str], [Add a new *optional* data field to a state/list key.]),
   ),
   examples: (
     "mx kv schema update builds --description \"successful CI builds\"",

--- a/docs/src/kv.typ
+++ b/docs/src/kv.typ
@@ -85,7 +85,7 @@ Schema fields:
 / `min`: Optional. Minimum value for counters (clamped, never errors).
 / `max`: Optional. Maximum value for counters (clamped, never errors).
 / `max_entries`: Optional. Maximum entries for history and list types. Oldest entries are dropped when exceeded. Omit to allow unbounded growth.
-/ `description`: Optional. Human-readable description of the key's purpose. Displayed as a third column by `mx kv keys`.
+/ `description`: Optional. Human-readable description of the key's purpose. Displayed as a third column by `mx kv schema list`.
 / `fields`: Optional. List of valid field names for state types. Writes to unlisted fields are rejected.
 
 === Auto-creating keys
@@ -95,6 +95,11 @@ When a key does not exist in the schema, `--create history` or
 `--create list` appends a new `[keys.<name>]` block to the TOML file
 and reloads the in-memory schema. This avoids manual schema editing for
 simple cases. See #link(<push>)[push] for details and validation rules.
+
+For defining keys of *any* type up front (not just `history`/`list`), and
+for removing or editing existing definitions, use the
+#link(<schema>)[`mx kv schema`] subcommands. `push --create` is an inline
+shortcut that routes through the same engine path as `schema add`.
 
 === Agent keying
 
@@ -216,7 +221,12 @@ KV commands use structured exit codes for scripting:
 
 #command(
   "mx kv keys",
-  [List all keys defined in the schema with their types. Output is
+  [*Deprecated.* A thin alias for #link(<schema-list>)[`mx kv schema list`].
+  Output on stdout is unchanged (so existing scripts keep working), but a
+  one-line deprecation notice is printed to stderr. Use `mx kv schema list`
+  instead.
+
+  List all keys defined in the schema with their types. Output is
   two columns: key name (left-aligned, 30 chars) and type. When a key
   has a `description` in the schema, it is shown as a third column.],
   examples: (
@@ -937,7 +947,12 @@ manual action is needed.
 
 #command(
   "mx kv rename <old-key> <new-key>",
-  [Rename a key, preserving all entries and data. The old key is removed
+  [*Deprecated.* Use #link(<schema-update>)[`mx kv schema update <key> --name <new>`]
+  instead, which shares the exact same rename path. The top-level
+  `mx kv rename` verb still works and prints a one-line deprecation notice to
+  stderr; it is slated for removal in a future major version.
+
+  Rename a key, preserving all entries and data. The old key is removed
   from both the schema (TOML) and data (JSON) files, and all its content
   -- type definition, constraints, entries, timestamps, structured data,
   memory links -- is moved to the new key name. Entry IDs are stable and
@@ -953,6 +968,129 @@ manual action is needed.
   examples: (
     "mx kv rename session_goal current_goal",
     "mx kv rename old_decisions archived_decisions",
+  ),
+)
+
+== Schema management <schema>
+
+All schema lifecycle operations -- listing, defining, removing, and editing
+key definitions -- live under the `mx kv schema` namespace. This consolidates
+what used to be scattered across `kv keys`, `kv push --create`, and `kv rename`
+(the latter two remain as ergonomic / deprecated aliases).
+
+#admonition[Note][Schema writes via `schema add`, `schema drop`, and
+`schema update` round-trip the TOML schema file through the serializer, which
+*drops comments and custom formatting*. This matches the existing behavior of
+`push --create`. If you hand-annotate your schema file, expect those
+annotations to be lost on the next schema-mutating command.]
+
+=== schema list <schema-list>
+
+#command(
+  "mx kv schema list",
+  [List every key in the schema with its type and optional description.
+  Output is identical to the (deprecated) `mx kv keys`: two columns -- key
+  name (left-aligned, 30 chars) and type -- with the `description` shown as a
+  third column when present.],
+  examples: (
+    "mx kv schema list",
+  ),
+)
+
+=== schema add <schema-add>
+
+#command(
+  "mx kv schema add <key> --type <type>",
+  [Define a new key of any of the five types. This is the first-class
+  replacement for the buried `push --create` flag, which is retained as an
+  inline shortcut and routes through the same engine path.
+
+  The key name is validated the same way as elsewhere: alphanumeric,
+  underscores, and hyphens only; maximum 128 characters; no dots. Defining a
+  key that already exists is an error.
+
+  Only the schema file is written -- no data entry is created until the key is
+  first written to.],
+  flags: (
+    ([`--type <type>`], [enum], [Required. One of `counter`, `history`, `state`, `string`, `list`.]),
+    ([`--max-entries <n>`], [int], [Cap for history/list keys; oldest entries drop when exceeded.]),
+    ([`--default <v>`], [str], [Initial value for counter/string keys.]),
+    ([`--min <n>`], [int], [Minimum value for counters (clamped). Accepts negatives.]),
+    ([`--max <n>`], [int], [Maximum value for counters (clamped). Accepts negatives.]),
+    ([`--description <text>`], [str], [Human-readable description, shown by `schema list`.]),
+    ([`--fields <a,b,c>`], [list], [Valid field names for a state key (comma-separated or repeatable).]),
+    ([`--data <name:type[:required]>`], [str], [Typed data-field definition (repeatable). `type` is one of `string`, `number`, `boolean`, `array`, `object`.]),
+  ),
+  examples: (
+    "mx kv schema add builds --type counter --default 0 --min 0",
+    "mx kv schema add decisions --type history --max-entries 50",
+    "mx kv schema add context --type state --fields task,phase,blocker",
+    "mx kv schema add session_goal --type string --default \"ship the docs\"",
+    "mx kv schema add todos --type list --data \"done:boolean\"",
+  ),
+)
+
+=== schema drop <schema-drop>
+
+#command(
+  "mx kv schema drop <key>",
+  [Remove a key's schema definition *and* its stored data entries in one
+  operation (unlike `remove`, which only clears entries but leaves the key
+  registered). This closes the orphaned-key gap: previously there was no way
+  to fully delete a key short of hand-editing the TOML.
+
+  `--force` is required when the key has stored entries; it is silently
+  allowed for empty or never-written keys. Dropping an unregistered key is an
+  error (exit code 1, key-not-found -- consistent with every other verb).
+
+  Any `--memory` (`kn-`) links the key carried are outbound pointers with no
+  reverse reference from the memory store, so dropping the key simply discards
+  them. Nothing in the memory store is touched.
+
+  Persistence follows the same transaction pattern as `rename`: the data file
+  is written first, then the schema; in-memory state is rolled back if the
+  data write fails.],
+  flags: (
+    ([`--force`], [flag], [Required to drop a key that has stored entries.]),
+  ),
+  examples: (
+    "mx kv schema drop scratch_key",
+    "mx kv schema drop old_decisions --force",
+  ),
+)
+
+=== schema update <schema-update>
+
+#command(
+  "mx kv schema update <key>",
+  [Apply *safe* metadata changes to an existing key's definition. Scoped to
+  non-destructive edits.
+
+  Changing a key's `--type` is *forbidden* -- type changes are out of scope
+  and any `--type` argument errors and points you at `mx kv migrate`. There is
+  no `--force` override.
+
+  `--name` renames the key, delegating to the exact same path as the
+  (deprecated) top-level `mx kv rename`. All entries, IDs, timestamps,
+  structured data, and memory links are preserved.
+
+  Like `schema add`/`drop`, this round-trips the schema TOML (dropping
+  comments). When only metadata changes (no `--name`), only the schema file is
+  written, and the in-memory mutation is rolled back if that write fails.],
+  flags: (
+    ([`--name <new>`], [str], [Rename the key (shares the `rename` path).]),
+    ([`--description <text>`], [str], [Replace the description; pass `""` to clear it.]),
+    ([`--max-entries <n>`], [int], [New cap for history/list keys.]),
+    ([`--min <n>`], [int], [New minimum for counters. Accepts negatives.]),
+    ([`--max <n>`], [int], [New maximum for counters. Accepts negatives.]),
+    ([`--add-field <name:type>`], [str], [Add a new *optional* data field to the key.]),
+  ),
+  examples: (
+    "mx kv schema update builds --description \"successful CI builds\"",
+    "mx kv schema update decisions --max-entries 100",
+    "mx kv schema update warmth --min -10 --max 100",
+    "mx kv schema update decisions --add-field \"author:string\"",
+    "mx kv schema update session_goal --name current_goal",
   ),
 )
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1770,6 +1770,21 @@ pub enum CreateType {
     List,
 }
 
+/// All five schema value types, for `kv schema add --type`.
+#[derive(Clone, Debug, ValueEnum)]
+pub enum SchemaType {
+    /// Counter (integer, optional min/max clamp)
+    Counter,
+    /// History (append-only, timestamped)
+    History,
+    /// State (named string fields)
+    State,
+    /// String (single scalar value)
+    String,
+    /// List (push/pop, ordered)
+    List,
+}
+
 /// Output format for `kv dump`.
 #[derive(Clone, Debug, ValueEnum)]
 pub enum DumpFormat {
@@ -2084,6 +2099,7 @@ pub enum KvCommands {
     },
 
     /// Rename a key, preserving all entries and data
+    /// (deprecated: use 'mx kv schema update <key> --name <new>')
     Rename {
         /// Current key name
         old_key: String,
@@ -2092,7 +2108,103 @@ pub enum KvCommands {
     },
 
     /// List all defined keys with their types and descriptions
+    /// (deprecated: use 'mx kv schema list')
     Keys,
+
+    /// Manage the schema: list, add, drop, and update key definitions
+    Schema {
+        #[command(subcommand)]
+        command: KvSchemaCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum KvSchemaCommands {
+    /// List all defined keys with their types and descriptions
+    List,
+
+    /// Define a new key of any type
+    Add {
+        /// Key name
+        key: String,
+
+        /// Value type
+        #[arg(long, value_enum)]
+        r#type: SchemaType,
+
+        /// Maximum entries (history/list); oldest dropped when exceeded
+        #[arg(long)]
+        max_entries: Option<usize>,
+
+        /// Initial value (counter/string)
+        #[arg(long)]
+        default: Option<String>,
+
+        /// Minimum value, clamped (counter)
+        #[arg(long, allow_hyphen_values = true)]
+        min: Option<i64>,
+
+        /// Maximum value, clamped (counter)
+        #[arg(long, allow_hyphen_values = true)]
+        max: Option<i64>,
+
+        /// Human-readable description of the key's purpose
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Valid field names for a state key (repeatable or comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        fields: Vec<String>,
+
+        /// Typed data field definition: name:type[:required] (repeatable).
+        /// type is one of string|number|boolean|array|object.
+        #[arg(long = "data")]
+        data: Vec<String>,
+    },
+
+    /// Remove a key's schema definition and its stored data entries
+    Drop {
+        /// Key name
+        key: String,
+
+        /// Required to drop a key that has stored entries
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Apply safe metadata changes to an existing key (no type changes)
+    Update {
+        /// Key name
+        key: String,
+
+        /// Rename the key (shares the same path as 'mx kv rename')
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New description (pass "" to clear)
+        #[arg(long)]
+        description: Option<String>,
+
+        /// New max entries (history/list)
+        #[arg(long)]
+        max_entries: Option<usize>,
+
+        /// New minimum value (counter)
+        #[arg(long, allow_hyphen_values = true)]
+        min: Option<i64>,
+
+        /// New maximum value (counter)
+        #[arg(long, allow_hyphen_values = true)]
+        max: Option<i64>,
+
+        /// Add a new optional data field: name:type (e.g. note:string)
+        #[arg(long = "add-field")]
+        add_field: Option<String>,
+
+        /// Forbidden: type changes are not allowed; use 'mx kv migrate'
+        #[arg(long = "type")]
+        type_change: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -4,8 +4,11 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 
-use crate::cli::{CreateType, DumpFormat, KvCommands};
-use crate::kv::{self, IdRef, KvError, KvStore, resolve_time_range};
+use crate::cli::{CreateType, DumpFormat, KvCommands, KvSchemaCommands, SchemaType};
+use crate::kv::{
+    self, DataFieldDef, DataFieldType, IdRef, KeyDef, KvError, KvStore, ValueType,
+    resolve_time_range,
+};
 
 /// Map a KvError to the appropriate exit code.
 fn exit_code_for(err: &KvError) -> Option<i32> {
@@ -1182,23 +1185,236 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             Err(e) => handle_kv_err(e),
         },
 
-        KvCommands::Rename { old_key, new_key } => match store.rename_key(&old_key, &new_key) {
-            Ok(()) => {
-                println!("Renamed {} to {}", old_key, new_key);
-                Ok(kv::EXIT_OK)
-            }
-            Err(e) => handle_kv_err(e),
-        },
+        KvCommands::Rename { old_key, new_key } => {
+            eprintln!(
+                "note: 'mx kv rename' is deprecated; use 'mx kv schema update {} --name {}'",
+                old_key, new_key
+            );
+            rename_key_handler(&mut store, &old_key, &new_key)
+        }
 
         KvCommands::Keys => {
-            let keys = store.keys();
-            for (name, vtype, desc) in &keys {
-                match desc {
-                    Some(d) => println!("{:30} {:10} {}", name, vtype, d),
-                    None => println!("{:30} {:10}", name, vtype),
+            eprintln!("note: 'mx kv keys' is deprecated; use 'mx kv schema list'");
+            schema_list_handler(&store);
+            Ok(kv::EXIT_OK)
+        }
+
+        KvCommands::Schema { command } => handle_kv_schema(&mut store, command),
+    }
+}
+
+/// Print the schema key listing (shared by `schema list` and the deprecated
+/// `kv keys` alias). Output on stdout is byte-identical between the two.
+fn schema_list_handler(store: &KvStore) {
+    for (name, vtype, desc) in &store.keys() {
+        match desc {
+            Some(d) => println!("{:30} {:10} {}", name, vtype, d),
+            None => println!("{:30} {:10}", name, vtype),
+        }
+    }
+}
+
+/// Rename a key (shared by `schema update --name` and the deprecated
+/// top-level `kv rename`). Both route through `KvStore::rename_key`.
+fn rename_key_handler(store: &mut KvStore, old_key: &str, new_key: &str) -> Result<i32> {
+    match store.rename_key(old_key, new_key) {
+        Ok(()) => {
+            println!("Renamed {} to {}", old_key, new_key);
+            Ok(kv::EXIT_OK)
+        }
+        Err(e) => handle_kv_err(e),
+    }
+}
+
+/// Parse a `--data name:type[:required]` field definition spec.
+fn parse_data_field_spec(spec: &str) -> Result<(String, DataFieldDef), String> {
+    let parts: Vec<&str> = spec.split(':').collect();
+    if parts.len() < 2 || parts.len() > 3 {
+        return Err(format!(
+            "invalid --data spec '{}': expected name:type[:required]",
+            spec
+        ));
+    }
+    let name = parts[0].trim();
+    if name.is_empty() {
+        return Err(format!("invalid --data spec '{}': empty field name", spec));
+    }
+    let field_type = match parts[1].trim().to_lowercase().as_str() {
+        "string" => DataFieldType::String,
+        "number" => DataFieldType::Number,
+        "boolean" => DataFieldType::Boolean,
+        "array" => DataFieldType::Array,
+        "object" => DataFieldType::Object,
+        other => {
+            return Err(format!(
+                "invalid --data type '{}': expected string|number|boolean|array|object",
+                other
+            ));
+        }
+    };
+    let required = match parts.get(2) {
+        None => false,
+        Some(r) => match r.trim().to_lowercase().as_str() {
+            "required" | "true" => true,
+            "optional" | "false" | "" => false,
+            other => {
+                return Err(format!(
+                    "invalid --data required flag '{}': expected 'required' or 'optional'",
+                    other
+                ));
+            }
+        },
+    };
+    Ok((
+        name.to_string(),
+        DataFieldDef {
+            field_type,
+            required,
+            default: None,
+        },
+    ))
+}
+
+fn handle_kv_schema(store: &mut KvStore, command: KvSchemaCommands) -> Result<i32> {
+    match command {
+        KvSchemaCommands::List => {
+            schema_list_handler(store);
+            Ok(kv::EXIT_OK)
+        }
+
+        KvSchemaCommands::Add {
+            key,
+            r#type,
+            max_entries,
+            default,
+            min,
+            max,
+            description,
+            fields,
+            data,
+        } => {
+            let value_type = match r#type {
+                SchemaType::Counter => ValueType::Counter,
+                SchemaType::History => ValueType::History,
+                SchemaType::State => ValueType::State,
+                SchemaType::String => ValueType::String,
+                SchemaType::List => ValueType::List,
+            };
+
+            // Parse typed --data field defs.
+            let mut data_defs = std::collections::BTreeMap::new();
+            for spec in &data {
+                match parse_data_field_spec(spec) {
+                    Ok((name, def)) => {
+                        data_defs.insert(name, def);
+                    }
+                    Err(msg) => {
+                        eprintln!("Error: {}", msg);
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
                 }
             }
-            Ok(kv::EXIT_OK)
+
+            let def = KeyDef {
+                value_type,
+                min,
+                max,
+                default,
+                max_entries,
+                description,
+                fields: if fields.is_empty() { None } else { Some(fields) },
+                data: if data_defs.is_empty() {
+                    None
+                } else {
+                    Some(data_defs)
+                },
+            };
+
+            match store.add_key_def(&key, def) {
+                Ok(()) => {
+                    println!("Added {} ({})", key, value_type);
+                    Ok(kv::EXIT_OK)
+                }
+                Err(e) => handle_kv_err(e),
+            }
+        }
+
+        KvSchemaCommands::Drop { key, force } => {
+            // Unregistered key -> KeyNotFound (exit 1), consistent with every
+            // other verb. (Issue prose says "exit 3" but the canonical KV
+            // exit-code table maps KeyNotFound -> 1; see PR notes.)
+            if !store.schema.keys.contains_key(&key) {
+                return handle_kv_err(KvError::KeyNotFound(key.clone()));
+            }
+
+            // Non-empty keys require --force; silent for empty/never-written.
+            if store.key_has_content(&key) && !force {
+                eprintln!(
+                    "Error: key '{}' has stored entries; pass --force to drop it and its data",
+                    key
+                );
+                return Ok(kv::EXIT_INVALID_INPUT);
+            }
+
+            match store.drop_key(&key) {
+                Ok(()) => {
+                    println!("Dropped {}", key);
+                    Ok(kv::EXIT_OK)
+                }
+                Err(e) => handle_kv_err(e),
+            }
+        }
+
+        KvSchemaCommands::Update {
+            key,
+            name,
+            description,
+            max_entries,
+            min,
+            max,
+            add_field,
+            type_change,
+        } => {
+            // Forbidden: type changes route to `kv migrate`, no override.
+            if type_change.is_some() {
+                eprintln!(
+                    "Error: changing a key's type is not supported by 'schema update'. \
+                     Type changes are out of scope; use 'mx kv migrate' to reshape data."
+                );
+                return Ok(kv::EXIT_INVALID_INPUT);
+            }
+
+            // --name delegates to the shared rename path.
+            if let Some(new_name) = name {
+                return rename_key_handler(store, &key, &new_name);
+            }
+
+            // Parse --add-field if present.
+            let add_field_def = match add_field {
+                Some(ref spec) => match parse_data_field_spec(spec) {
+                    Ok(parsed) => Some(parsed),
+                    Err(msg) => {
+                        eprintln!("Error: {}", msg);
+                        return Ok(kv::EXIT_INVALID_INPUT);
+                    }
+                },
+                None => None,
+            };
+
+            match store.update_key_meta(
+                &key,
+                description,
+                max_entries,
+                min,
+                max,
+                add_field_def,
+            ) {
+                Ok(()) => {
+                    println!("Updated {}", key);
+                    Ok(kv::EXIT_OK)
+                }
+                Err(e) => handle_kv_err(e),
+            }
         }
     }
 }
@@ -1210,6 +1426,52 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- parse_data_field_spec (schema add/update --data, --add-field) --
+
+    #[test]
+    fn parse_data_field_name_type() {
+        let (name, def) = parse_data_field_spec("note:string").unwrap();
+        assert_eq!(name, "note");
+        assert_eq!(def.field_type, DataFieldType::String);
+        assert!(!def.required);
+    }
+
+    #[test]
+    fn parse_data_field_required() {
+        let (name, def) = parse_data_field_spec("score:number:required").unwrap();
+        assert_eq!(name, "score");
+        assert_eq!(def.field_type, DataFieldType::Number);
+        assert!(def.required);
+    }
+
+    #[test]
+    fn parse_data_field_all_types() {
+        for (spec, ty) in [
+            ("a:string", DataFieldType::String),
+            ("b:number", DataFieldType::Number),
+            ("c:boolean", DataFieldType::Boolean),
+            ("d:array", DataFieldType::Array),
+            ("e:object", DataFieldType::Object),
+        ] {
+            assert_eq!(parse_data_field_spec(spec).unwrap().1.field_type, ty);
+        }
+    }
+
+    #[test]
+    fn parse_data_field_rejects_bad_type() {
+        assert!(parse_data_field_spec("x:notatype").is_err());
+    }
+
+    #[test]
+    fn parse_data_field_rejects_missing_type() {
+        assert!(parse_data_field_spec("justaname").is_err());
+    }
+
+    #[test]
+    fn parse_data_field_rejects_empty_name() {
+        assert!(parse_data_field_spec(":string").is_err());
+    }
 
     // -- parse_id_spec --
 

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -679,16 +679,34 @@ pub(crate) fn handle_kv(cmd: KvCommands, verbose: bool) -> Result<i32> {
             create,
             max_entries,
         } => {
-            // Handle --create: auto-add key to schema if missing
+            // Handle --create: auto-add key to schema if missing.
+            //
+            // C1 (#363 AC): `push --create` routes through the SAME engine
+            // path as `schema add` -- `add_key_def`. The user-facing surface
+            // stays history/list-limited (CreateType), but creation is now
+            // unified so both verbs share one persistence path. (This trades
+            // the old append-based, comment-preserving write for the
+            // round-tripping `save_schema`, which drops comments -- documented
+            // and accepted for schema writes.)
             if let Some(ref create_type) = create {
-                let type_str = match create_type {
-                    CreateType::History => "history",
-                    CreateType::List => "list",
+                let value_type = match create_type {
+                    CreateType::History => ValueType::History,
+                    CreateType::List => ValueType::List,
                 };
-                if !store.schema.keys.contains_key(&key)
-                    && let Err(e) = store.add_key_to_schema(&key, type_str, max_entries)
-                {
-                    return handle_kv_err(e);
+                if !store.schema.keys.contains_key(&key) {
+                    let def = KeyDef {
+                        value_type,
+                        min: None,
+                        max: None,
+                        default: None,
+                        max_entries,
+                        description: None,
+                        fields: None,
+                        data: None,
+                    };
+                    if let Err(e) = store.add_key_def(&key, def) {
+                        return handle_kv_err(e);
+                    }
                 }
                 // If key already exists, silently ignore --create
             }
@@ -1275,6 +1293,63 @@ fn parse_data_field_spec(spec: &str) -> Result<(String, DataFieldDef), String> {
     ))
 }
 
+/// W1 (#363): reject type-inappropriate options on `schema add`/`schema update`.
+///
+/// Each option only makes sense for a subset of value types (the issue's
+/// "type-appropriate options" table):
+///   - `--max-entries`        -> history, list
+///   - `--default`            -> counter, string, state
+///   - `--min` / `--max`      -> counter
+///   - `--fields`             -> state
+///   - `--data` / `--add-field` -> state, list
+///   - `--description`        -> all types
+///
+/// `which` is a flag set: each present flag is checked against `value_type`.
+/// Returns a usage-style error message naming the offending flag and the
+/// type it does not apply to. The caller maps `Err` to exit 4.
+struct OptionFlags {
+    max_entries: bool,
+    default: bool,
+    min: bool,
+    max: bool,
+    fields: bool,
+    data: bool,
+}
+
+fn validate_type_options(value_type: ValueType, flags: &OptionFlags) -> Result<(), String> {
+    use ValueType::*;
+
+    let bad = |flag: &str, allowed: &str| {
+        Err(format!(
+            "--{flag} does not apply to a '{value_type}' key (only valid for: {allowed})"
+        ))
+    };
+
+    if flags.max_entries && !matches!(value_type, History | List) {
+        return bad("max-entries", "history, list");
+    }
+    if flags.default && !matches!(value_type, Counter | String | State) {
+        return bad("default", "counter, string, state");
+    }
+    if flags.min && !matches!(value_type, Counter) {
+        return bad("min", "counter");
+    }
+    if flags.max && !matches!(value_type, Counter) {
+        return bad("max", "counter");
+    }
+    if flags.fields && !matches!(value_type, State) {
+        return bad("fields", "state");
+    }
+    if flags.data && !matches!(value_type, State | List) {
+        // Covers `--data` (schema add) and `--add-field` (schema update).
+        return Err(format!(
+            "--data/--add-field does not apply to a '{value_type}' key \
+             (only valid for: state, list)"
+        ));
+    }
+    Ok(())
+}
+
 fn handle_kv_schema(store: &mut KvStore, command: KvSchemaCommands) -> Result<i32> {
     match command {
         KvSchemaCommands::List => {
@@ -1300,6 +1375,20 @@ fn handle_kv_schema(store: &mut KvStore, command: KvSchemaCommands) -> Result<i3
                 SchemaType::String => ValueType::String,
                 SchemaType::List => ValueType::List,
             };
+
+            // W1: reject type-inappropriate options before persisting.
+            let flags = OptionFlags {
+                max_entries: max_entries.is_some(),
+                default: default.is_some(),
+                min: min.is_some(),
+                max: max.is_some(),
+                fields: !fields.is_empty(),
+                data: !data.is_empty(),
+            };
+            if let Err(msg) = validate_type_options(value_type, &flags) {
+                eprintln!("Error: {}", msg);
+                return Ok(kv::EXIT_INVALID_INPUT);
+            }
 
             // Parse typed --data field defs.
             let mut data_defs = std::collections::BTreeMap::new();
@@ -1391,6 +1480,43 @@ fn handle_kv_schema(store: &mut KvStore, command: KvSchemaCommands) -> Result<i3
             // --name delegates to the shared rename path.
             if let Some(new_name) = name {
                 return rename_key_handler(store, &key, &new_name);
+            }
+
+            // S1: a no-op update (no metadata flags set) would re-serialize the
+            // schema for nothing -- dropping comments/formatting. Short-circuit
+            // with a notice instead of rewriting the file.
+            if description.is_none()
+                && max_entries.is_none()
+                && min.is_none()
+                && max.is_none()
+                && add_field.is_none()
+            {
+                eprintln!(
+                    "Error: 'schema update {}' had no changes to apply \
+                     (set at least one of --description, --max-entries, --min, \
+                     --max, --add-field, or --name)",
+                    key
+                );
+                return Ok(kv::EXIT_INVALID_INPUT);
+            }
+
+            // W1: reject options that don't apply to this key's existing type.
+            // The key must exist for a type to gate against; if it doesn't,
+            // let update_key_meta report KeyNotFound (exit 1) below.
+            if let Some(def) = store.schema.keys.get(&key) {
+                let existing_type = def.value_type;
+                let flags = OptionFlags {
+                    max_entries: max_entries.is_some(),
+                    default: false, // `schema update` exposes no --default
+                    min: min.is_some(),
+                    max: max.is_some(),
+                    fields: false, // `schema update` exposes no --fields
+                    data: add_field.is_some(),
+                };
+                if let Err(msg) = validate_type_options(existing_type, &flags) {
+                    eprintln!("Error: {}", msg);
+                    return Ok(kv::EXIT_INVALID_INPUT);
+                }
             }
 
             // Parse --add-field if present.
@@ -1877,5 +2003,355 @@ mod tests {
         ]);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("empty field name"));
+    }
+
+    // -- W1: validate_type_options (pure gate) --
+
+    fn no_flags() -> OptionFlags {
+        OptionFlags {
+            max_entries: false,
+            default: false,
+            min: false,
+            max: false,
+            fields: false,
+            data: false,
+        }
+    }
+
+    #[test]
+    fn type_options_max_entries_only_history_list() {
+        let f = OptionFlags {
+            max_entries: true,
+            ..no_flags()
+        };
+        assert!(validate_type_options(ValueType::History, &f).is_ok());
+        assert!(validate_type_options(ValueType::List, &f).is_ok());
+        for vt in [ValueType::Counter, ValueType::String, ValueType::State] {
+            let err = validate_type_options(vt, &f).unwrap_err();
+            assert!(err.contains("--max-entries"), "{err}");
+        }
+    }
+
+    #[test]
+    fn type_options_min_max_only_counter() {
+        let fmin = OptionFlags {
+            min: true,
+            ..no_flags()
+        };
+        let fmax = OptionFlags {
+            max: true,
+            ..no_flags()
+        };
+        assert!(validate_type_options(ValueType::Counter, &fmin).is_ok());
+        assert!(validate_type_options(ValueType::Counter, &fmax).is_ok());
+        for vt in [
+            ValueType::History,
+            ValueType::List,
+            ValueType::String,
+            ValueType::State,
+        ] {
+            assert!(
+                validate_type_options(vt, &fmin)
+                    .unwrap_err()
+                    .contains("--min")
+            );
+            assert!(
+                validate_type_options(vt, &fmax)
+                    .unwrap_err()
+                    .contains("--max")
+            );
+        }
+    }
+
+    #[test]
+    fn type_options_default_only_counter_string_state() {
+        let f = OptionFlags {
+            default: true,
+            ..no_flags()
+        };
+        for vt in [ValueType::Counter, ValueType::String, ValueType::State] {
+            assert!(validate_type_options(vt, &f).is_ok());
+        }
+        for vt in [ValueType::History, ValueType::List] {
+            assert!(
+                validate_type_options(vt, &f)
+                    .unwrap_err()
+                    .contains("--default")
+            );
+        }
+    }
+
+    #[test]
+    fn type_options_fields_only_state() {
+        let f = OptionFlags {
+            fields: true,
+            ..no_flags()
+        };
+        assert!(validate_type_options(ValueType::State, &f).is_ok());
+        for vt in [
+            ValueType::Counter,
+            ValueType::History,
+            ValueType::List,
+            ValueType::String,
+        ] {
+            assert!(
+                validate_type_options(vt, &f)
+                    .unwrap_err()
+                    .contains("--fields")
+            );
+        }
+    }
+
+    #[test]
+    fn type_options_data_only_state_list() {
+        let f = OptionFlags {
+            data: true,
+            ..no_flags()
+        };
+        assert!(validate_type_options(ValueType::State, &f).is_ok());
+        assert!(validate_type_options(ValueType::List, &f).is_ok());
+        for vt in [ValueType::Counter, ValueType::History, ValueType::String] {
+            let err = validate_type_options(vt, &f).unwrap_err();
+            assert!(err.contains("--data/--add-field"), "{err}");
+        }
+    }
+
+    #[test]
+    fn type_options_no_flags_always_ok() {
+        for vt in [
+            ValueType::Counter,
+            ValueType::History,
+            ValueType::State,
+            ValueType::String,
+            ValueType::List,
+        ] {
+            assert!(validate_type_options(vt, &no_flags()).is_ok());
+        }
+    }
+
+    // -- W1 / S1: handler-path integration (exit codes + persistence) --
+
+    use crate::kv::KvStore;
+    use tempfile::TempDir;
+
+    fn store_for(schema_toml: &str) -> (KvStore, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let schema_path = dir.path().join("schema.toml");
+        let data_path = dir.path().join("data.json");
+        std::fs::write(&schema_path, schema_toml).unwrap();
+        let store = KvStore::load(&schema_path, &data_path).unwrap();
+        (store, dir)
+    }
+
+    const SCHEMA: &str = r#"
+[keys.ctr]
+type = "counter"
+min = 0
+
+[keys.hist]
+type = "history"
+max_entries = 5
+
+[keys.st]
+type = "state"
+fields = ["a", "b"]
+"#;
+
+    #[test]
+    fn schema_add_rejects_min_on_history() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Add {
+            key: "h2".to_string(),
+            r#type: SchemaType::History,
+            max_entries: None,
+            default: None,
+            min: Some(-5),
+            max: None,
+            description: None,
+            fields: vec![],
+            data: vec![],
+        };
+        let code = handle_kv_schema(&mut store, cmd).unwrap();
+        assert_eq!(code, kv::EXIT_INVALID_INPUT);
+        // Nonsense was not persisted.
+        assert!(!store.schema.keys.contains_key("h2"));
+    }
+
+    #[test]
+    fn schema_add_rejects_max_entries_on_counter() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Add {
+            key: "c2".to_string(),
+            r#type: SchemaType::Counter,
+            max_entries: Some(10),
+            default: None,
+            min: None,
+            max: None,
+            description: None,
+            fields: vec![],
+            data: vec![],
+        };
+        assert_eq!(
+            handle_kv_schema(&mut store, cmd).unwrap(),
+            kv::EXIT_INVALID_INPUT
+        );
+        assert!(!store.schema.keys.contains_key("c2"));
+    }
+
+    #[test]
+    fn schema_add_rejects_fields_on_list() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Add {
+            key: "l2".to_string(),
+            r#type: SchemaType::List,
+            max_entries: None,
+            default: None,
+            min: None,
+            max: None,
+            description: None,
+            fields: vec!["a".to_string()],
+            data: vec![],
+        };
+        assert_eq!(
+            handle_kv_schema(&mut store, cmd).unwrap(),
+            kv::EXIT_INVALID_INPUT
+        );
+        assert!(!store.schema.keys.contains_key("l2"));
+    }
+
+    #[test]
+    fn schema_add_accepts_appropriate_options() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Add {
+            key: "bounded".to_string(),
+            r#type: SchemaType::Counter,
+            max_entries: None,
+            default: Some("0".to_string()),
+            min: Some(-5),
+            max: Some(5),
+            description: Some("ok".to_string()),
+            fields: vec![],
+            data: vec![],
+        };
+        assert_eq!(handle_kv_schema(&mut store, cmd).unwrap(), kv::EXIT_OK);
+        assert!(store.schema.keys.contains_key("bounded"));
+    }
+
+    #[test]
+    fn schema_update_rejects_add_field_on_counter() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Update {
+            key: "ctr".to_string(),
+            name: None,
+            description: None,
+            max_entries: None,
+            min: None,
+            max: None,
+            add_field: Some("note:string".to_string()),
+            type_change: None,
+        };
+        assert_eq!(
+            handle_kv_schema(&mut store, cmd).unwrap(),
+            kv::EXIT_INVALID_INPUT
+        );
+        // No data block was written onto the counter.
+        assert!(store.schema.keys["ctr"].data.is_none());
+    }
+
+    #[test]
+    fn schema_update_rejects_max_entries_on_counter() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Update {
+            key: "ctr".to_string(),
+            name: None,
+            description: None,
+            max_entries: Some(99),
+            min: None,
+            max: None,
+            add_field: None,
+            type_change: None,
+        };
+        assert_eq!(
+            handle_kv_schema(&mut store, cmd).unwrap(),
+            kv::EXIT_INVALID_INPUT
+        );
+        assert!(store.schema.keys["ctr"].max_entries.is_none());
+    }
+
+    #[test]
+    fn schema_update_rejects_min_on_history() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Update {
+            key: "hist".to_string(),
+            name: None,
+            description: None,
+            max_entries: None,
+            min: Some(-1),
+            max: None,
+            add_field: None,
+            type_change: None,
+        };
+        assert_eq!(
+            handle_kv_schema(&mut store, cmd).unwrap(),
+            kv::EXIT_INVALID_INPUT
+        );
+        assert!(store.schema.keys["hist"].min.is_none());
+    }
+
+    #[test]
+    fn schema_update_accepts_appropriate_options() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let cmd = KvSchemaCommands::Update {
+            key: "hist".to_string(),
+            name: None,
+            description: Some("a log".to_string()),
+            max_entries: Some(10),
+            min: None,
+            max: None,
+            add_field: None,
+            type_change: None,
+        };
+        assert_eq!(handle_kv_schema(&mut store, cmd).unwrap(), kv::EXIT_OK);
+        assert_eq!(store.schema.keys["hist"].max_entries, Some(10));
+        assert_eq!(
+            store.schema.keys["hist"].description.as_deref(),
+            Some("a log")
+        );
+    }
+
+    // S1: a no-op update short-circuits with an error and does NOT rewrite.
+    #[test]
+    fn schema_update_noop_short_circuits() {
+        let (mut store, _dir) = store_for(SCHEMA);
+        let mtime_before = std::fs::metadata(&store.schema_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let cmd = KvSchemaCommands::Update {
+            key: "ctr".to_string(),
+            name: None,
+            description: None,
+            max_entries: None,
+            min: None,
+            max: None,
+            add_field: None,
+            type_change: None,
+        };
+        assert_eq!(
+            handle_kv_schema(&mut store, cmd).unwrap(),
+            kv::EXIT_INVALID_INPUT
+        );
+
+        // Schema file untouched (comments/formatting preserved): same content.
+        let after = std::fs::read_to_string(&store.schema_path).unwrap();
+        assert!(after.contains("[keys.ctr]"));
+        // And the original file (with comments-as-written) is byte-identical.
+        assert_eq!(after, SCHEMA);
+        let mtime_after = std::fs::metadata(&store.schema_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert_eq!(mtime_before, mtime_after);
     }
 }

--- a/src/handlers/kv.rs
+++ b/src/handlers/kv.rs
@@ -1322,7 +1322,11 @@ fn handle_kv_schema(store: &mut KvStore, command: KvSchemaCommands) -> Result<i3
                 default,
                 max_entries,
                 description,
-                fields: if fields.is_empty() { None } else { Some(fields) },
+                fields: if fields.is_empty() {
+                    None
+                } else {
+                    Some(fields)
+                },
                 data: if data_defs.is_empty() {
                     None
                 } else {
@@ -1401,14 +1405,7 @@ fn handle_kv_schema(store: &mut KvStore, command: KvSchemaCommands) -> Result<i3
                 None => None,
             };
 
-            match store.update_key_meta(
-                &key,
-                description,
-                max_entries,
-                min,
-                max,
-                add_field_def,
-            ) {
+            match store.update_key_meta(&key, description, max_entries, min, max, add_field_def) {
                 Ok(()) => {
                     println!("Updated {}", key);
                     Ok(kv::EXIT_OK)

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1118,13 +1118,13 @@ impl KvStore {
         Ok(())
     }
 
-    /// Add a new key to the schema file and reload the in-memory schema.
+    /// Add a new `history`/`list` key to the schema file (the `push --create`
+    /// inline shortcut path) by appending a `[keys.<name>]` block to the TOML
+    /// file (preserving existing content exactly) and re-parsing.
     ///
-    /// Appends a `[keys.<name>]` block to the TOML file (preserving existing
-    /// content exactly) and re-parses the file to update `self.schema`.
-    ///
-    /// Only `history` and `list` types are accepted -- those are the types
-    /// that support `push`.
+    /// `schema add` uses the richer [`KvStore::add_key_def`] path instead;
+    /// this method is retained so `push --create` keeps its append-based,
+    /// comment-preserving behavior.
     pub fn add_key_to_schema(
         &mut self,
         key: &str,
@@ -1181,6 +1181,171 @@ impl KvStore {
             ))
         })?;
         self.schema = schema;
+
+        Ok(())
+    }
+
+    /// First-class key definition (`mx kv schema add`).
+    ///
+    /// Inserts a fully-formed [`KeyDef`] into the in-memory schema and
+    /// persists it via [`KvStore::save_schema`]. Unlike [`add_key_to_schema`],
+    /// this accepts any of the five [`ValueType`]s and the full set of
+    /// type-appropriate options.
+    ///
+    /// Schema round-trips through `toml = "0.8"`, which drops comments and
+    /// custom formatting -- acceptable and consistent with `save_schema`.
+    ///
+    /// Errors:
+    /// - invalid key name (`validate_key_name`)
+    /// - duplicate key -> `DataValidation`
+    pub fn add_key_def(&mut self, key: &str, def: KeyDef) -> Result<(), KvError> {
+        Self::validate_key_name(key)?;
+
+        if self.schema.keys.contains_key(key) {
+            return Err(KvError::DataValidation {
+                message: format!("Key already exists: {}", key),
+            });
+        }
+
+        self.schema.keys.insert(key.to_string(), def);
+
+        // No data is written on definition; only the schema changes.
+        self.save_schema().map_err(KvError::Other)?;
+
+        Ok(())
+    }
+
+    /// Returns true if the key has stored data entries that are non-empty.
+    ///
+    /// "Empty" means: never written (no data entry), or written but holding
+    /// only default/empty content (zero-length string, empty history/list,
+    /// or a state with no populated fields). Used by `schema drop` to decide
+    /// whether `--force` is required.
+    pub fn key_has_content(&self, key: &str) -> bool {
+        match self.data.entries.get(key) {
+            None => false,
+            Some(DataValue::Counter { value }) => *value != 0,
+            Some(DataValue::String { value }) => !value.is_empty(),
+            Some(DataValue::History { entries, .. }) => !entries.is_empty(),
+            Some(DataValue::List { items, .. }) => !items.is_empty(),
+            Some(DataValue::State { fields, .. }) => {
+                fields.values().any(|v| !v.is_empty())
+            }
+        }
+    }
+
+    /// Drop a key entirely: remove both its schema definition and its stored
+    /// data entry (full removal, not the entry-clearing that `remove` does).
+    ///
+    /// Mirrors the [`rename_key`](KvStore::rename_key) transaction pattern:
+    /// mutate in-memory fully, persist data first (higher-value file) then
+    /// schema, and roll back the in-memory mutations if the data write fails.
+    ///
+    /// Any `--memory` (`kn-`) links the key carried are outbound pointers with
+    /// no reverse reference from the memory store, so dropping the key simply
+    /// discards them -- nothing downstream breaks.
+    ///
+    /// Errors:
+    /// - unregistered key -> `KeyNotFound`
+    pub fn drop_key(&mut self, key: &str) -> Result<(), KvError> {
+        // Key must be registered in the schema.
+        if !self.schema.keys.contains_key(key) {
+            return Err(KvError::KeyNotFound(key.to_string()));
+        }
+
+        // Mutate in-memory fully before any write.
+        let removed_def = self.schema.keys.remove(key).expect("checked above");
+        let removed_data = self.data.entries.remove(key);
+
+        // Persist data first, then schema -- matching rename_key.
+        if let Err(e) = self.save() {
+            // Roll back so the KvStore stays clean.
+            self.schema.keys.insert(key.to_string(), removed_def);
+            if let Some(data_value) = removed_data {
+                self.data.entries.insert(key.to_string(), data_value);
+            }
+            return Err(KvError::Other(e));
+        }
+
+        // Schema write -- if this fails, the data file already lacks the key
+        // while the schema still references it. Same narrow consistency gap
+        // documented on `rename_key`; both writes target the same directory.
+        self.save_schema().map_err(KvError::Other)?;
+
+        Ok(())
+    }
+
+    /// Apply safe metadata changes to an existing key's definition
+    /// (`mx kv schema update`). Scoped to non-destructive edits only.
+    ///
+    /// Supported (all optional; `None` leaves the field untouched):
+    /// - `description`: replace the description (pass `Some("")` to clear)
+    /// - `max_entries`: history/list cap
+    /// - `min` / `max`: counter clamp bounds
+    /// - `add_field`: append a new *optional* `[keys.X.data]` field def
+    ///
+    /// Type changes are intentionally **not** representable here -- they are
+    /// forbidden and routed to `kv migrate` at the CLI layer.
+    ///
+    /// Follows the [`rename_key`](KvStore::rename_key) transaction pattern:
+    /// because `update` never touches the data file, only the schema is
+    /// written, and the in-memory mutation is rolled back if that write fails.
+    ///
+    /// Errors:
+    /// - unregistered key -> `KeyNotFound`
+    /// - duplicate data field -> `DataValidation`
+    pub fn update_key_meta(
+        &mut self,
+        key: &str,
+        description: Option<String>,
+        max_entries: Option<usize>,
+        min: Option<i64>,
+        max: Option<i64>,
+        add_field: Option<(String, DataFieldDef)>,
+    ) -> Result<(), KvError> {
+        if !self.schema.keys.contains_key(key) {
+            return Err(KvError::KeyNotFound(key.to_string()));
+        }
+
+        // Snapshot for rollback.
+        let original = self.schema.keys.get(key).expect("checked above").clone();
+
+        {
+            let def = self.schema.keys.get_mut(key).expect("checked above");
+
+            if let Some(desc) = description {
+                def.description = if desc.is_empty() { None } else { Some(desc) };
+            }
+            if let Some(me) = max_entries {
+                def.max_entries = Some(me);
+            }
+            if let Some(mn) = min {
+                def.min = Some(mn);
+            }
+            if let Some(mx) = max {
+                def.max = Some(mx);
+            }
+            if let Some((field_name, field_def)) = add_field {
+                let data = def.data.get_or_insert_with(BTreeMap::new);
+                if data.contains_key(&field_name) {
+                    // Restore and bail.
+                    self.schema.keys.insert(key.to_string(), original);
+                    return Err(KvError::DataValidation {
+                        message: format!(
+                            "data field '{}' already exists on key '{}'",
+                            field_name, key
+                        ),
+                    });
+                }
+                data.insert(field_name, field_def);
+            }
+        }
+
+        // Only the schema changes; persist it, rolling back on failure.
+        if let Err(e) = self.save_schema() {
+            self.schema.keys.insert(key.to_string(), original);
+            return Err(KvError::Other(e));
+        }
 
         Ok(())
     }
@@ -8611,5 +8776,281 @@ count = { type = "number" }
             before, after,
             "Serialized data should be identical after rename"
         );
+    }
+
+    // -- add_key_def (schema add) --
+
+    fn empty_def(value_type: ValueType) -> KeyDef {
+        KeyDef {
+            value_type,
+            min: None,
+            max: None,
+            default: None,
+            max_entries: None,
+            description: None,
+            fields: None,
+            data: None,
+        }
+    }
+
+    #[test]
+    fn add_key_def_each_type() {
+        let (mut store, _dir) = setup_store(test_schema());
+
+        for (name, vt) in [
+            ("new_counter", ValueType::Counter),
+            ("new_history", ValueType::History),
+            ("new_state", ValueType::State),
+            ("new_string", ValueType::String),
+            ("new_list", ValueType::List),
+        ] {
+            store.add_key_def(name, empty_def(vt)).unwrap();
+            assert_eq!(store.schema.keys[name].value_type, vt);
+        }
+
+        // Persisted: reload from disk and confirm.
+        let reloaded = KvStore::load(&store.schema_path, &store.data_path).unwrap();
+        assert_eq!(reloaded.schema.keys["new_counter"].value_type, ValueType::Counter);
+        assert_eq!(reloaded.schema.keys["new_list"].value_type, ValueType::List);
+    }
+
+    #[test]
+    fn add_key_def_preserves_options() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let mut def = empty_def(ValueType::Counter);
+        def.min = Some(-5);
+        def.max = Some(5);
+        def.default = Some("0".to_string());
+        def.description = Some("a bounded counter".to_string());
+
+        store.add_key_def("bounded", def).unwrap();
+        let reloaded = KvStore::load(&store.schema_path, &store.data_path).unwrap();
+        let kd = &reloaded.schema.keys["bounded"];
+        assert_eq!(kd.min, Some(-5));
+        assert_eq!(kd.max, Some(5));
+        assert_eq!(kd.description.as_deref(), Some("a bounded counter"));
+    }
+
+    #[test]
+    fn add_key_def_duplicate_errors() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let err = store
+            .add_key_def("warmth", empty_def(ValueType::Counter))
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::DataValidation { .. }),
+            "Expected DataValidation, got: {err}"
+        );
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn add_key_def_invalid_name_errors() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let err = store
+            .add_key_def("bad.name", empty_def(ValueType::String))
+            .unwrap_err();
+        assert!(matches!(err, KvError::DataValidation { .. }));
+    }
+
+    // -- key_has_content --
+
+    #[test]
+    fn key_has_content_never_written() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .add_key_def("fresh", empty_def(ValueType::History))
+            .unwrap();
+        assert!(!store.key_has_content("fresh"));
+    }
+
+    #[test]
+    fn key_has_content_empty_vs_populated() {
+        let (mut store, _dir) = setup_store(test_schema());
+        // History with entries is content; empty string is not.
+        store.push("flavor_history", "matcha", None, None).unwrap();
+        assert!(store.key_has_content("flavor_history"));
+
+        store.set("current_mood", "", None).unwrap();
+        assert!(!store.key_has_content("current_mood"));
+        store.set("current_mood", "calm", None).unwrap();
+        assert!(store.key_has_content("current_mood"));
+    }
+
+    // -- drop_key --
+
+    #[test]
+    fn drop_key_empty_removes_schema_only() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .add_key_def("scratch", empty_def(ValueType::History))
+            .unwrap();
+        assert!(!store.key_has_content("scratch"));
+
+        store.drop_key("scratch").unwrap();
+        assert!(!store.schema.keys.contains_key("scratch"));
+
+        let reloaded = KvStore::load(&store.schema_path, &store.data_path).unwrap();
+        assert!(!reloaded.schema.keys.contains_key("scratch"));
+    }
+
+    #[test]
+    fn drop_key_non_empty_removes_schema_and_data() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "matcha", None, None).unwrap();
+        store.save().unwrap();
+        assert!(store.data.entries.contains_key("flavor_history"));
+
+        store.drop_key("flavor_history").unwrap();
+        assert!(!store.schema.keys.contains_key("flavor_history"));
+        assert!(!store.data.entries.contains_key("flavor_history"));
+
+        let reloaded = KvStore::load(&store.schema_path, &store.data_path).unwrap();
+        assert!(!reloaded.schema.keys.contains_key("flavor_history"));
+        assert!(!reloaded.data.entries.contains_key("flavor_history"));
+    }
+
+    #[test]
+    fn drop_key_unregistered_errors_key_not_found() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let err = store.drop_key("ghost").unwrap_err();
+        assert!(
+            matches!(err, KvError::KeyNotFound(ref k) if k == "ghost"),
+            "Expected KeyNotFound, got: {err}"
+        );
+    }
+
+    #[test]
+    fn drop_key_with_memory_link_discards_pointer() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store.push("flavor_history", "matcha", None, None).unwrap();
+        store
+            .set_memory("flavor_history", Some("kn-abc123".to_string()))
+            .unwrap();
+        store.save().unwrap();
+        assert_eq!(
+            store.get_memory("flavor_history").unwrap(),
+            Some("kn-abc123")
+        );
+
+        // Dropping simply discards the outbound pointer; no error.
+        store.drop_key("flavor_history").unwrap();
+        assert!(!store.schema.keys.contains_key("flavor_history"));
+        assert!(!store.data.entries.contains_key("flavor_history"));
+    }
+
+    // -- update_key_meta --
+
+    #[test]
+    fn update_key_meta_safe_changes() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .update_key_meta(
+                "capped",
+                Some("max warmth allowed".to_string()),
+                None,
+                Some(-10),
+                Some(200),
+                None,
+            )
+            .unwrap();
+
+        let reloaded = KvStore::load(&store.schema_path, &store.data_path).unwrap();
+        let kd = &reloaded.schema.keys["capped"];
+        assert_eq!(kd.description.as_deref(), Some("max warmth allowed"));
+        assert_eq!(kd.min, Some(-10));
+        assert_eq!(kd.max, Some(200));
+        // Type unchanged.
+        assert_eq!(kd.value_type, ValueType::Counter);
+    }
+
+    #[test]
+    fn update_key_meta_clear_description() {
+        let (mut store, _dir) = setup_store(test_schema());
+        store
+            .update_key_meta("warmth", Some("desc".to_string()), None, None, None, None)
+            .unwrap();
+        assert_eq!(
+            store.schema.keys["warmth"].description.as_deref(),
+            Some("desc")
+        );
+        // Empty string clears.
+        store
+            .update_key_meta("warmth", Some(String::new()), None, None, None, None)
+            .unwrap();
+        assert_eq!(store.schema.keys["warmth"].description, None);
+    }
+
+    #[test]
+    fn update_key_meta_add_optional_field() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let field = DataFieldDef {
+            field_type: DataFieldType::String,
+            required: false,
+            default: None,
+        };
+        store
+            .update_key_meta(
+                "flavor_history",
+                None,
+                None,
+                None,
+                None,
+                Some(("note".to_string(), field)),
+            )
+            .unwrap();
+        let kd = &store.schema.keys["flavor_history"];
+        assert!(kd.data.as_ref().unwrap().contains_key("note"));
+        assert!(!kd.data.as_ref().unwrap()["note"].required);
+    }
+
+    #[test]
+    fn update_key_meta_duplicate_field_errors() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let field = DataFieldDef {
+            field_type: DataFieldType::String,
+            required: false,
+            default: None,
+        };
+        store
+            .update_key_meta(
+                "flavor_history",
+                None,
+                None,
+                None,
+                None,
+                Some(("note".to_string(), field.clone())),
+            )
+            .unwrap();
+        // Second add of same field name errors and does not corrupt schema.
+        let err = store
+            .update_key_meta(
+                "flavor_history",
+                None,
+                None,
+                None,
+                None,
+                Some(("note".to_string(), field)),
+            )
+            .unwrap_err();
+        assert!(matches!(err, KvError::DataValidation { .. }));
+        // Still exactly one field def.
+        assert_eq!(
+            store.schema.keys["flavor_history"]
+                .data
+                .as_ref()
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn update_key_meta_unregistered_errors() {
+        let (mut store, _dir) = setup_store(test_schema());
+        let err = store
+            .update_key_meta("ghost", Some("x".to_string()), None, None, None, None)
+            .unwrap_err();
+        assert!(matches!(err, KvError::KeyNotFound(ref k) if k == "ghost"));
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1118,13 +1118,16 @@ impl KvStore {
         Ok(())
     }
 
-    /// Add a new `history`/`list` key to the schema file (the `push --create`
-    /// inline shortcut path) by appending a `[keys.<name>]` block to the TOML
-    /// file (preserving existing content exactly) and re-parsing.
+    /// Add a new `history`/`list` key to the schema file by appending a
+    /// `[keys.<name>]` block to the TOML file (preserving existing content
+    /// exactly) and re-parsing.
     ///
-    /// `schema add` uses the richer [`KvStore::add_key_def`] path instead;
-    /// this method is retained so `push --create` keeps its append-based,
-    /// comment-preserving behavior.
+    /// NOTE (C1, #363): `push --create` no longer uses this method. To satisfy
+    /// the acceptance criterion that `push --create` route through the SAME
+    /// creation path as `schema add`, both now go through
+    /// [`KvStore::add_key_def`]. This append-based, comment-preserving variant
+    /// is retained as a standalone engine helper (and for its existing tests)
+    /// but is no longer wired to any CLI verb.
     pub fn add_key_to_schema(
         &mut self,
         key: &str,
@@ -9053,5 +9056,129 @@ count = { type = "number" }
             .update_key_meta("ghost", Some("x".to_string()), None, None, None, None)
             .unwrap_err();
         assert!(matches!(err, KvError::KeyNotFound(ref k) if k == "ghost"));
+    }
+
+    // -- W2: rollback-on-failure (drop / update / rename) --
+    //
+    // The transaction pattern persists data-first, then schema, and rolls back
+    // in-memory mutations if a write fails. To force a write failure portably
+    // we redirect the relevant path so that `create_dir_all(parent)` (the first
+    // step of both `save` and `save_schema`) fails: we point the path *inside*
+    // a regular file, so its "parent" is a file, not a directory. This makes
+    // the write deterministically error without relying on permission bits.
+
+    /// Redirect `path` to live under a freshly-created blocker *file*, so any
+    /// `create_dir_all(parent)` against it fails. Returns the doomed path.
+    fn unwritable_under_file(dir: &std::path::Path, name: &str) -> PathBuf {
+        let blocker = dir.join("blocker_file");
+        fs::write(&blocker, b"not a directory").unwrap();
+        // parent of the returned path is `blocker_file`, which is a file.
+        blocker.join(name)
+    }
+
+    #[test]
+    fn drop_key_rollback_on_data_write_failure() {
+        let (mut store, dir) = setup_store(test_schema());
+        store.push("flavor_history", "matcha", None, None).unwrap();
+        store.save().unwrap();
+
+        // Snapshot good on-disk state for the later assertion.
+        let good_data_path = store.data_path.clone();
+        let good_schema_path = store.schema_path.clone();
+
+        // Force the data write (the first persist in drop_key) to fail.
+        store.data_path = unwritable_under_file(dir.path(), "data.json");
+
+        let err = store.drop_key("flavor_history").unwrap_err();
+        assert!(
+            matches!(err, KvError::Other(_)),
+            "expected a write failure, got: {err}"
+        );
+
+        // In-memory state fully rolled back: schema def and data both restored.
+        assert!(store.schema.keys.contains_key("flavor_history"));
+        assert!(store.data.entries.contains_key("flavor_history"));
+        match store.data.entries.get("flavor_history").unwrap() {
+            DataValue::History { entries, .. } => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].value, "matcha");
+            }
+            other => panic!("expected History, got {other:?}"),
+        }
+
+        // On-disk state untouched: the good files still hold the key.
+        let reloaded = KvStore::load(&good_schema_path, &good_data_path).unwrap();
+        assert!(reloaded.schema.keys.contains_key("flavor_history"));
+        assert!(reloaded.data.entries.contains_key("flavor_history"));
+    }
+
+    #[test]
+    fn update_key_meta_rollback_on_schema_write_failure() {
+        let (mut store, dir) = setup_store(test_schema());
+        let good_schema_path = store.schema_path.clone();
+        let good_data_path = store.data_path.clone();
+
+        // Force the schema write (the only persist in update_key_meta) to fail.
+        store.schema_path = unwritable_under_file(dir.path(), "schema.toml");
+
+        let err = store
+            .update_key_meta(
+                "capped",
+                Some("changed".to_string()),
+                None,
+                Some(-99),
+                Some(99),
+                None,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::Other(_)),
+            "expected a write failure, got: {err}"
+        );
+
+        // In-memory def fully restored to its original values.
+        let kd = &store.schema.keys["capped"];
+        assert_eq!(kd.description, None);
+        assert_eq!(kd.min, Some(0));
+        assert_eq!(kd.max, Some(100));
+
+        // On-disk schema untouched.
+        let reloaded = KvStore::load(&good_schema_path, &good_data_path).unwrap();
+        let rkd = &reloaded.schema.keys["capped"];
+        assert_eq!(rkd.description, None);
+        assert_eq!(rkd.min, Some(0));
+        assert_eq!(rkd.max, Some(100));
+    }
+
+    #[test]
+    fn rename_key_rollback_on_data_write_failure() {
+        let (mut store, dir) = setup_store(test_schema());
+        store.push("flavor_history", "matcha", None, None).unwrap();
+        store.save().unwrap();
+
+        let good_schema_path = store.schema_path.clone();
+        let good_data_path = store.data_path.clone();
+
+        // Force the data write (first persist in rename_key) to fail.
+        store.data_path = unwritable_under_file(dir.path(), "data.json");
+
+        let err = store
+            .rename_key("flavor_history", "tea_history")
+            .unwrap_err();
+        assert!(
+            matches!(err, KvError::Other(_)),
+            "expected a write failure, got: {err}"
+        );
+
+        // In-memory state rolled back: old key present, new key absent.
+        assert!(store.schema.keys.contains_key("flavor_history"));
+        assert!(!store.schema.keys.contains_key("tea_history"));
+        assert!(store.data.entries.contains_key("flavor_history"));
+        assert!(!store.data.entries.contains_key("tea_history"));
+
+        // On-disk state untouched.
+        let reloaded = KvStore::load(&good_schema_path, &good_data_path).unwrap();
+        assert!(reloaded.schema.keys.contains_key("flavor_history"));
+        assert!(!reloaded.schema.keys.contains_key("tea_history"));
     }
 }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1228,9 +1228,7 @@ impl KvStore {
             Some(DataValue::String { value }) => !value.is_empty(),
             Some(DataValue::History { entries, .. }) => !entries.is_empty(),
             Some(DataValue::List { items, .. }) => !items.is_empty(),
-            Some(DataValue::State { fields, .. }) => {
-                fields.values().any(|v| !v.is_empty())
-            }
+            Some(DataValue::State { fields, .. }) => fields.values().any(|v| !v.is_empty()),
         }
     }
 
@@ -8810,7 +8808,10 @@ count = { type = "number" }
 
         // Persisted: reload from disk and confirm.
         let reloaded = KvStore::load(&store.schema_path, &store.data_path).unwrap();
-        assert_eq!(reloaded.schema.keys["new_counter"].value_type, ValueType::Counter);
+        assert_eq!(
+            reloaded.schema.keys["new_counter"].value_type,
+            ValueType::Counter
+        );
         assert_eq!(reloaded.schema.keys["new_list"].value_type, ValueType::List);
     }
 


### PR DESCRIPTION
Closes #363

## Summary

Consolidates KV schema lifecycle management under a single `mx kv schema [list | add | drop | update]` namespace. Closes the orphaned-key gap (no removal path existed) and makes key definition a first-class verb for all five types. The legacy top-level `kv keys` and `kv rename` verbs are retained as deprecated aliases — no breaking changes this cycle.

## Commands

- `mx kv schema list` — absorbs `kv keys`; stdout byte-identical.
- `mx kv schema add <key> --type <T>` — first-class definition for all five `ValueType`s, with `--max-entries / --default / --min / --max / --description / --fields / --data`. Routes through the same engine as the retained `push --create` shortcut.
- `mx kv schema drop <key> [--force]` — removes schema definition **and** stored data. `--force` gates non-empty keys; silent for empty/never-written. Unregistered → `KeyNotFound`.
- `mx kv schema update <key>` — safe metadata edits only (`--description / --max-entries / --min / --max / --add-field`); `--name` delegates to `rename_key`. `--type` is forbidden and points at `kv migrate` (no override).

## Binding decrees honored (kn-fdabe4c6 / kn-14ed7e8a)

1. `update` retype — **forbidden**, errors to `kv migrate`, no `--force`.
2. Rename — top-level `kv rename` kept working AND mirrored as `schema update --name`; both route to `rename_key`. Top-level marked deprecated (clap doc-comment + stderr notice).
3. `drop` non-empty — `--force` required; silent for empty/never-written.
4. `drop` unregistered — error via `KvError::KeyNotFound`.
5. No `--json` flag anywhere (deferred to the mx-wide JSON overhaul).
6. `kv keys` deprecated alias of `schema list` — stderr notice, stdout byte-identical.
7. `drop`/`update` follow the `rename_key` transaction pattern (mutate in-memory, persist data-first then schema, roll back on data-write failure).

## Spec ambiguity resolved (flagged for review)

The issue prose says unregistered `drop` returns **"exit code 3 (KeyNotFound)"**, but the canonical KV exit-code table (decree kn-daf2020b, PR #250) maps `key-not-found = 1` and `schema-missing = 3`. Every other verb returns **exit 1** for an unknown key. Honoring the decree's "consistent with every other verb" intent, I routed `drop` of an unregistered key through `KvError::KeyNotFound` → **exit 1**. The "3" in the issue text appears to conflate the variant name with a number; using 3 here would contradict the foundational exit-code contract. **Please confirm.**

## Engine (src/kv.rs)

- `add_key_def(key, KeyDef)` — general definition path (all types), persists via `save_schema`.
- `drop_key(key)` — full removal, rename_key transaction pattern.
- `update_key_meta(...)` — safe-only metadata edits, schema-only persist with rollback.
- `key_has_content(key)` — drives the `--force` gate (distinguishes empty/default vs. populated).
- `add_key_to_schema` retained unchanged for `push --create` (append-based, comment-preserving).

## Docs (all 6 surfaces)

`docs/src/kv.typ` (new Schema management section + deprecation notes), `architecture.typ` (schema-mutation model), `getting-started.typ`, `README.md`, regenerated HTML via `docs/build.sh`, and the tracked LLM bundle `docs/out/llm/mx-docs.md`.

## Test evidence

`cargo test --bin mx`: **1128 passed; 0 failed; 3 ignored**.

New coverage: `add` each of the five types + duplicate/invalid-name; `drop` empty/non-empty/unregistered/with-memory-link; `update` safe-metadata/clear-description/add-field/duplicate-field/unregistered; `key_has_content` empty-vs-populated; `parse_data_field_spec` all types + rejections. Rename delegation is exercised via the shared `rename_key` engine tests.

Live verification (scratch `MX_KV_SCHEMA`/`MX_KV_DATA`):
- `kv keys` vs `kv schema list` stdout: **byte-identical** (`cmp -s` clean); deprecation notice on stderr only.
- `drop` non-empty without `--force` → exit 4; with `--force` → exit 0; unregistered → **exit 1**.
- `push --create` still works through the shared path.
- `--type` on update → exit 4 with `kv migrate` pointer.
- Negative counter bounds (`--min -10`) parse (added `allow_hyphen_values`).

## Notes for reviewers

- HTML under `docs/out/html/` is gitignored; only `docs/out/llm/mx-docs.md` is tracked. Both regenerated.
- The repo working tree has pre-existing untracked junk (`C:/`, `examples/`, `memory-export/`). The `examples/win_lock_repro.rs` junk fails `cargo fmt --check` independently of this PR — it was moved aside only for the push hook and is not part of this branch.