### PR TITLE
feat(memory): --no-embed gate + add-batch with hoisted embedding provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# mx
+
+mx — Rust CLI for memory graph and KV store operations.
+
+Used by hearth and companions to persist memory, traits, and session state to
+a SurrealDB backend. Companions invoke it via the `hearth mx` proxy, which
+injects credentials at runtime. No runbook yet — the codebase is the reference.
+
+Key commands: `memory add`, `memory list`, `memory get`, `kv set`, `kv get`.
+The `--mine` flag scopes queries to the calling agent (`MX_CURRENT_AGENT`).
+
+## Maintenance Rule
+
+If you change behavior of existing commands, note it in the CHANGELOG and
+verify companion-facing usage in `~/.soren/config/agents/` still holds.

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -363,6 +363,79 @@ mx migrate            # apply schema (ignores MX_SKIP_SCHEMA)
 mx migrate -v         # verbose: see connection and schema details
 ```
 
+## Environment variable reference {#env-vars}
+
+Key environment variables recognized by mx. All boolean opt-outs follow
+the same convention: `"1"` or `"true"` (case-insensitive) to disable;
+any other value leaves the default behavior on.
+
++------------------------+-----------------+-----------------+-------------------------+
+| **Variable**           | **Type**        | **Default**     | **Description**         |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_HOME`              | path            | `~/.mx/`        | Root directory for all  |
+|                        |                 |                 | mx data. Override to    |
+|                        |                 |                 | move the whole tree.    |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_SURREAL_MODE`      | string          | `embedded`      | `embedded` (local       |
+|                        |                 |                 | SurrealKV file) or      |
+|                        |                 |                 | `network` (remote       |
+|                        |                 |                 | WebSocket). Embedding   |
+|                        |                 |                 | model calls only work   |
+|                        |                 |                 | in network mode.        |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_SURREAL_URL`       | string          | ---             | WebSocket URL for       |
+|                        |                 |                 | network mode (e.g.      |
+|                        |                 |                 | `ws://localhost:8000`). |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_SURREAL_NS`        | string          | ---             | SurrealDB namespace for |
+|                        |                 |                 | network mode.           |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_SURREAL_DB`        | string          | ---             | SurrealDB database name |
+|                        |                 |                 | for network mode.       |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_CURRENT_AGENT`     | string          | ---             | Active agent            |
+|                        |                 |                 | identifier. Used as     |
+|                        |                 |                 | default `source_agent`  |
+|                        |                 |                 | on writes and to scope  |
+|                        |                 |                 | private entry           |
+|                        |                 |                 | visibility.             |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_SKIP_SCHEMA`       | bool            | `false`         | Skip automatic schema   |
+|                        |                 |                 | application on          |
+|                        |                 |                 | connection. Use         |
+|                        |                 |                 | `mx migrate` to apply   |
+|                        |                 |                 | the schema explicitly   |
+|                        |                 |                 | when set.               |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_SKIP_WRITE_ANCHOR` | bool            | `false`         | Skip synchronous        |
+|                        |                 |                 | `auto-anchor` on every  |
+|                        |                 |                 | write. Equivalent to    |
+|                        |                 |                 | passing                 |
+|                        |                 |                 | `--no-auto-anchor`      |
+|                        |                 |                 | globally. Useful when a |
+|                        |                 |                 | nightly                 |
+|                        |                 |                 | `mx memory auto-anchor` |
+|                        |                 |                 | handles anchoring in    |
+|                        |                 |                 | batch.                  |
++------------------------+-----------------+-----------------+-------------------------+
+| `MX_SKIP_WRITE_EMBED`  | bool            | `false`         | Skip synchronous        |
+|                        |                 |                 | embedding generation on |
+|                        |                 |                 | every write. Equivalent |
+|                        |                 |                 | to passing `--no-embed` |
+|                        |                 |                 | globally. Entries       |
+|                        |                 |                 | written with this set   |
+|                        |                 |                 | are absent from         |
+|                        |                 |                 | `--semantic` search     |
+|                        |                 |                 | until                   |
+|                        |                 |                 | `mx memory embed --all` |
+|                        |                 |                 | runs. Intended for      |
+|                        |                 |                 | deployments where a     |
+|                        |                 |                 | nightly embed timer     |
+|                        |                 |                 | (e.g. Cinder's          |
+|                        |                 |                 | `embed.nix`) keeps the  |
+|                        |                 |                 | graph fresh.            |
++------------------------+-----------------+-----------------+-------------------------+
+
 ## What's next
 
 - Read the commit, log, and show reference pages for the full flag
@@ -1170,6 +1243,7 @@ the category and generates a title from content).
   `--session`             `string`   Session to link fact to via EXTRACTED_FROM relationship. Requires `--type`.
   `--thread-id`           `string`   Thread ID for `thread_closed` operations. Requires `--type`.
   `--no-auto-anchor`      `flag`     Skip automatic anchor generation.
+  `--no-embed`            `flag`     Skip synchronous embedding generation on write.
   `--json`                `flag`     Output as JSON.
 
 ### Examples
@@ -1202,6 +1276,55 @@ mx memory add --category ingredient -t "API reference" -f api-notes.md
 **TIP:** When `--type` is provided, `--category` and `--title` become
 optional. The fact type routes to an appropriate category and generates
 a title from the content automatically.
+:::
+
+## `mx memory add-batch`
+
+Add multiple entries in a single invocation from a JSONL file or stdin.
+Each line is a JSON object whose fields match `mx memory add` arguments
+(`category`, `title`, `content`, `tags`, `source_agent`, `type`, etc.).
+The store is opened once and the  435 MB embedding model is loaded once
+for the whole batch, so a 30-entry bulk caller pays one cold-load
+instead of thirty. Malformed lines are skipped and reported at the end;
+one bad entry does not abort the rest (partial-success semantics). Exits
+non-zero when any entry failed.
+
+**Recommended delivery:** pass a JSONL file via `--file` when calling
+through a `sudo` wrapper (e.g. the hearth `_secret-exec` proxy) --- a
+file path survives wrapper layers where a piped stdin may not.
+
+### Flags
+
+  **Flag**       **Type**   **Description**
+  -------------- ---------- ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  `-f, --file`   `path`     Path to a JSONL file (one JSON object per line). Reads from stdin when omitted.
+  `--no-embed`   `flag`     Skip embedding for the whole batch. Defers to the next `mx memory embed --all` run (e.g. a nightly cron). Keyword and tag search are unaffected; only `--semantic` search misses un-embedded entries until then.
+
+### Examples
+
+``` bash
+# Stdin pipe
+printf '{"category":"insight","title":"T1","content":"C1","source_agent":"soren"}\n{"type":"decision","content":"chose Rust","source_agent":"soren"}\n' \
+  | mx memory add-batch
+```
+
+``` bash
+# File (safer through sudo wrappers)
+mx memory add-batch --file /tmp/pocket-entries.jsonl
+```
+
+``` bash
+# Skip embedding — defer to nightly embed --all
+mx memory add-batch --file entries.jsonl --no-embed
+```
+
+::: {.admonition .note}
+**NOTE:** Each JSONL line for `add-batch` is a self-describing payload:
+include all per-entry fields (`category`, `title`, `content`,
+`source_agent`, `tags`, `private`, `resonance`, `type`, etc.) on each
+line. There are no batch-wide field overrides except `--no-embed`. This
+design supports heterogeneous batches (facts, person nodes, summaries,
+blooms) in a single invocation --- which is the primary pocket use-case.
 :::
 
 ## Reading entries {#reading}
@@ -1391,6 +1514,7 @@ field. Content mutation modes are mutually exclusive.
   `--session-id`           `string`   Update session ID (for retrofitting entries with wrong or missing session linkage).
   `--force`                `flag`     Force dangerous visibility changes (e.g., making blooms public).
   `--no-auto-anchor`       `flag`     Skip automatic anchor generation.
+  `--no-embed`             `flag`     Skip synchronous embedding generation on write.
   `--json`                 `flag`     Output as JSON.
 
 ### Examples
@@ -1430,6 +1554,7 @@ interface.
   `--replace-all`      `flag`     Replace all occurrences (default: error if multiple matches).
   `--nth`              `int`      Replace only the Nth occurrence (1-indexed).
   `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--no-embed`         `flag`     Skip synchronous embedding generation on write.
   `--json`             `flag`     Output as JSON.
 
 ### Examples
@@ -1454,6 +1579,7 @@ Append content to the end of an entry's body. Shortcut for
   `--content`          `string`   Content to append (omit to read from stdin).
   `-f, --file`         `path`     Read content from file. Also accepts `--content-file`.
   `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--no-embed`         `flag`     Skip synchronous embedding generation on write.
   `--json`             `flag`     Output as JSON.
 
 ### Examples
@@ -1478,6 +1604,7 @@ Prepend content to the start of an entry's body. Shortcut for
   `--content`          `string`   Content to prepend (omit to read from stdin).
   `-f, --file`         `path`     Read content from file. Also accepts `--content-file`.
   `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--no-embed`         `flag`     Skip synchronous embedding generation on write.
   `--json`             `flag`     Output as JSON.
 
 ### Examples
@@ -1494,9 +1621,10 @@ backups before restoring.
 ### Flags
 
   **Flag**             **Type**   **Description**
-  -------------------- ---------- ----------------------------------------------
+  -------------------- ---------- -------------------------------------------------
   `--list`             `flag`     List available backups instead of restoring.
   `--no-auto-anchor`   `flag`     Skip automatic anchor generation.
+  `--no-embed`         `flag`     Skip synchronous embedding generation on write.
   `--json`             `flag`     Output as JSON.
 
 ### Examples
@@ -1760,6 +1888,25 @@ After each write, mx re-evaluates anchors and prunes stale ones using
 the same similarity thresholds. Pass `--no-auto-anchor` on any of these
 commands to skip this step -- useful for bulk operations or cleanup
 scripts where the overhead is unwanted.
+:::
+
+::: {.admonition .note}
+**NOTE:** **Deferred embedding:** Pass `--no-embed` (or set
+`MX_SKIP_WRITE_EMBED=1`) on any write command (`add`, `update`, `edit`,
+`append`, `prepend`, `restore`, `add-batch`) to skip synchronous
+embedding generation on that write. The entry is written and fully
+durable immediately; only the vector embedding is deferred.
+
+**Trade-off:** entries written with `--no-embed` are absent from
+`--semantic` (vector) search results until a later
+`mx memory embed --all` run fills the gap. Keyword search
+(`mx memory search <query>`) and tag-based filters are unaffected.
+
+This flag exists to amortize the  435 MB embedding model cold-load: use
+it with `add-batch` (which does its own single hoisted embed pass at the
+end), or set `MX_SKIP_WRITE_EMBED=1` globally in a deployment where a
+nightly `mx memory embed --all` (e.g. via Cinder's `embed.nix` timer)
+keeps the graph fresh.
 :::
 
 ## Relationships

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -239,14 +239,14 @@ Key environment variables recognized by mx. All boolean opt-outs follow the
 same convention: `"1"` or `"true"` (case-insensitive) to disable; any other
 value leaves the default behavior on.
 
+SurrealDB connection variables (`MX_SURREAL_MODE`, `MX_SURREAL_URL`,
+`MX_SURREAL_NS`, `MX_SURREAL_DB`, etc.) are documented in full with their
+defaults in #link("paths.html#env-surreal")[filesystem layout → SurrealDB connection].
+
 #table(
   columns: (auto, auto, auto, 1fr),
   [*Variable*], [*Type*], [*Default*], [*Description*],
   [`MX_HOME`], [path], [`~/.mx/`], [Root directory for all mx data. Override to move the whole tree.],
-  [`MX_SURREAL_MODE`], [string], [`embedded`], [`embedded` (local SurrealKV file) or `network` (remote WebSocket). Embedding model calls only work in network mode.],
-  [`MX_SURREAL_URL`], [string], [—], [WebSocket URL for network mode (e.g. `ws://localhost:8000`).],
-  [`MX_SURREAL_NS`], [string], [—], [SurrealDB namespace for network mode.],
-  [`MX_SURREAL_DB`], [string], [—], [SurrealDB database name for network mode.],
   [`MX_CURRENT_AGENT`], [string], [—], [Active agent identifier. Used as default `source_agent` on writes and to scope private entry visibility.],
   [`MX_SKIP_SCHEMA`], [bool], [`false`], [Skip automatic schema application on connection. Use `mx migrate` to apply the schema explicitly when set.],
   [`MX_SKIP_WRITE_ANCHOR`], [bool], [`false`], [Skip synchronous `auto-anchor` on every write. Equivalent to passing `--no-auto-anchor` globally. Useful when a nightly `mx memory auto-anchor` handles anchoring in batch.],

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -233,6 +233,26 @@ mx migrate            # apply schema (ignores MX_SKIP_SCHEMA)
 mx migrate -v         # verbose: see connection and schema details
 ```
 
+== Environment variable reference <env-vars>
+
+Key environment variables recognized by mx. All boolean opt-outs follow the
+same convention: `"1"` or `"true"` (case-insensitive) to disable; any other
+value leaves the default behavior on.
+
+#table(
+  columns: (auto, auto, auto, 1fr),
+  [*Variable*], [*Type*], [*Default*], [*Description*],
+  [`MX_HOME`], [path], [`~/.mx/`], [Root directory for all mx data. Override to move the whole tree.],
+  [`MX_SURREAL_MODE`], [string], [`embedded`], [`embedded` (local SurrealKV file) or `network` (remote WebSocket). Embedding model calls only work in network mode.],
+  [`MX_SURREAL_URL`], [string], [—], [WebSocket URL for network mode (e.g. `ws://localhost:8000`).],
+  [`MX_SURREAL_NS`], [string], [—], [SurrealDB namespace for network mode.],
+  [`MX_SURREAL_DB`], [string], [—], [SurrealDB database name for network mode.],
+  [`MX_CURRENT_AGENT`], [string], [—], [Active agent identifier. Used as default `source_agent` on writes and to scope private entry visibility.],
+  [`MX_SKIP_SCHEMA`], [bool], [`false`], [Skip automatic schema application on connection. Use `mx migrate` to apply the schema explicitly when set.],
+  [`MX_SKIP_WRITE_ANCHOR`], [bool], [`false`], [Skip synchronous `auto-anchor` on every write. Equivalent to passing `--no-auto-anchor` globally. Useful when a nightly `mx memory auto-anchor` handles anchoring in batch.],
+  [`MX_SKIP_WRITE_EMBED`], [bool], [`false`], [Skip synchronous embedding generation on every write. Equivalent to passing `--no-embed` globally. Entries written with this set are absent from `--semantic` search until `mx memory embed --all` runs. Intended for deployments where a nightly embed timer (e.g. Cinder's `embed.nix`) keeps the graph fresh.],
+)
+
 == What's next
 
 - Read the #link("commit.html")[commit], #link("log.html")[log], and

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -76,6 +76,7 @@ explicitly apply the schema (it ignores `MX_SKIP_SCHEMA`).]
     ([`--session`],    [`string`], [Session to link fact to via EXTRACTED_FROM relationship. Requires `--type`.]),
     ([`--thread-id`],  [`string`], [Thread ID for `thread_closed` operations. Requires `--type`.]),
     ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
+    ([`--no-embed`],   [`flag`],   [Skip synchronous embedding generation on write.]),
     ([`--json`],       [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -89,6 +90,38 @@ explicitly apply the schema (it ignores `MX_SKIP_SCHEMA`).]
 #tip[When `--type` is provided, `--category` and `--title` become optional. The
 fact type routes to an appropriate category and generates a title from the
 content automatically.]
+
+#command(
+  "mx memory add-batch",
+  [Add multiple entries in a single invocation from a JSONL file or stdin.
+  Each line is a JSON object whose fields match `mx memory add` arguments
+  (`category`, `title`, `content`, `tags`, `source_agent`, `type`, etc.).
+  The store is opened once and the ~435 MB embedding model is loaded once for
+  the whole batch, so a 30-entry bulk caller pays one cold-load instead of
+  thirty. Malformed lines are skipped and reported at the end; one bad entry
+  does not abort the rest (partial-success semantics). Exits non-zero when any
+  entry failed.
+
+  *Recommended delivery:* pass a JSONL file via `--file` when calling through
+  a `sudo` wrapper (e.g. the hearth `_secret-exec` proxy) — a file path
+  survives wrapper layers where a piped stdin may not.],
+  flags: (
+    ([`-f, --file`], [`path`],  [Path to a JSONL file (one JSON object per line). Reads from stdin when omitted.]),
+    ([`--no-embed`], [`flag`],  [Skip embedding for the whole batch. Defers to the next `mx memory embed --all` run (e.g. a nightly cron). Keyword and tag search are unaffected; only `--semantic` search misses un-embedded entries until then.]),
+  ),
+  examples: (
+    "# Stdin pipe\nprintf '{\"category\":\"insight\",\"title\":\"T1\",\"content\":\"C1\",\"source_agent\":\"soren\"}\\n{\"type\":\"decision\",\"content\":\"chose Rust\",\"source_agent\":\"soren\"}\\n' \\\n  | mx memory add-batch",
+    "# File (safer through sudo wrappers)\nmx memory add-batch --file /tmp/pocket-entries.jsonl",
+    "# Skip embedding — defer to nightly embed --all\nmx memory add-batch --file entries.jsonl --no-embed",
+  ),
+)
+
+#note[Each JSONL line for `add-batch` is a self-describing payload: include all
+per-entry fields (`category`, `title`, `content`, `source_agent`, `tags`,
+`private`, `resonance`, `type`, etc.) on each line. There are no batch-wide
+field overrides except `--no-embed`. This design supports heterogeneous batches
+(facts, person nodes, summaries, blooms) in a single invocation --- which is
+the primary pocket use-case.]
 
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -237,6 +270,7 @@ engagement. Use `--activate` when you are intentionally consuming the results
     ([`--session-id`],    [`string`], [Update session ID (for retrofitting entries with wrong or missing session linkage).]),
     ([`--force`],         [`flag`],   [Force dangerous visibility changes (e.g., making blooms public).]),
     ([`--no-auto-anchor`], [`flag`],  [Skip automatic anchor generation.]),
+    ([`--no-embed`],      [`flag`],  [Skip synchronous embedding generation on write.]),
     ([`--json`],          [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -258,6 +292,7 @@ engagement. Use `--activate` when you are intentionally consuming the results
     ([`--replace-all`], [`flag`],   [Replace all occurrences (default: error if multiple matches).]),
     ([`--nth`],         [`int`],    [Replace only the Nth occurrence (1-indexed).]),
     ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
+    ([`--no-embed`],    [`flag`],   [Skip synchronous embedding generation on write.]),
     ([`--json`],        [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -274,6 +309,7 @@ engagement. Use `--activate` when you are intentionally consuming the results
     ([`--content`], [`string`], [Content to append (omit to read from stdin).]),
     ([`-f, --file`], [`path`],  [Read content from file. Also accepts `--content-file`.]),
     ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
+    ([`--no-embed`], [`flag`],  [Skip synchronous embedding generation on write.]),
     ([`--json`],    [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -290,6 +326,7 @@ engagement. Use `--activate` when you are intentionally consuming the results
     ([`--content`], [`string`], [Content to prepend (omit to read from stdin).]),
     ([`-f, --file`], [`path`],  [Read content from file. Also accepts `--content-file`.]),
     ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
+    ([`--no-embed`], [`flag`],  [Skip synchronous embedding generation on write.]),
     ([`--json`],    [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -304,6 +341,7 @@ engagement. Use `--activate` when you are intentionally consuming the results
   flags: (
     ([`--list`], [`flag`], [List available backups instead of restoring.]),
     ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
+    ([`--no-embed`], [`flag`], [Skip synchronous embedding generation on write.]),
     ([`--json`], [`flag`], [Output as JSON.]),
   ),
   examples: (
@@ -489,6 +527,22 @@ mx re-evaluates anchors and prunes stale ones using the same similarity
 thresholds. Pass `--no-auto-anchor` on any of these commands to skip this
 step -- useful for bulk operations or cleanup scripts where the overhead is
 unwanted.]
+
+#note[*Deferred embedding:* Pass `--no-embed` (or set `MX_SKIP_WRITE_EMBED=1`)
+on any write command (`add`, `update`, `edit`, `append`, `prepend`, `restore`,
+`add-batch`) to skip synchronous embedding generation on that write. The entry
+is written and fully durable immediately; only the vector embedding is deferred.
+
+*Trade-off:* entries written with `--no-embed` are absent from `--semantic`
+(vector) search results until a later `mx memory embed --all` run fills the
+gap. Keyword search (`mx memory search <query>`) and tag-based filters are
+unaffected.
+
+This flag exists to amortize the ~435 MB embedding model cold-load: use it with
+`add-batch` (which does its own single hoisted embed pass at the end), or set
+`MX_SKIP_WRITE_EMBED=1` globally in a deployment where a nightly
+`mx memory embed --all` (e.g. via Cinder's `embed.nix` timer) keeps the graph
+fresh.]
 
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -668,6 +668,10 @@ pub enum MemoryCommands {
         /// Skip automatic anchor generation
         #[arg(long)]
         no_auto_anchor: bool,
+
+        /// Skip synchronous embedding generation on write
+        #[arg(long)]
+        no_embed: bool,
     },
 
     /// Update an existing entry in the database
@@ -819,6 +823,10 @@ pub enum MemoryCommands {
         #[arg(long)]
         no_auto_anchor: bool,
 
+        /// Skip synchronous embedding generation on write
+        #[arg(long)]
+        no_embed: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -849,6 +857,10 @@ pub enum MemoryCommands {
         #[arg(long)]
         no_auto_anchor: bool,
 
+        /// Skip synchronous embedding generation on write
+        #[arg(long)]
+        no_embed: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -875,6 +887,10 @@ pub enum MemoryCommands {
         /// Skip automatic anchor generation
         #[arg(long)]
         no_auto_anchor: bool,
+
+        /// Skip synchronous embedding generation on write
+        #[arg(long)]
+        no_embed: bool,
 
         /// Output as JSON
         #[arg(long)]
@@ -903,6 +919,10 @@ pub enum MemoryCommands {
         #[arg(long)]
         no_auto_anchor: bool,
 
+        /// Skip synchronous embedding generation on write
+        #[arg(long)]
+        no_embed: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -921,9 +941,44 @@ pub enum MemoryCommands {
         #[arg(long)]
         no_auto_anchor: bool,
 
+        /// Skip synchronous embedding generation on write
+        #[arg(long)]
+        no_embed: bool,
+
         /// Output as JSON
         #[arg(long)]
         json: bool,
+    },
+
+    /// Add multiple entries in a single invocation from a JSONL file or stdin.
+    ///
+    /// Each line of input must be a JSON object whose fields match the `mx
+    /// memory add` arguments (category, title, content, tags, source_agent,
+    /// etc.). The store is opened ONCE and the embedding model is loaded ONCE
+    /// for the whole batch, amortizing the ~435 MB cold-load across all
+    /// entries. Malformed lines are skipped and reported; one bad entry does
+    /// not abort the rest (partial-success semantics). Exits non-zero when any
+    /// entry failed.
+    ///
+    /// Example (stdin):
+    ///   printf '{"category":"insight","title":"T1","content":"C1","source_agent":"soren"}\n...' \
+    ///     | mx memory add-batch
+    ///
+    /// Example (file):
+    ///   mx memory add-batch --file entries.jsonl
+    AddBatch {
+        /// Path to a JSONL file (one JSON object per line). If omitted, reads
+        /// from stdin. Use --file when piping through a sudo wrapper that may
+        /// consume stdin.
+        #[arg(short, long)]
+        file: Option<String>,
+
+        /// Skip synchronous embedding generation for the whole batch.
+        /// Defers embedding to the next `mx memory embed --all` run (e.g. a
+        /// nightly cron). Keyword and tag search are unaffected; only
+        /// `--semantic` search misses uembedded entries.
+        #[arg(long)]
+        no_embed: bool,
     },
 
     /// Generate embedding for a knowledge entry

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -339,6 +339,151 @@ fn write_verification_ctx(
     }
 }
 
+/// Resolved arguments for a single standard-mode `memory add` write.
+///
+/// Both the `Add` CLI arm and `AddBatch` JSONL path construct this struct from
+/// their respective sources (flag values vs JSON fields) and call `add_one` as
+/// the single shared write path. This ensures both callers are identical in
+/// what they write — fact-type routing, edge creation, embedding, and anchoring
+/// all happen in one place so neither path can silently drift.
+struct AddOneArgs {
+    agent_id: String,
+    category: String,
+    title: String,
+    body: String,
+    tag_list: Vec<String>,
+    applicability_list: Vec<String>,
+    anchor_list: Vec<String>,
+    trigger_list: Vec<String>,
+    wake_phrase_list: Vec<String>,
+    wake_phrase: Option<String>,
+    wake_order: Option<i32>,
+    entry_visibility: String,
+    entry_owner: Option<String>,
+    session_id: Option<String>,
+    ephemeral: bool,
+    source_type: String,
+    entry_type: String,
+    content_type: String,
+    domain: Option<String>,
+    resonance: i32,
+    resonance_type: Option<String>,
+    project: Option<String>,
+}
+
+/// Core standard-mode write path shared by `Add` and `AddBatch`.
+///
+/// Inserts one entry, verifies the write, wires the EXTRACTED_FROM edge, and
+/// (when not suppressed) runs embed and auto-anchor. Returns the inserted
+/// `KnowledgeEntry` so the caller can format output without duplicating field
+/// reads.
+///
+/// `embed`           — when `true` calls `auto_embed`; pass
+///                     `write_embed_enabled(no_embed)` from the caller.
+/// `no_auto_anchor`  — passed through to `write_anchor_enabled`; mirrors the
+///                     same flag on the single-add path.
+fn add_one(
+    args: AddOneArgs,
+    db: &dyn store::KnowledgeStore,
+    embed: bool,
+    no_auto_anchor: bool,
+) -> Result<knowledge::KnowledgeEntry> {
+    let path_hint = args.domain.unwrap_or_else(|| args.category.clone());
+    let id = knowledge::KnowledgeEntry::generate_id(&path_hint, &args.title);
+    let now = chrono::Utc::now().to_rfc3339();
+
+    let entry = knowledge::KnowledgeEntry {
+        id: id.clone(),
+        category_id: args.category.clone(),
+        title: args.title.clone(),
+        body: Some(args.body.clone()),
+        summary: None,
+        applicability: args.applicability_list.clone(),
+        source_project_id: args.project,
+        source_agent_id: Some(args.agent_id.clone()),
+        file_path: None,
+        tags: args.tag_list,
+        created_at: Some(now.clone()),
+        updated_at: Some(now),
+        content_hash: Some(knowledge::KnowledgeEntry::compute_hash(&args.title)),
+        source_type_id: Some(args.source_type),
+        entry_type_id: Some(args.entry_type),
+        session_id: args.session_id.clone(),
+        ephemeral: args.ephemeral,
+        content_type_id: Some(args.content_type),
+        owner: args.entry_owner.clone(),
+        visibility: args.entry_visibility.clone(),
+        resonance: args.resonance,
+        resonance_type: args.resonance_type,
+        last_activated: None,
+        activation_count: 0,
+        decay_rate: 0.0,
+        anchors: args.anchor_list,
+        wake_phrases: args.wake_phrase_list,
+        triggers: args.trigger_list,
+        wake_order: args.wake_order,
+        wake_phrase: args.wake_phrase,
+        embedding: None,
+        embedding_model: None,
+        embedded_at: None,
+        chunk_count: 0,
+        format: "markdown".to_string(),
+        effective_resonance: None,
+    };
+
+    // Insert into database.
+    db.upsert_knowledge(&entry)?;
+
+    // Verify the write landed. SurrealDB's PERMISSIONS clause silently rejects
+    // unauthorized writes (zero rows affected, no error). A read-after-write
+    // catches that and turns silent data-loss into a loud failure.
+    {
+        let ctx = write_verification_ctx(
+            &args.entry_visibility,
+            args.entry_owner.as_deref(),
+            &args.agent_id,
+        );
+        if db.get(&id, &ctx)?.is_none() {
+            bail!(
+                "write rejected: entry '{}' was not persisted (likely a permission denial — \
+                 check that the writing agent owns the entry or has permission to create it)",
+                id
+            );
+        }
+    }
+
+    // Wire EXTRACTED_FROM edge when session_id is provided.
+    if let Some(ref sess_id) = args.session_id {
+        let session_ref = normalize_id(sess_id);
+        let ctx = store::AgentContext::public_only();
+        if db.get(&session_ref, &ctx)?.is_none() {
+            eprintln!(
+                "Warning: Session {} not found - EXTRACTED_FROM edge not created",
+                session_ref
+            );
+        } else {
+            db.add_relationship(&id, &session_ref, "extracted_from")?;
+        }
+    }
+
+    // Auto-generate embedding. Gated by the caller-resolved `embed` flag
+    // (which reflects both --no-embed and MX_SKIP_WRITE_EMBED).
+    if embed {
+        auto_embed(&id, db)?;
+    } else {
+        println!("  (embed skipped)");
+    }
+
+    // Auto-generate anchors. Gated by --no-auto-anchor / MX_SKIP_WRITE_ANCHOR.
+    if write_anchor_enabled(no_auto_anchor) {
+        auto_anchor(&id, db, None)?;
+    } else {
+        println!("  (auto-anchor skipped)");
+    }
+
+    Ok(entry)
+}
+
 pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
     let config = IndexConfig::default();
 
@@ -1071,112 +1216,40 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
             }
 
-            // Generate ID
-            let path_hint = domain.unwrap_or_else(|| category.clone());
-            let id = knowledge::KnowledgeEntry::generate_id(&path_hint, &title);
+            // Delegate to the shared single-entry write path. Both `Add` and
+            // `AddBatch` route through `add_one` so the write contract (insert,
+            // verify, edge, embed, anchor) stays in one place.
+            let entry = add_one(
+                AddOneArgs {
+                    agent_id: agent_id.clone(),
+                    category: category.clone(),
+                    title: title.clone(),
+                    body,
+                    tag_list,
+                    applicability_list,
+                    anchor_list,
+                    trigger_list,
+                    wake_phrase_list,
+                    wake_phrase,
+                    wake_order,
+                    entry_visibility: entry_visibility.clone(),
+                    entry_owner: entry_owner.clone(),
+                    session_id,
+                    ephemeral,
+                    source_type,
+                    entry_type,
+                    content_type,
+                    domain,
+                    resonance: resonance.unwrap_or(0),
+                    resonance_type,
+                    project,
+                },
+                db.as_ref(),
+                write_embed_enabled(no_embed),
+                no_auto_anchor,
+            )?;
 
-            // Create entry
-            let now = chrono::Utc::now().to_rfc3339();
-            let entry = knowledge::KnowledgeEntry {
-                id: id.clone(),
-                category_id: category.clone(),
-                title: title.clone(),
-                body: Some(body),
-                summary: None,
-                applicability: applicability_list.clone(),
-                source_project_id: project,
-                source_agent_id: Some(agent_id.clone()),
-                file_path: None,
-                tags: tag_list,
-                created_at: Some(now.clone()),
-                updated_at: Some(now),
-                content_hash: Some(knowledge::KnowledgeEntry::compute_hash(&title)),
-                source_type_id: Some(source_type),
-                entry_type_id: Some(entry_type),
-                session_id: session_id.clone(),
-                ephemeral,
-                content_type_id: Some(content_type),
-                owner: entry_owner.clone(),
-                visibility: entry_visibility.clone(),
-                resonance: resonance.unwrap_or(0),
-                resonance_type,
-                last_activated: None,
-                activation_count: 0,
-                decay_rate: 0.0,
-                anchors: anchor_list,
-                wake_phrases: wake_phrase_list,
-                // Issue #246: triggers from the --triggers CLI flag (PR2).
-                triggers: trigger_list,
-                wake_order,
-                wake_phrase,
-                embedding: None,
-                embedding_model: None,
-                embedded_at: None,
-                chunk_count: 0,
-                format: "markdown".to_string(),
-                effective_resonance: None,
-            };
-
-            // Insert into database (applicability already set in struct)
-            db.upsert_knowledge(&entry)?;
-
-            // Verify the write landed by reading it back. A genuinely lost write
-            // (e.g. a record-level PERMISSIONS denial that affects zero rows without
-            // erroring) reads back as absent, so we bail loudly instead of printing
-            // a false success. The read-back must use a context whose visibility
-            // matches the row we wrote: the entry's own `owner`. Reading a private
-            // entry back as the *acting* agent would falsely fail when --owner points
-            // at someone else, because the visibility filter only admits a private
-            // row when `owner = $current_agent`. A public entry is always visible, so
-            // any agent context (or none) matches.
-            {
-                let ctx =
-                    write_verification_ctx(&entry_visibility, entry_owner.as_deref(), &agent_id);
-                if db.get(&id, &ctx)?.is_none() {
-                    bail!(
-                        "write rejected: entry '{}' was not persisted (likely a permission denial — check that the writing agent owns the entry or has permission to create it)",
-                        id
-                    );
-                }
-            }
-
-            // Create EXTRACTED_FROM edge when --session-id is provided.
-            // Standard mode stores session_id as a field but the for-session query
-            // traverses the relates_to edge — wire both paths for consistency.
-            if let Some(ref sess_id) = session_id {
-                let session_ref = normalize_id(sess_id);
-                let ctx = crate::store::AgentContext::public_only();
-                if db.get(&session_ref, &ctx)?.is_none() {
-                    eprintln!(
-                        "Warning: Session {} not found - EXTRACTED_FROM edge not created",
-                        session_ref
-                    );
-                } else {
-                    db.add_relationship(&id, &session_ref, "extracted_from")?;
-                }
-            }
-
-            // Auto-generate embedding if in network SurrealDB mode.
-            // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see
-            // write_embed_enabled). The entry is already durable here, so
-            // skipping embedding is safe; the explicit `mx memory embed --all`
-            // command is never gated and still embeds deferred entries.
-            if write_embed_enabled(no_embed) {
-                auto_embed(&id, db.as_ref())?;
-            } else {
-                println!("  (embed skipped)");
-            }
-
-            // Auto-generate anchors if in network SurrealDB mode.
-            // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
-            // write_anchor_enabled). The entry is already durable here, so
-            // skipping anchoring is safe; the explicit `mx memory auto-anchor`
-            // command is never gated and still anchors deferred writes.
-            if write_anchor_enabled(no_auto_anchor) {
-                auto_anchor(&id, db.as_ref(), None)?;
-            } else {
-                println!("  (auto-anchor skipped)");
-            }
+            let id = entry.id.clone();
 
             if json {
                 println!(
@@ -2299,16 +2372,29 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         effective_resonance: None,
                     };
 
-                    db.upsert_knowledge(&entry)?;
+                    match db.upsert_knowledge(&entry) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            entry_errors.push((line_idx + 1, format!("db write error: {}", e)));
+                            continue;
+                        }
+                    }
 
                     // Read-back verify (same as single-add path)
                     let ctx = store::AgentContext::for_agent(&agent_id);
-                    if db.get(&id, &ctx)?.is_none() {
-                        entry_errors.push((
-                            line_idx + 1,
-                            format!("write rejected: fact '{}' not persisted", id),
-                        ));
-                        continue;
+                    match db.get(&id, &ctx) {
+                        Ok(Some(_)) => {}
+                        Ok(None) => {
+                            entry_errors.push((
+                                line_idx + 1,
+                                format!("write rejected: fact '{}' not persisted", id),
+                            ));
+                            continue;
+                        }
+                        Err(e) => {
+                            entry_errors.push((line_idx + 1, format!("read-back error: {}", e)));
+                            continue;
+                        }
                     }
 
                     // EXTRACTED_FROM edge if session provided
@@ -2319,21 +2405,41 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                             format!("kn-{}", sess)
                         };
                         let pub_ctx = store::AgentContext::public_only();
-                        if db.get(&session_ref, &pub_ctx)?.is_none() {
-                            eprintln!(
-                                "  line {}: Warning: Session {} not found - relationship not created",
-                                line_idx + 1,
-                                session_ref
-                            );
-                        } else {
-                            db.add_relationship(&id, &session_ref, "extracted_from")?;
+                        match db.get(&session_ref, &pub_ctx) {
+                            Ok(None) => {
+                                eprintln!(
+                                    "  line {}: Warning: Session {} not found - relationship not created",
+                                    line_idx + 1,
+                                    session_ref
+                                );
+                            }
+                            Ok(Some(_)) => {
+                                if let Err(e) = db.add_relationship(&id, &session_ref, "extracted_from") {
+                                    eprintln!(
+                                        "  line {}: Warning: EXTRACTED_FROM edge failed: {}",
+                                        line_idx + 1,
+                                        e
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "  line {}: Warning: session lookup error for {}: {}",
+                                    line_idx + 1,
+                                    session_ref,
+                                    e
+                                );
+                            }
                         }
                     }
 
                     println!("  [{}] Added fact: {}", line_idx + 1, id);
                     added_ids.push(id);
                 } else {
-                    // Standard add path (category + title required).
+                    // Standard add path — delegate to add_one(), the shared single-
+                    // entry write path. This ensures batch-added standard entries get
+                    // the same insert, verify, edge, embed (deferred), and anchor
+                    // logic as single adds, with no drift possible between the paths.
                     let category = match str_field("category") {
                         Some(c) if !c.is_empty() => c,
                         _ => {
@@ -2378,20 +2484,37 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         continue;
                     };
 
-                    // Validate category.
-                    if db.get_category(&category)?.is_none() {
-                        let categories = db.list_categories()?;
-                        let valid: Vec<&str> =
-                            categories.iter().map(|c| c.id.as_str()).collect();
-                        entry_errors.push((
-                            line_idx + 1,
-                            format!(
-                                "invalid category '{}'. Valid: {}",
-                                category,
-                                valid.join(", ")
-                            ),
-                        ));
-                        continue;
+                    // Validate category (done before add_one to provide skip-and-continue).
+                    match db.get_category(&category) {
+                        Ok(Some(_)) => {}
+                        Ok(None) => {
+                            match db.list_categories() {
+                                Ok(cats) => {
+                                    let valid: Vec<&str> =
+                                        cats.iter().map(|c| c.id.as_str()).collect();
+                                    entry_errors.push((
+                                        line_idx + 1,
+                                        format!(
+                                            "invalid category '{}'. Valid: {}",
+                                            category,
+                                            valid.join(", ")
+                                        ),
+                                    ));
+                                }
+                                Err(e) => {
+                                    entry_errors.push((
+                                        line_idx + 1,
+                                        format!("category lookup error: {}", e),
+                                    ));
+                                }
+                            }
+                            continue;
+                        }
+                        Err(e) => {
+                            entry_errors
+                                .push((line_idx + 1, format!("category lookup error: {}", e)));
+                            continue;
+                        }
                     }
 
                     let is_private = bool_field("private")
@@ -2447,94 +2570,55 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                                 .unwrap_or_default()
                         });
 
-                    let domain = str_field("domain");
-                    let path_hint = domain.unwrap_or_else(|| category.clone());
-                    let id = knowledge::KnowledgeEntry::generate_id(&path_hint, &title);
-                    let now = chrono::Utc::now().to_rfc3339();
-
-                    let entry = knowledge::KnowledgeEntry {
-                        id: id.clone(),
-                        category_id: category.clone(),
-                        title: title.clone(),
-                        body: Some(body.clone()),
-                        summary: None,
-                        applicability: applicability_list,
-                        source_project_id: str_field("project"),
-                        source_agent_id: Some(agent_id.clone()),
-                        file_path: None,
-                        tags: tag_list,
-                        created_at: Some(now.clone()),
-                        updated_at: Some(now),
-                        content_hash: Some(knowledge::KnowledgeEntry::compute_hash(&title)),
-                        source_type_id: Some(
-                            str_field("source_type")
+                    // Call the shared write path. Batch passes embed=false so the
+                    // hoisted embedding pass at the end of the loop handles it once.
+                    // no_auto_anchor mirrors the batch-level --no-embed: the batch
+                    // contract is defer-and-hoist for embedding; anchoring runs
+                    // per-entry here (same as single-add) because add_one handles it.
+                    let entry_result = add_one(
+                        AddOneArgs {
+                            agent_id: agent_id.clone(),
+                            category: category.clone(),
+                            title: title.clone(),
+                            body,
+                            tag_list,
+                            applicability_list,
+                            anchor_list,
+                            trigger_list,
+                            wake_phrase_list,
+                            wake_phrase: str_field("wake_phrase"),
+                            wake_order: int_field("wake_order"),
+                            entry_visibility,
+                            entry_owner,
+                            session_id: str_field("session_id"),
+                            ephemeral: bool_field("ephemeral"),
+                            source_type: str_field("source_type")
                                 .unwrap_or_else(|| "manual".to_string()),
-                        ),
-                        entry_type_id: Some(
-                            str_field("entry_type")
+                            entry_type: str_field("entry_type")
                                 .unwrap_or_else(|| "primary".to_string()),
-                        ),
-                        session_id: str_field("session_id"),
-                        ephemeral: bool_field("ephemeral"),
-                        content_type_id: Some(
-                            str_field("content_type")
+                            content_type: str_field("content_type")
                                 .unwrap_or_else(|| "text".to_string()),
-                        ),
-                        owner: entry_owner.clone(),
-                        visibility: entry_visibility.clone(),
-                        resonance: int_field("resonance").unwrap_or(0),
-                        resonance_type: str_field("resonance_type"),
-                        last_activated: None,
-                        activation_count: 0,
-                        decay_rate: 0.0,
-                        anchors: anchor_list,
-                        wake_phrases: wake_phrase_list,
-                        triggers: trigger_list,
-                        wake_order: int_field("wake_order"),
-                        wake_phrase: str_field("wake_phrase"),
-                        embedding: None,
-                        embedding_model: None,
-                        embedded_at: None,
-                        chunk_count: 0,
-                        format: "markdown".to_string(),
-                        effective_resonance: None,
-                    };
+                            domain: str_field("domain"),
+                            resonance: int_field("resonance").unwrap_or(0),
+                            resonance_type: str_field("resonance_type"),
+                            project: str_field("project"),
+                        },
+                        db.as_ref(),
+                        false, // embed=false — hoisted pass below embeds all at once
+                        true,  // no_auto_anchor=true — batch anchoring via nightly run
+                    );
 
-                    db.upsert_knowledge(&entry)?;
-
-                    // Read-back verify.
-                    {
-                        let ctx = write_verification_ctx(
-                            &entry_visibility,
-                            entry_owner.as_deref(),
-                            &agent_id,
-                        );
-                        if db.get(&id, &ctx)?.is_none() {
-                            entry_errors.push((
-                                line_idx + 1,
-                                format!("write rejected: entry '{}' not persisted", id),
-                            ));
+                    match entry_result {
+                        Ok(entry) => {
+                            println!("  [{}] Added entry: {} ({})", line_idx + 1, entry.id, title);
+                            added_ids.push(entry.id);
+                        }
+                        Err(e) => {
+                            entry_errors
+                                .push((line_idx + 1, format!("write error: {}", e)));
                             continue;
                         }
                     }
-
-                    // EXTRACTED_FROM edge when session_id provided.
-                    if let Some(ref sess_id) = str_field("session_id") {
-                        let session_ref = normalize_id(sess_id);
-                        let ctx = store::AgentContext::public_only();
-                        if db.get(&session_ref, &ctx)?.is_none() {
-                            eprintln!(
-                                "  line {}: Warning: Session {} not found - EXTRACTED_FROM edge not created",
-                                line_idx + 1,
-                                session_ref
-                            );
-                        } else {
-                            db.add_relationship(&id, &session_ref, "extracted_from")?;
-                        }
-                    }
-
-                    println!("  [{}] Added entry: {} ({})", line_idx + 1, id, title);
-                    added_ids.push(id);
                 }
             }
 

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -744,6 +744,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             session,
             thread_id,
             no_auto_anchor,
+            no_embed,
         } => {
             use anyhow::Context;
             use std::fs;
@@ -962,8 +963,16 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 println!("  Category: {}", routing.category);
                 println!("  Content: {}", body);
 
-                // Auto-generate embedding if in network SurrealDB mode
-                auto_embed(&id, db.as_ref())?;
+                // Auto-generate embedding if in network SurrealDB mode.
+                // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see
+                // write_embed_enabled). The entry is already durable here, so
+                // skipping embedding is safe; the explicit `mx memory embed --all`
+                // command is never gated and still embeds deferred entries.
+                if write_embed_enabled(no_embed) {
+                    auto_embed(&id, db.as_ref())?;
+                } else {
+                    println!("  (embed skipped)");
+                }
 
                 return Ok(());
             }
@@ -1147,8 +1156,16 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
             }
 
-            // Auto-generate embedding if in network SurrealDB mode
-            auto_embed(&id, db.as_ref())?;
+            // Auto-generate embedding if in network SurrealDB mode.
+            // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see
+            // write_embed_enabled). The entry is already durable here, so
+            // skipping embedding is safe; the explicit `mx memory embed --all`
+            // command is never gated and still embeds deferred entries.
+            if write_embed_enabled(no_embed) {
+                auto_embed(&id, db.as_ref())?;
+            } else {
+                println!("  (embed skipped)");
+            }
 
             // Auto-generate anchors if in network SurrealDB mode.
             // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
@@ -1250,6 +1267,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             session_id,
             force,
             no_auto_anchor,
+            no_embed,
             json,
         } => {
             use anyhow::Context;
@@ -1701,8 +1719,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 db.upsert_knowledge(&entry)?;
             }
 
-            // Auto-generate embedding if in network SurrealDB mode
-            auto_embed(&id, db.as_ref())?;
+            // Auto-generate embedding if in network SurrealDB mode.
+            // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            if write_embed_enabled(no_embed) {
+                auto_embed(&id, db.as_ref())?;
+            } else {
+                println!("  (embed skipped)");
+            }
 
             // Auto-generate anchors if in network SurrealDB mode
             // Pass explicitly removed anchors so auto_anchor respects user intent:
@@ -1750,6 +1773,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             replace_all,
             nth,
             no_auto_anchor,
+            no_embed,
             json,
         } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
@@ -1773,8 +1797,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             let result = db.edit_content(&id, &ctx, &find, &replace, replace_all, nth)?;
 
-            // Auto-generate embedding if in network SurrealDB mode
-            auto_embed(&id, db.as_ref())?;
+            // Auto-generate embedding if in network SurrealDB mode.
+            // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            if write_embed_enabled(no_embed) {
+                auto_embed(&id, db.as_ref())?;
+            } else {
+                println!("  (embed skipped)");
+            }
 
             // Auto-generate anchors if in network SurrealDB mode.
             // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
@@ -1810,6 +1839,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             content,
             file,
             no_auto_anchor,
+            no_embed,
             json,
         } => {
             use std::io::{self, Read};
@@ -1853,8 +1883,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             db.append_content(&id, &ctx, &text)?;
 
-            // Auto-generate embedding if in network SurrealDB mode
-            auto_embed(&id, db.as_ref())?;
+            // Auto-generate embedding if in network SurrealDB mode.
+            // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            if write_embed_enabled(no_embed) {
+                auto_embed(&id, db.as_ref())?;
+            } else {
+                println!("  (embed skipped)");
+            }
 
             // Auto-generate anchors if in network SurrealDB mode.
             // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
@@ -1886,6 +1921,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             content,
             file,
             no_auto_anchor,
+            no_embed,
             json,
         } => {
             use std::io::{self, Read};
@@ -1929,8 +1965,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             db.prepend_content(&id, &ctx, &text)?;
 
-            // Auto-generate embedding if in network SurrealDB mode
-            auto_embed(&id, db.as_ref())?;
+            // Auto-generate embedding if in network SurrealDB mode.
+            // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            if write_embed_enabled(no_embed) {
+                auto_embed(&id, db.as_ref())?;
+            } else {
+                println!("  (embed skipped)");
+            }
 
             // Auto-generate anchors if in network SurrealDB mode.
             // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
@@ -1961,6 +2002,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             id,
             list,
             no_auto_anchor,
+            no_embed,
             json,
         } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
@@ -2044,8 +2086,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
                 db.upsert_knowledge(&entry)?;
 
-                // #3: update embeddings and anchors like all other mutation paths
-                auto_embed(&id, db.as_ref())?;
+                // #3: update embeddings and anchors like all other mutation paths.
+                // Embedding gated by --no-embed or MX_SKIP_WRITE_EMBED (see
+                // write_embed_enabled). The entry is already durable here.
+                if write_embed_enabled(no_embed) {
+                    auto_embed(&id, db.as_ref())?;
+                } else {
+                    println!("  (embed skipped)");
+                }
                 // Gated by --no-auto-anchor or MX_SKIP_WRITE_ANCHOR (see
                 // write_anchor_enabled). The entry is already durable here, so
                 // skipping anchoring is safe; the explicit `mx memory
@@ -2080,6 +2128,464 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             }
         }
 
+        MemoryCommands::AddBatch { file, no_embed } => {
+            use std::io::BufRead;
+
+            // Read JSONL lines from --file or stdin.
+            let lines: Vec<String> = if let Some(ref path) = file {
+                let f = std::fs::File::open(path)
+                    .with_context(|| format!("Failed to open batch file: {}", path))?;
+                std::io::BufReader::new(f)
+                    .lines()
+                    .collect::<std::result::Result<_, _>>()
+                    .context("Failed to read batch file")?
+            } else {
+                let stdin = std::io::stdin();
+                stdin
+                    .lock()
+                    .lines()
+                    .collect::<std::result::Result<_, _>>()
+                    .context("Failed to read from stdin")?
+            };
+
+            // Open store ONCE for the whole batch.
+            let db = store::create_store_with_verbose(&config.db_path, verbose)?;
+
+            let mut added_ids: Vec<String> = Vec::new();
+            let mut entry_errors: Vec<(usize, String)> = Vec::new();
+
+            for (line_idx, raw) in lines.iter().enumerate() {
+                let raw = raw.trim();
+                if raw.is_empty() || raw.starts_with('#') {
+                    continue;
+                }
+
+                // Parse the JSON line.
+                let v: serde_json::Value = match serde_json::from_str(raw) {
+                    Ok(val) => val,
+                    Err(e) => {
+                        entry_errors.push((line_idx + 1, format!("JSON parse error: {}", e)));
+                        continue;
+                    }
+                };
+
+                // Extract fields matching the Add command signature.
+                // Each JSONL line is a self-describing Add payload.
+                let str_field = |key: &str| -> Option<String> {
+                    v.get(key).and_then(|x| x.as_str()).map(|s| s.to_string())
+                };
+                let bool_field = |key: &str| -> bool {
+                    v.get(key).and_then(|x| x.as_bool()).unwrap_or(false)
+                };
+                let int_field = |key: &str| -> Option<i32> {
+                    v.get(key).and_then(|x| x.as_i64()).map(|n| n as i32)
+                };
+
+                // Resolve agent: source_agent field or MX_CURRENT_AGENT env.
+                let agent_id = match str_field("source_agent").filter(|s| !s.is_empty()) {
+                    Some(a) => a,
+                    None => match std::env::var("MX_CURRENT_AGENT") {
+                        Ok(a) if !a.is_empty() => a,
+                        _ => {
+                            entry_errors.push((
+                                line_idx + 1,
+                                "source_agent not provided and MX_CURRENT_AGENT not set"
+                                    .to_string(),
+                            ));
+                            continue;
+                        }
+                    },
+                };
+
+                // Determine the fact-type path vs standard path.
+                if let Some(fact_type) = str_field("type") {
+                    // Fact-type routing path.
+                    let body = match str_field("content") {
+                        Some(b) if !b.is_empty() => b,
+                        _ => {
+                            entry_errors.push((
+                                line_idx + 1,
+                                "fact entries require a 'content' field".to_string(),
+                            ));
+                            continue;
+                        }
+                    };
+
+                    let routing = match route_fact_type(&fact_type) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            entry_errors
+                                .push((line_idx + 1, format!("invalid fact type: {}", e)));
+                            continue;
+                        }
+                    };
+
+                    let session = str_field("session");
+                    let session_hint = session.as_deref().unwrap_or("fact");
+                    let truncated_title = crate::display::safe_truncate(&body, 60);
+                    let fact_title = format!("{}: {}", fact_type, truncated_title);
+                    let id = knowledge::KnowledgeEntry::generate_id(session_hint, &fact_title);
+
+                    let now = chrono::Utc::now().to_rfc3339();
+                    let trigger_list: Vec<String> = str_field("triggers")
+                        .map(|t| knowledge::normalize_triggers(t.split(',')))
+                        .unwrap_or_default();
+                    let mut tag_list: Vec<String> = routing.tags.iter().map(|s| s.to_string()).collect();
+                    if let Some(t) = str_field("tags") {
+                        tag_list.extend(
+                            t.split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty()),
+                        );
+                    }
+
+                    let mut metadata = serde_json::Map::new();
+                    metadata.insert(
+                        "fact_type".to_string(),
+                        serde_json::Value::String(fact_type.clone()),
+                    );
+                    metadata.insert(
+                        "agent".to_string(),
+                        serde_json::Value::String(agent_id.clone()),
+                    );
+                    metadata.insert(
+                        "date".to_string(),
+                        serde_json::Value::String(chrono::Local::now().format("%Y-%m-%d").to_string()),
+                    );
+                    if routing.category == "thread" {
+                        metadata.insert(
+                            "state".to_string(),
+                            serde_json::Value::String("open".to_string()),
+                        );
+                    }
+                    let summary_json = serde_json::Value::Object(metadata).to_string();
+
+                    let entry = knowledge::KnowledgeEntry {
+                        id: id.clone(),
+                        category_id: routing.category.to_string(),
+                        title: fact_title,
+                        body: Some(body.clone()),
+                        summary: Some(summary_json),
+                        applicability: vec![],
+                        source_project_id: str_field("project"),
+                        source_agent_id: Some(format!("agent:{}", agent_id)),
+                        file_path: None,
+                        tags: tag_list,
+                        created_at: Some(now.clone()),
+                        updated_at: Some(now),
+                        content_hash: Some(knowledge::KnowledgeEntry::compute_hash(&body)),
+                        source_type_id: Some("source_type:agent_session".to_string()),
+                        entry_type_id: Some("entry_type:primary".to_string()),
+                        session_id: session.clone(),
+                        ephemeral: true,
+                        content_type_id: Some("content_type:text".to_string()),
+                        owner: Some(format!("agent:{}", agent_id)),
+                        visibility: "public".to_string(),
+                        resonance: int_field("resonance").unwrap_or(3),
+                        resonance_type: Some("ephemeral".to_string()),
+                        last_activated: None,
+                        activation_count: 0,
+                        decay_rate: 0.0,
+                        anchors: vec![],
+                        wake_phrases: vec![],
+                        triggers: trigger_list,
+                        wake_order: None,
+                        wake_phrase: None,
+                        embedding: None,
+                        embedding_model: None,
+                        embedded_at: None,
+                        chunk_count: 0,
+                        format: "markdown".to_string(),
+                        effective_resonance: None,
+                    };
+
+                    db.upsert_knowledge(&entry)?;
+
+                    // Read-back verify (same as single-add path)
+                    let ctx = store::AgentContext::for_agent(&agent_id);
+                    if db.get(&id, &ctx)?.is_none() {
+                        entry_errors.push((
+                            line_idx + 1,
+                            format!("write rejected: fact '{}' not persisted", id),
+                        ));
+                        continue;
+                    }
+
+                    // EXTRACTED_FROM edge if session provided
+                    if let Some(ref sess) = session {
+                        let session_ref = if sess.starts_with("kn-") {
+                            sess.clone()
+                        } else {
+                            format!("kn-{}", sess)
+                        };
+                        let pub_ctx = store::AgentContext::public_only();
+                        if db.get(&session_ref, &pub_ctx)?.is_none() {
+                            eprintln!(
+                                "  line {}: Warning: Session {} not found - relationship not created",
+                                line_idx + 1,
+                                session_ref
+                            );
+                        } else {
+                            db.add_relationship(&id, &session_ref, "extracted_from")?;
+                        }
+                    }
+
+                    println!("  [{}] Added fact: {}", line_idx + 1, id);
+                    added_ids.push(id);
+                } else {
+                    // Standard add path (category + title required).
+                    let category = match str_field("category") {
+                        Some(c) if !c.is_empty() => c,
+                        _ => {
+                            entry_errors.push((
+                                line_idx + 1,
+                                "missing 'category' field (required when 'type' not set)"
+                                    .to_string(),
+                            ));
+                            continue;
+                        }
+                    };
+                    let title = match str_field("title") {
+                        Some(t) if !t.is_empty() => t,
+                        _ => {
+                            entry_errors.push((
+                                line_idx + 1,
+                                "missing 'title' field (required when 'type' not set)".to_string(),
+                            ));
+                            continue;
+                        }
+                    };
+
+                    // Resolve body from 'content' or 'file'.
+                    let body = if let Some(c) = str_field("content") {
+                        c
+                    } else if let Some(file_path) = str_field("file") {
+                        match std::fs::read_to_string(&file_path) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                entry_errors.push((
+                                    line_idx + 1,
+                                    format!("failed to read file '{}': {}", file_path, e),
+                                ));
+                                continue;
+                            }
+                        }
+                    } else {
+                        entry_errors.push((
+                            line_idx + 1,
+                            "missing 'content' or 'file' field".to_string(),
+                        ));
+                        continue;
+                    };
+
+                    // Validate category.
+                    if db.get_category(&category)?.is_none() {
+                        let categories = db.list_categories()?;
+                        let valid: Vec<&str> =
+                            categories.iter().map(|c| c.id.as_str()).collect();
+                        entry_errors.push((
+                            line_idx + 1,
+                            format!(
+                                "invalid category '{}'. Valid: {}",
+                                category,
+                                valid.join(", ")
+                            ),
+                        ));
+                        continue;
+                    }
+
+                    let is_private = bool_field("private")
+                        || str_field("visibility").as_deref() == Some("private");
+                    let entry_visibility = if is_private {
+                        "private".to_string()
+                    } else {
+                        "public".to_string()
+                    };
+                    let entry_owner: Option<String> = if is_private {
+                        Some(str_field("owner").unwrap_or_else(|| agent_id.clone()))
+                    } else {
+                        str_field("owner")
+                    };
+
+                    let tag_list: Vec<String> = str_field("tags")
+                        .map(|t| {
+                            t.split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let applicability_list: Vec<String> = str_field("applicability")
+                        .map(|a| {
+                            a.split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let anchor_list: Vec<String> = str_field("anchors")
+                        .map(|a| {
+                            a.split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let trigger_list: Vec<String> = str_field("triggers")
+                        .map(|t| knowledge::normalize_triggers(t.split(',')))
+                        .unwrap_or_default();
+                    let wake_phrase_list: Vec<String> = str_field("wake_phrases")
+                        .map(|p| {
+                            p.split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect()
+                        })
+                        .unwrap_or_else(|| {
+                            str_field("wake_phrase")
+                                .map(|p| vec![p])
+                                .unwrap_or_default()
+                        });
+
+                    let domain = str_field("domain");
+                    let path_hint = domain.unwrap_or_else(|| category.clone());
+                    let id = knowledge::KnowledgeEntry::generate_id(&path_hint, &title);
+                    let now = chrono::Utc::now().to_rfc3339();
+
+                    let entry = knowledge::KnowledgeEntry {
+                        id: id.clone(),
+                        category_id: category.clone(),
+                        title: title.clone(),
+                        body: Some(body.clone()),
+                        summary: None,
+                        applicability: applicability_list,
+                        source_project_id: str_field("project"),
+                        source_agent_id: Some(agent_id.clone()),
+                        file_path: None,
+                        tags: tag_list,
+                        created_at: Some(now.clone()),
+                        updated_at: Some(now),
+                        content_hash: Some(knowledge::KnowledgeEntry::compute_hash(&title)),
+                        source_type_id: Some(
+                            str_field("source_type")
+                                .unwrap_or_else(|| "manual".to_string()),
+                        ),
+                        entry_type_id: Some(
+                            str_field("entry_type")
+                                .unwrap_or_else(|| "primary".to_string()),
+                        ),
+                        session_id: str_field("session_id"),
+                        ephemeral: bool_field("ephemeral"),
+                        content_type_id: Some(
+                            str_field("content_type")
+                                .unwrap_or_else(|| "text".to_string()),
+                        ),
+                        owner: entry_owner.clone(),
+                        visibility: entry_visibility.clone(),
+                        resonance: int_field("resonance").unwrap_or(0),
+                        resonance_type: str_field("resonance_type"),
+                        last_activated: None,
+                        activation_count: 0,
+                        decay_rate: 0.0,
+                        anchors: anchor_list,
+                        wake_phrases: wake_phrase_list,
+                        triggers: trigger_list,
+                        wake_order: int_field("wake_order"),
+                        wake_phrase: str_field("wake_phrase"),
+                        embedding: None,
+                        embedding_model: None,
+                        embedded_at: None,
+                        chunk_count: 0,
+                        format: "markdown".to_string(),
+                        effective_resonance: None,
+                    };
+
+                    db.upsert_knowledge(&entry)?;
+
+                    // Read-back verify.
+                    {
+                        let ctx = write_verification_ctx(
+                            &entry_visibility,
+                            entry_owner.as_deref(),
+                            &agent_id,
+                        );
+                        if db.get(&id, &ctx)?.is_none() {
+                            entry_errors.push((
+                                line_idx + 1,
+                                format!("write rejected: entry '{}' not persisted", id),
+                            ));
+                            continue;
+                        }
+                    }
+
+                    // EXTRACTED_FROM edge when session_id provided.
+                    if let Some(ref sess_id) = str_field("session_id") {
+                        let session_ref = normalize_id(sess_id);
+                        let ctx = store::AgentContext::public_only();
+                        if db.get(&session_ref, &ctx)?.is_none() {
+                            eprintln!(
+                                "  line {}: Warning: Session {} not found - EXTRACTED_FROM edge not created",
+                                line_idx + 1,
+                                session_ref
+                            );
+                        } else {
+                            db.add_relationship(&id, &session_ref, "extracted_from")?;
+                        }
+                    }
+
+                    println!("  [{}] Added entry: {} ({})", line_idx + 1, id, title);
+                    added_ids.push(id);
+                }
+            }
+
+            // Report any per-entry errors (partial success: don't abort on them).
+            if !entry_errors.is_empty() {
+                eprintln!("\nBatch errors ({} of {} entries failed):", entry_errors.len(), lines.len());
+                for (lineno, msg) in &entry_errors {
+                    eprintln!("  line {}: {}", lineno, msg);
+                }
+            }
+
+            // Single hoisted embedding pass — ONE model cold-load for all entries.
+            // This is the entire point of add-batch: amortize the ~435 MB TractProvider
+            // load across N entries rather than paying it N times.
+            if !added_ids.is_empty() && !no_embed {
+                use crate::embeddings::TractProvider;
+                println!("\nEmbedding {} entr{}...", added_ids.len(), if added_ids.len() == 1 { "y" } else { "ies" });
+                let provider = TractProvider::new()?;
+                let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
+                for (i, entry_id) in added_ids.iter().enumerate() {
+                    println!(
+                        "  Embedding {}/{}: {}",
+                        i + 1,
+                        added_ids.len(),
+                        entry_id
+                    );
+                    crate::helpers::auto_embed_with(
+                        entry_id,
+                        db.as_ref(),
+                        &provider,
+                        &chunking_tokenizer,
+                    )?;
+                }
+                println!("Embedding complete.");
+            } else if no_embed && !added_ids.is_empty() {
+                println!("\n(embed skipped for {} entries — run `mx memory embed --all` to embed)", added_ids.len());
+            }
+
+            // Summary
+            println!(
+                "\nBatch complete: {} added, {} failed.",
+                added_ids.len(),
+                entry_errors.len()
+            );
+
+            // Exit non-zero if any entries failed.
+            if !entry_errors.is_empty() {
+                std::process::exit(1);
+            }
+        }
+
         MemoryCommands::Embed { id, all, long_only } => {
             let db = store::create_store_with_verbose(&config.db_path, verbose)?;
 
@@ -2093,12 +2599,15 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 let entries = db.list_all(&ctx)?;
                 let total = entries.len();
 
-                // If --long-only is specified, load tokenizer for token counting
-                let tokenizer = if long_only.is_some() {
-                    Some(crate::embeddings::load_tokenizer()?)
-                } else {
-                    None
-                };
+                // Hoist provider construction ONCE above the loop so the whole
+                // --all batch pays one ~435 MB cold-load instead of one per entry.
+                // Uses auto_embed_with (provider injected) rather than auto_embed
+                // (which constructs internally on every call).
+                use crate::embeddings::TractProvider;
+                let provider = TractProvider::new()?;
+                // Load the chunking tokenizer once. When --long-only is also set
+                // this tokenizer serves double duty: token-count gate + chunking.
+                let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
 
                 let mut embedded = 0;
                 let mut skipped = 0;
@@ -2106,11 +2615,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 println!("Found {} entries to embed", total);
                 for entry in &entries {
                     // Check token count if --long-only is specified
-                    if let Some(min_tokens) = long_only
-                        && let Some(ref tok) = tokenizer
-                    {
+                    if let Some(min_tokens) = long_only {
                         let text = entry.embedding_text();
-                        let encoding = tok
+                        let encoding = chunking_tokenizer
                             .encode(text.as_str(), false)
                             .map_err(|e| anyhow::anyhow!("Tokenization failed: {}", e))?;
                         if encoding.get_ids().len() <= min_tokens {
@@ -2126,7 +2633,12 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         total - skipped,
                         entry.title
                     );
-                    crate::helpers::auto_embed(&entry.id, db.as_ref())?;
+                    crate::helpers::auto_embed_with(
+                        &entry.id,
+                        db.as_ref(),
+                        &provider,
+                        &chunking_tokenizer,
+                    )?;
                 }
                 if long_only.is_some() {
                     println!(

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -2247,9 +2247,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 let str_field = |key: &str| -> Option<String> {
                     v.get(key).and_then(|x| x.as_str()).map(|s| s.to_string())
                 };
-                let bool_field = |key: &str| -> bool {
-                    v.get(key).and_then(|x| x.as_bool()).unwrap_or(false)
-                };
+                let bool_field =
+                    |key: &str| -> bool { v.get(key).and_then(|x| x.as_bool()).unwrap_or(false) };
                 let int_field = |key: &str| -> Option<i32> {
                     v.get(key).and_then(|x| x.as_i64()).map(|n| n as i32)
                 };
@@ -2287,8 +2286,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     let routing = match route_fact_type(&fact_type) {
                         Ok(r) => r,
                         Err(e) => {
-                            entry_errors
-                                .push((line_idx + 1, format!("invalid fact type: {}", e)));
+                            entry_errors.push((line_idx + 1, format!("invalid fact type: {}", e)));
                             continue;
                         }
                     };
@@ -2303,7 +2301,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     let trigger_list: Vec<String> = str_field("triggers")
                         .map(|t| knowledge::normalize_triggers(t.split(',')))
                         .unwrap_or_default();
-                    let mut tag_list: Vec<String> = routing.tags.iter().map(|s| s.to_string()).collect();
+                    let mut tag_list: Vec<String> =
+                        routing.tags.iter().map(|s| s.to_string()).collect();
                     if let Some(t) = str_field("tags") {
                         tag_list.extend(
                             t.split(',')
@@ -2323,7 +2322,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     );
                     metadata.insert(
                         "date".to_string(),
-                        serde_json::Value::String(chrono::Local::now().format("%Y-%m-%d").to_string()),
+                        serde_json::Value::String(
+                            chrono::Local::now().format("%Y-%m-%d").to_string(),
+                        ),
                     );
                     if routing.category == "thread" {
                         metadata.insert(
@@ -2414,7 +2415,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                                 );
                             }
                             Ok(Some(_)) => {
-                                if let Err(e) = db.add_relationship(&id, &session_ref, "extracted_from") {
+                                if let Err(e) =
+                                    db.add_relationship(&id, &session_ref, "extracted_from")
+                                {
                                     eprintln!(
                                         "  line {}: Warning: EXTRACTED_FROM edge failed: {}",
                                         line_idx + 1,
@@ -2614,8 +2617,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                             added_ids.push(entry.id);
                         }
                         Err(e) => {
-                            entry_errors
-                                .push((line_idx + 1, format!("write error: {}", e)));
+                            entry_errors.push((line_idx + 1, format!("write error: {}", e)));
                             continue;
                         }
                     }
@@ -2624,7 +2626,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Report any per-entry errors (partial success: don't abort on them).
             if !entry_errors.is_empty() {
-                eprintln!("\nBatch errors ({} of {} entries failed):", entry_errors.len(), lines.len());
+                eprintln!(
+                    "\nBatch errors ({} of {} entries failed):",
+                    entry_errors.len(),
+                    lines.len()
+                );
                 for (lineno, msg) in &entry_errors {
                     eprintln!("  line {}: {}", lineno, msg);
                 }
@@ -2635,16 +2641,15 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // load across N entries rather than paying it N times.
             if !added_ids.is_empty() && !no_embed {
                 use crate::embeddings::TractProvider;
-                println!("\nEmbedding {} entr{}...", added_ids.len(), if added_ids.len() == 1 { "y" } else { "ies" });
+                println!(
+                    "\nEmbedding {} entr{}...",
+                    added_ids.len(),
+                    if added_ids.len() == 1 { "y" } else { "ies" }
+                );
                 let provider = TractProvider::new()?;
                 let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
                 for (i, entry_id) in added_ids.iter().enumerate() {
-                    println!(
-                        "  Embedding {}/{}: {}",
-                        i + 1,
-                        added_ids.len(),
-                        entry_id
-                    );
+                    println!("  Embedding {}/{}: {}", i + 1, added_ids.len(), entry_id);
                     crate::helpers::auto_embed_with(
                         entry_id,
                         db.as_ref(),
@@ -2654,7 +2659,10 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
                 println!("Embedding complete.");
             } else if no_embed && !added_ids.is_empty() {
-                println!("\n(embed skipped for {} entries — run `mx memory embed --all` to embed)", added_ids.len());
+                println!(
+                    "\n(embed skipped for {} entries — run `mx memory embed --all` to embed)",
+                    added_ids.len()
+                );
             }
 
             // Summary

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -211,15 +211,24 @@ pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     dot_product / (magnitude_a * magnitude_b)
 }
 
-/// Auto-embed a knowledge entry after add/update.
+/// Auto-embed a knowledge entry using a pre-constructed provider and tokenizer.
+///
+/// This is the core embedding implementation. It accepts an already-constructed
+/// `TractProvider` and tokenizer so a batch caller can hoist model construction
+/// ONCE above a loop and amortize the ~435 MB cold-load across N entries.
 ///
 /// For short entries (<=400 tokens): stores a single embedding on the entry.
 /// For long entries (>400 tokens): splits into overlapping chunks, embeds each
 /// chunk separately, stores chunks in `embedding_chunk` table, and stores a
 /// mean vector on the entry for auto_anchor compatibility.
-pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Result<()> {
+pub(crate) fn auto_embed_with(
+    entry_id: &str,
+    db: &dyn store::KnowledgeStore,
+    provider: &crate::embeddings::TractProvider,
+    chunking_tokenizer: &tokenizers::Tokenizer,
+) -> Result<()> {
     use crate::chunking::{ChunkConfig, chunk_text};
-    use crate::embeddings::{EmbeddingProvider, TractProvider};
+    use crate::embeddings::EmbeddingProvider;
 
     let ctx = match std::env::var("MX_CURRENT_AGENT") {
         Ok(agent) if !agent.is_empty() => store::AgentContext::for_agent(agent),
@@ -231,14 +240,12 @@ pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Resu
         None => return Ok(()),
     };
 
-    let provider = TractProvider::new()?;
     let embedding_text = entry.embedding_text();
     let config = ChunkConfig::default();
     // Use load_tokenizer() (no truncation) for chunking — the provider's
     // tokenizer truncates at 512 which would hide content beyond that point.
     // Chunking must see ALL tokens to split them correctly.
-    let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
-    let chunks = chunk_text(&embedding_text, &chunking_tokenizer, &config);
+    let chunks = chunk_text(&embedding_text, chunking_tokenizer, &config);
 
     if chunks.len() == 1 {
         // Short entry: single embedding, no chunks
@@ -302,6 +309,23 @@ pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Resu
     Ok(())
 }
 
+/// Auto-embed a knowledge entry after add/update.
+///
+/// Thin wrapper around `auto_embed_with` that constructs the `TractProvider`
+/// and chunking tokenizer inline. Use this on single-entry write paths
+/// (Add, Update, Edit, Append, Prepend, Restore) where paying one model
+/// cold-load per call is acceptable.
+///
+/// For batch callers that need to amortize the ~435 MB model cold-load across
+/// N entries, use `auto_embed_with` directly: construct the provider and
+/// tokenizer once, then call `auto_embed_with` in the loop.
+pub(crate) fn auto_embed(entry_id: &str, db: &dyn store::KnowledgeStore) -> Result<()> {
+    use crate::embeddings::TractProvider;
+    let provider = TractProvider::new()?;
+    let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
+    auto_embed_with(entry_id, db, &provider, &chunking_tokenizer)
+}
+
 /// Whether the write path should run `auto_anchor` synchronously after a
 /// mutation (Add/Update/Edit/Append/Prepend/Restore).
 ///
@@ -328,6 +352,32 @@ pub(crate) fn write_anchor_enabled(no_auto_anchor: bool) -> bool {
     let skip_via_env =
         std::env::var("MX_SKIP_WRITE_ANCHOR").is_ok_and(|v| v == "1" || v.to_lowercase() == "true");
     !no_auto_anchor && !skip_via_env
+}
+
+/// Whether the write path should run `auto_embed` synchronously after a
+/// mutation (Add/Update/Edit/Append/Prepend/Restore).
+///
+/// Embedding on the write path is disabled when EITHER:
+///   - the caller passed `--no-embed` (`no_embed == true`), or
+///   - `MX_SKIP_WRITE_EMBED` is set to `1`/`true` (case-insensitive).
+///
+/// The env-var parsing mirrors the `MX_SKIP_SCHEMA` convention
+/// (`connection.rs`) so the project keeps one rule for boolean opt-out flags.
+///
+/// `MX_SKIP_WRITE_EMBED` is a deployment opt-out: it lets a caller defer
+/// embedding entirely to the explicit `mx memory embed --all` batch command
+/// (e.g. a nightly cron), which is never gated by this flag.
+///
+/// Skipping embedding does NOT affect durability or keyword/tag search.
+/// By the time this gate is evaluated the entry has already been
+/// `upsert_knowledge`d and read-back verified, so the write is provably
+/// durable. Entries written with `--no-embed` appear in keyword and tag
+/// searches but are absent from `--semantic` (vector) search results until
+/// `mx memory embed --all` runs.
+pub(crate) fn write_embed_enabled(no_embed: bool) -> bool {
+    let skip_via_env =
+        std::env::var("MX_SKIP_WRITE_EMBED").is_ok_and(|v| v == "1" || v.to_lowercase() == "true");
+    !no_embed && !skip_via_env
 }
 
 /// Auto-anchor a knowledge entry after add/update
@@ -1350,6 +1400,96 @@ mod auto_anchor_tests {
         assert!(
             got.is_some(),
             "a write with anchoring skipped must persist across a drop+reopen (no commit_entry needed)"
+        );
+    }
+
+    // =====================================================================
+    // MX_SKIP_WRITE_EMBED opt-out
+    //
+    // Mirrors the MX_SKIP_WRITE_ANCHOR tests above. `write_embed_enabled` is
+    // the single source of truth for the embed gate; these tests cover every
+    // accepted value plus the `--no-embed` CLI flag.
+    // =====================================================================
+
+    /// Save the current MX_SKIP_WRITE_EMBED value, set it (or clear it),
+    /// evaluate the gate, then restore — so the env state never leaks.
+    /// SAFETY: process-wide env mutation, serialized via `#[serial]`.
+    fn embed_gate_with_env(value: Option<&str>, no_embed: bool) -> bool {
+        let prev = std::env::var("MX_SKIP_WRITE_EMBED").ok();
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var("MX_SKIP_WRITE_EMBED", v),
+                None => std::env::remove_var("MX_SKIP_WRITE_EMBED"),
+            }
+        }
+        let enabled = write_embed_enabled(no_embed);
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_SKIP_WRITE_EMBED", v),
+                None => std::env::remove_var("MX_SKIP_WRITE_EMBED"),
+            }
+        }
+        enabled
+    }
+
+    #[test]
+    #[serial]
+    fn write_embed_enabled_unset_flag_runs_embedding() {
+        assert!(
+            embed_gate_with_env(None, false),
+            "unset MX_SKIP_WRITE_EMBED must leave embedding ON (default behavior preserved)"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn write_embed_enabled_flag_1_skips_embedding() {
+        assert!(
+            !embed_gate_with_env(Some("1"), false),
+            "MX_SKIP_WRITE_EMBED=1 must turn write-path embedding OFF"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn write_embed_enabled_flag_true_skips_embedding() {
+        assert!(
+            !embed_gate_with_env(Some("true"), false),
+            "MX_SKIP_WRITE_EMBED=true must turn write-path embedding OFF"
+        );
+        assert!(
+            !embed_gate_with_env(Some("TRUE"), false),
+            "MX_SKIP_WRITE_EMBED is case-insensitive for 'true'"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn write_embed_enabled_other_values_run_embedding() {
+        // Only "1"/"true" opt out; anything else (incl. "0", "false", "yes")
+        // leaves embedding on, matching the MX_SKIP_SCHEMA convention.
+        assert!(embed_gate_with_env(Some("0"), false), "'0' must not opt out");
+        assert!(
+            embed_gate_with_env(Some("false"), false),
+            "'false' must not opt out"
+        );
+        assert!(
+            embed_gate_with_env(Some(""), false),
+            "empty must not opt out"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn write_embed_enabled_cli_flag_always_skips() {
+        // --no-embed closes the gate regardless of the env var.
+        assert!(
+            !embed_gate_with_env(None, true),
+            "--no-embed must skip embedding even with the env flag unset"
+        );
+        assert!(
+            !embed_gate_with_env(Some("0"), true),
+            "--no-embed must skip embedding even when env flag would allow it"
         );
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1468,7 +1468,10 @@ mod auto_anchor_tests {
     fn write_embed_enabled_other_values_run_embedding() {
         // Only "1"/"true" opt out; anything else (incl. "0", "false", "yes")
         // leaves embedding on, matching the MX_SKIP_SCHEMA convention.
-        assert!(embed_gate_with_env(Some("0"), false), "'0' must not opt out");
+        assert!(
+            embed_gate_with_env(Some("0"), false),
+            "'0' must not opt out"
+        );
         assert!(
             embed_gate_with_env(Some("false"), false),
             "'false' must not opt out"


### PR DESCRIPTION
## What

Fixes #384 — the embedding model (~416MB) cold-loaded from scratch on every memory write.

Three pieces:

1. **`--no-embed` flag + `MX_SKIP_WRITE_EMBED` env** gating the synchronous `auto_embed` at the 7 mutation write sites (6 commands), cloned from the existing `--no-auto-anchor` / `MX_SKIP_WRITE_ANCHOR` pattern. `embedding` was already nullable. 5 unit tests cover the gate.

2. **Provider hoisting:** `auto_embed` refactored into `auto_embed_with(entry_id, db, &provider, &tokenizer)` with the original signature kept as a thin construct-and-delegate wrapper. `Embed --all` now uses the hoisted path too — it previously cold-loaded the model once per entry within a single process.

3. **`add-batch`:** N entries via JSONL (per-entry heterogeneous fields), one process, ONE model load — writes happen embed-deferred through the shared `add_one` extraction, then a single hoisted embedding pass runs over the added ids. Skip-and-report error semantics: a malformed line or transient store error on entry 12 doesn't lose entries 13-30; per-entry errors are reported and the exit code is non-zero on any failure.

## Measured

30-entry batch: **54.6s** vs ~86s paying 30 cold-loads (singles measure ~2.9s each). Verified in embedded mode.

## Notes for review

- **Anchor deferral contract:** batch-added standard entries skip per-entry anchoring (deliberate, parallels the deferred-embed model). Re-anchor via `mx memory auto-anchor --all` / the nightly. Flagging explicitly so the contract freezes knowingly.
- **Embed-pass boundary:** in `add-batch`, entries are durably written and read-back-verified BEFORE the final embedding pass; if the embed pass aborts midway, the un-embedded remainder is fully recoverable via `mx memory embed --all`. Could be hardened to skip-and-continue per entry — left as-is, noted.
- **`add_one` is standard-mode only by design** — the fact-type write paths remain parallel between single-add and batch; reasonable follow-up, not in scope.
- **Pre-existing test failures:** `tests/trigger_check.rs` fails 5/10 locally with an embedded-SurrealDB IAM error — identical failure set on pristine origin/main (baselined via worktree), unrelated to this PR.
- Base may be a couple commits behind main by the time you read this — branch updates cleanly (verified against 8694c60, disjoint files).
- Docs: `--no-embed` rows on the 6 commands, `add-batch` command block, deferred-embedding trade-off note, `MX_SKIP_WRITE_EMBED` env row; LLM markdown regenerated.

Built and reviewed by the hearth pipeline (3 review rounds, fmt/clippy clean, 1151 unit tests green).