### PR TITLE
pr merge: --admin and --auto passthrough with mx-encoded squash message (#377)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,15 @@ mx pr merge 42 --rebase
 
 # Standard merge commit
 mx pr merge 42 --merge-commit
+
+# Merge now with admin privileges, bypassing branch policy (e.g. REVIEW_REQUIRED)
+mx pr merge 42 --admin
+
+# Queue the merge until all branch requirements are met
+mx pr merge 42 --auto
 ```
+
+`--admin` and `--auto` are mutually exclusive and work with any merge mode. `--admin` passes `--admin` through to `gh` for an immediate merge that bypasses base-branch protection. This is the sanctioned path for single-account agent workflows: GitHub forbids approving your own pull request, so an agent committing under one account cannot satisfy a `REVIEW_REQUIRED` policy on its own — `--admin` merges anyway, using admin merge rights. `--auto` queues the merge and lets GitHub complete it once requirements are met; it does not merge immediately, so post-merge cleanup (branch switch and local source-branch deletion) is deferred. In both cases mx still constructs the encoded `--subject`/`--body`, so admin merges produce a decodable commit like any other.
 
 ### Session Archival (Codex)
 

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -339,11 +339,14 @@ mx state schemas
 ### PR
 
 PR merge handles pull request merging with encoded commit messages.
-Supports squash (default), rebase, and standard merge commits.
+Supports squash (default), rebase, and standard merge commits, plus
+`--admin` (merge now, bypassing branch policy like `REVIEW_REQUIRED`)
+and `--auto` (queue the merge until requirements are met).
 
 ``` bash
 mx pr merge 42             # squash merge
 mx pr merge 42 --rebase    # rebase merge
+mx pr merge 42 --admin     # bypass REVIEW_REQUIRED (single-account agents)
 ```
 
 ### Sync
@@ -5452,9 +5455,11 @@ workflow and keeps the target branch history linear.
 ### Flags
 
   **Flag**           **Type**   **Description**
-  ------------------ ---------- ----------------------------------------------------------------------------------------------------------------------------------------------
-  `--rebase`         flag       Use rebase merge instead of squash. Replays the PR's commits onto the target branch individually. The final commit message is still encoded.
+  ------------------ ---------- ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  `--rebase`         flag       Use rebase merge instead of squash. Replays the PR's already-encoded commits onto the target branch individually. There is no new merge commit, so each replayed commit keeps its own encoded message and decodes on its own through `mx log`.
   `--merge-commit`   flag       Use a standard merge commit instead of squash. Preserves the full branch topology in the target branch history.
+  `--admin`          flag       Merge immediately with admin privileges, bypassing base-branch policy such as `REVIEW_REQUIRED`. Mutually exclusive with `--auto`. See *Admin and auto-merge* below.
+  `--auto`           flag       Queue the merge and let GitHub complete it once all branch requirements are met. Does not merge immediately. Mutually exclusive with `--admin`. See *Admin and auto-merge* below.
 
 ### Examples
 
@@ -5470,6 +5475,14 @@ mx pr merge 42 --rebase
 mx pr merge 42 --merge-commit
 ```
 
+``` bash
+mx pr merge 42 --admin
+```
+
+``` bash
+mx pr merge 42 --auto
+```
+
 When deciding which strategy to use:
 
 - **Squash** (default) is best for feature branches where individual
@@ -5480,6 +5493,72 @@ When deciding which strategy to use:
 
 - **Merge commit** preserves full branch topology. Useful for long-lived
   branches where the merge point itself is significant.
+
+## Admin and auto-merge
+
+Two passthrough flags control *when* and *under what authority* the
+merge happens. They are mutually exclusive and compose with any of the
+three merge strategies above.
+
+## `mx pr merge <number> --admin`
+
+Merge immediately with admin privileges, passing `--admin` through to
+`gh`. This bypasses base-branch protection -- most importantly the
+`REVIEW_REQUIRED` policy. It is the sanctioned path for single-account
+agent workflows: GitHub forbids approving your own pull request, so an
+agent that authors and commits under one account can never satisfy a
+required-review rule on its own. `--admin` merges anyway, using the
+caller's admin merge rights on the repository.
+
+### Examples
+
+``` bash
+mx pr merge 42 --admin
+```
+
+``` bash
+mx pr merge 42 --rebase --admin
+```
+
+``` bash
+mx pr merge 42 --merge-commit --admin
+```
+
+The encoded message is constructed exactly as it is on a normal merge,
+so an admin merge produces a decodable squash commit -- it does not
+regress to the undecodable, default-concatenated body that an unencoded
+admin merge would leave behind.
+
+## `mx pr merge <number> --auto`
+
+Queue the merge instead of performing it now. Passes `--auto` through to
+`gh`, which completes the merge automatically once every branch
+requirement (status checks, required reviews) is satisfied. The command
+returns as soon as the merge is queued.
+
+### Examples
+
+``` bash
+mx pr merge 42 --auto
+```
+
+``` bash
+mx pr merge 42 --rebase --auto
+```
+
+::: {.admonition .warning}
+**WARNING:** `--auto` does not merge the PR -- it only schedules the
+merge. Because the merge has not happened, post-merge cleanup is
+**skipped**: the target branch is not checked out and the local source
+branch is not deleted. The command prints a deferred-cleanup notice. Run
+cleanup or delete the source branch manually once GitHub completes the
+queued merge.
+
+If a merge fails because the flag's precondition is not met, the command
+surfaces the raw `gh` error and adds a targeted hint -- that `--admin`
+requires admin merge rights on the repository, or that `--auto` requires
+auto-merge to be enabled in repository settings.
+:::
 
 ## Post-merge cleanup
 
@@ -7848,6 +7927,12 @@ options that do not apply to the declared/existing `ValueType` (e.g.
 `--min` on a history key, `--add-field` on a counter) with exit code 4,
 before any persist. A no-op `schema update` (no flags set) is likewise
 rejected rather than rewriting the schema file.
+
+A legacy `add_key_to_schema()` method still exists as a standalone
+engine helper -- it appends a `[keys.<name>]` block to the TOML without
+reformatting, preserving comments, for `history`/`list` only. It is no
+longer wired to any CLI verb (it formerly backed `push --create`); it is
+retained for its existing tests and as an append-based alternative.
 
 The `drop_key()` method backs `kv schema drop`: it removes both the
 schema definition and the stored data entry. It follows the `rename_key`

--- a/docs/src/getting-started.typ
+++ b/docs/src/getting-started.typ
@@ -207,11 +207,14 @@ mx state schemas
 === PR
 
 #link("pr.html")[PR merge] handles pull request merging with encoded commit
-messages. Supports squash (default), rebase, and standard merge commits.
+messages. Supports squash (default), rebase, and standard merge commits, plus
+`--admin` (merge now, bypassing branch policy like `REVIEW_REQUIRED`) and
+`--auto` (queue the merge until requirements are met).
 
 ```bash
 mx pr merge 42             # squash merge
 mx pr merge 42 --rebase    # rebase merge
+mx pr merge 42 --admin     # bypass REVIEW_REQUIRED (single-account agents)
 ```
 
 === Sync

--- a/docs/src/pr.typ
+++ b/docs/src/pr.typ
@@ -34,16 +34,25 @@ one flag may be passed.
   keeps the target branch history linear.],
   flags: (
     ([`--rebase`], [flag], [Use rebase merge instead of squash. Replays the
-    PR's commits onto the target branch individually. The final commit
-    message is still encoded.]),
+    PR's already-encoded commits onto the target branch individually. There
+    is no new merge commit, so each replayed commit keeps its own encoded
+    message and decodes on its own through `mx log`.]),
     ([`--merge-commit`], [flag], [Use a standard merge commit instead of
     squash. Preserves the full branch topology in the target branch
     history.]),
+    ([`--admin`], [flag], [Merge immediately with admin privileges, bypassing
+    base-branch policy such as `REVIEW_REQUIRED`. Mutually exclusive with
+    `--auto`. See _Admin and auto-merge_ below.]),
+    ([`--auto`], [flag], [Queue the merge and let GitHub complete it once all
+    branch requirements are met. Does not merge immediately. Mutually
+    exclusive with `--admin`. See _Admin and auto-merge_ below.]),
   ),
   examples: (
     "mx pr merge 42",
     "mx pr merge 42 --rebase",
     "mx pr merge 42 --merge-commit",
+    "mx pr merge 42 --admin",
+    "mx pr merge 42 --auto",
   ),
 )
 
@@ -55,6 +64,54 @@ When deciding which strategy to use:
   history. Useful when each commit is meaningful on its own.
 - *Merge commit* preserves full branch topology. Useful for long-lived
   branches where the merge point itself is significant.
+
+== Admin and auto-merge
+
+Two passthrough flags control _when_ and _under what authority_ the merge
+happens. They are mutually exclusive and compose with any of the three merge
+strategies above.
+
+#command("mx pr merge <number> --admin",
+  [Merge immediately with admin privileges, passing `--admin` through to
+  `gh`. This bypasses base-branch protection -- most importantly the
+  `REVIEW_REQUIRED` policy. It is the sanctioned path for single-account
+  agent workflows: GitHub forbids approving your own pull request, so an
+  agent that authors and commits under one account can never satisfy a
+  required-review rule on its own. `--admin` merges anyway, using the
+  caller's admin merge rights on the repository.],
+  examples: (
+    "mx pr merge 42 --admin",
+    "mx pr merge 42 --rebase --admin",
+    "mx pr merge 42 --merge-commit --admin",
+  ),
+)
+
+The encoded message is constructed exactly as it is on a normal merge, so an
+admin merge produces a decodable squash commit -- it does not regress to the
+undecodable, default-concatenated body that an unencoded admin merge would
+leave behind.
+
+#command("mx pr merge <number> --auto",
+  [Queue the merge instead of performing it now. Passes `--auto` through to
+  `gh`, which completes the merge automatically once every branch
+  requirement (status checks, required reviews) is satisfied. The command
+  returns as soon as the merge is queued.],
+  examples: (
+    "mx pr merge 42 --auto",
+    "mx pr merge 42 --rebase --auto",
+  ),
+)
+
+#warning[`--auto` does not merge the PR -- it only schedules the merge. Because
+the merge has not happened, post-merge cleanup is *skipped*: the target
+branch is not checked out and the local source branch is not deleted. The
+command prints a deferred-cleanup notice. Run cleanup or delete the source
+branch manually once GitHub completes the queued merge.]
+
+If a merge fails because the flag's precondition is not met, the command
+surfaces the raw `gh` error and adds a targeted hint -- that `--admin`
+requires admin merge rights on the repository, or that `--auto` requires
+auto-merge to be enabled in repository settings.
 
 == Post-merge cleanup
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -289,14 +289,18 @@ pub enum PrCommands {
         no_cleanup: bool,
 
         /// Merge immediately with admin privileges, bypassing base-branch policy
-        /// (e.g. REVIEW_REQUIRED). Passes --admin to gh while keeping mx's encoded
-        /// squash message. Mutually exclusive with --auto.
+        /// (e.g. REVIEW_REQUIRED). Passes --admin to gh while keeping mx's message
+        /// encoded for the selected merge method. Mutually exclusive with --auto.
+        /// clap's conflicts_with is symmetric, so declaring it once here also
+        /// rejects --auto --admin; no need to repeat it on `auto`.
         #[arg(long, conflicts_with = "auto")]
         admin: bool,
 
         /// Merge automatically once all merge requirements are met. Passes --auto to
-        /// gh while keeping mx's encoded squash message. Mutually exclusive with --admin.
-        #[arg(long, conflicts_with = "admin")]
+        /// gh while keeping mx's message encoded for the selected merge method.
+        /// Mutually exclusive with --admin (enforced by the conflict declared on
+        /// `admin`).
+        #[arg(long)]
         auto: bool,
     },
 }
@@ -2322,6 +2326,14 @@ mod tests {
         for mode in ["--rebase", "--merge-commit"] {
             let (admin, _) = merge_flags(&["mx", "pr", "merge", "375", mode, "--admin"]);
             assert!(admin, "--admin with {mode} should parse and set admin");
+        }
+    }
+
+    #[test]
+    fn pr_merge_auto_works_with_rebase_and_merge_commit() {
+        for mode in ["--rebase", "--merge-commit"] {
+            let (_, auto) = merge_flags(&["mx", "pr", "merge", "375", mode, "--auto"]);
+            assert!(auto, "--auto with {mode} should parse and set auto");
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -287,6 +287,17 @@ pub enum PrCommands {
         /// Skip post-merge cleanup (don't switch to target branch or delete local source branch)
         #[arg(long)]
         no_cleanup: bool,
+
+        /// Merge immediately with admin privileges, bypassing base-branch policy
+        /// (e.g. REVIEW_REQUIRED). Passes --admin to gh while keeping mx's encoded
+        /// squash message. Mutually exclusive with --auto.
+        #[arg(long, conflicts_with = "auto")]
+        admin: bool,
+
+        /// Merge automatically once all merge requirements are met. Passes --auto to
+        /// gh while keeping mx's encoded squash message. Mutually exclusive with --admin.
+        #[arg(long, conflicts_with = "admin")]
+        auto: bool,
     },
 }
 
@@ -2242,4 +2253,75 @@ pub enum WorktreeCommands {
         #[arg(long)]
         force: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn cli_definition_is_valid() {
+        // Catches clap config errors (e.g. conflicts_with referencing a
+        // nonexistent arg) at test time rather than at runtime.
+        Cli::command().debug_assert();
+    }
+
+    // `Cli` intentionally does not derive `Debug`, so these helpers match on
+    // the parse result rather than using `Result::expect`/`expect_err`.
+    fn merge_flags(args: &[&str]) -> (bool, bool) {
+        match Cli::try_parse_from(args) {
+            Ok(Cli {
+                command:
+                    Commands::Pr {
+                        command: PrCommands::Merge { admin, auto, .. },
+                    },
+                ..
+            }) => (admin, auto),
+            Ok(_) => panic!("expected pr merge subcommand"),
+            Err(e) => panic!("parse should succeed for {args:?}: {e}"),
+        }
+    }
+
+    fn parse_err(args: &[&str]) -> clap::Error {
+        match Cli::try_parse_from(args) {
+            Ok(_) => panic!("expected parse error for {args:?}"),
+            Err(e) => e,
+        }
+    }
+
+    #[test]
+    fn pr_merge_accepts_admin() {
+        let (admin, auto) = merge_flags(&["mx", "pr", "merge", "375", "--admin"]);
+        assert!(admin);
+        assert!(!auto);
+    }
+
+    #[test]
+    fn pr_merge_accepts_auto() {
+        let (admin, auto) = merge_flags(&["mx", "pr", "merge", "375", "--auto"]);
+        assert!(!admin);
+        assert!(auto);
+    }
+
+    #[test]
+    fn pr_merge_defaults_admin_and_auto_off() {
+        let (admin, auto) = merge_flags(&["mx", "pr", "merge", "375"]);
+        assert!(!admin);
+        assert!(!auto);
+    }
+
+    #[test]
+    fn pr_merge_admin_and_auto_conflict() {
+        let err = parse_err(&["mx", "pr", "merge", "375", "--admin", "--auto"]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn pr_merge_admin_works_with_rebase_and_merge_commit() {
+        for mode in ["--rebase", "--merge-commit"] {
+            let (admin, _) = merge_flags(&["mx", "pr", "merge", "375", mode, "--admin"]);
+            assert!(admin, "--admin with {mode} should parse and set admin");
+        }
+    }
 }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -578,6 +578,46 @@ fn get_pr_diff(number: u32) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Build the argument vector for `gh pr merge`.
+///
+/// Always supplies an explicit, encoded `--subject`/`--body`. This is THE
+/// design constraint behind `mx pr merge`: never let gh default-concatenate
+/// the branch's per-commit mx-ENCODED bodies (which produces an undecodable
+/// composite that `mx log` renders as gibberish). The encoded message path
+/// is identical across all flag combinations, including `--admin`/`--auto`,
+/// so the squash subject -- and thus GitHub's "(#NNN)" issue auto-close
+/// behavior -- is unchanged when those flags are present.
+///
+/// `--admin` (immediate, admin-privilege merge that bypasses base-branch
+/// policy such as REVIEW_REQUIRED) and `--auto` (merge once requirements are
+/// met) are simple passthroughs to gh; clap enforces their mutual exclusivity.
+fn build_gh_merge_args(
+    number: u32,
+    method: &str,
+    subject: &str,
+    body: &str,
+    admin: bool,
+    auto: bool,
+) -> Vec<String> {
+    let mut args = vec![
+        "pr".to_string(),
+        "merge".to_string(),
+        number.to_string(),
+        format!("--{}", method),
+        "--subject".to_string(),
+        subject.to_string(),
+        "--body".to_string(),
+        body.to_string(),
+    ];
+    if admin {
+        args.push("--admin".to_string());
+    }
+    if auto {
+        args.push("--auto".to_string());
+    }
+    args
+}
+
 /// Merge a pull request with encoded commit message.
 ///
 /// When `no_cleanup` is false (the default), performs post-merge cleanup:
@@ -585,7 +625,22 @@ fn get_pr_diff(number: u32) -> Result<String> {
 /// pulls, and deletes the local source branch. This prevents the common
 /// footgun where `git pull --rebase` fails because the remote source
 /// branch has been deleted by GitHub.
-pub fn pr_merge(number: u32, rebase: bool, merge_commit: bool, no_cleanup: bool) -> Result<()> {
+///
+/// `admin` passes `--admin` through to gh for an immediate, admin-privilege
+/// merge that bypasses base-branch policy (e.g. REVIEW_REQUIRED, which
+/// single-account agent workflows hit because GitHub forbids self-approval).
+/// `auto` passes `--auto` through so gh merges once requirements are met.
+/// The two are mutually exclusive (enforced at the clap layer). Both keep
+/// mx's encoded `--subject`/`--body` construction rather than letting gh
+/// default-concatenate per-commit encoded bodies.
+pub fn pr_merge(
+    number: u32,
+    rebase: bool,
+    merge_commit: bool,
+    no_cleanup: bool,
+    admin: bool,
+    auto: bool,
+) -> Result<()> {
     // Get PR diff for title hash
     let diff = get_pr_diff(number)?;
 
@@ -633,19 +688,19 @@ pub fn pr_merge(number: u32, rebase: bool, merge_commit: bool, no_cleanup: bool)
         "squash"
     };
 
-    // Merge with gh - pass encoded title and body+footer separately
+    // Merge with gh - pass encoded title and body+footer separately.
+    // --admin/--auto (if set) slot into this same encoded-message invocation.
     let body_with_footer = format!("{}\n\n{}", encoded.body, encoded.footer);
+    let merge_args = build_gh_merge_args(
+        number,
+        method,
+        &encoded.title,
+        &body_with_footer,
+        admin,
+        auto,
+    );
     let output = Command::new("gh")
-        .args([
-            "pr",
-            "merge",
-            &number.to_string(),
-            &format!("--{}", method),
-            "--subject",
-            &encoded.title,
-            "--body",
-            &body_with_footer,
-        ])
+        .args(&merge_args)
         .output()
         .context("Failed to run gh pr merge")?;
 
@@ -654,6 +709,15 @@ pub fn pr_merge(number: u32, rebase: bool, merge_commit: bool, no_cleanup: bool)
             "gh pr merge failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    if auto {
+        // --auto only queues the merge; the PR is not merged yet, so skip
+        // cleanup (the source branch still exists and the target branch is
+        // not yet updated). Deleting/switching now would be premature.
+        println!("Queued PR #{} for auto-merge ({})", number, method);
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+        return Ok(());
     }
 
     println!("Merged PR #{} ({})", number, method);
@@ -1567,5 +1631,101 @@ mod tests {
         let unpushed = check_unpushed_in_dir(path, "feature-x");
         assert!(unpushed.is_ok());
         assert!(!unpushed.unwrap(), "feature branch is pushed");
+    }
+
+    // --- build_gh_merge_args ---
+
+    #[test]
+    fn test_build_gh_merge_args_squash_default() {
+        let args = build_gh_merge_args(
+            42,
+            "squash",
+            "encoded-subject",
+            "encoded-body",
+            false,
+            false,
+        );
+        assert_eq!(
+            args,
+            vec![
+                "pr",
+                "merge",
+                "42",
+                "--squash",
+                "--subject",
+                "encoded-subject",
+                "--body",
+                "encoded-body",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_gh_merge_args_always_supplies_subject_and_body() {
+        // THE design constraint: an explicit encoded --subject/--body is
+        // present for every flag combination, so gh never default-concatenates
+        // per-commit encoded bodies into an undecodable composite.
+        for (method, admin, auto) in [
+            ("squash", false, false),
+            ("rebase", false, false),
+            ("merge", false, false),
+            ("squash", true, false),
+            ("rebase", true, false),
+            ("merge", true, false),
+            ("squash", false, true),
+            ("rebase", false, true),
+            ("merge", false, true),
+        ] {
+            let args = build_gh_merge_args(7, method, "subj", "body", admin, auto);
+            let subj_idx = args
+                .iter()
+                .position(|a| a == "--subject")
+                .expect("--subject present");
+            assert_eq!(args[subj_idx + 1], "subj");
+            let body_idx = args
+                .iter()
+                .position(|a| a == "--body")
+                .expect("--body present");
+            assert_eq!(args[body_idx + 1], "body");
+            assert!(args.contains(&format!("--{}", method)));
+        }
+    }
+
+    #[test]
+    fn test_build_gh_merge_args_admin_passthrough() {
+        let args = build_gh_merge_args(99, "squash", "s", "b", true, false);
+        assert!(args.contains(&"--admin".to_string()));
+        assert!(!args.contains(&"--auto".to_string()));
+    }
+
+    #[test]
+    fn test_build_gh_merge_args_auto_passthrough() {
+        let args = build_gh_merge_args(99, "squash", "s", "b", false, true);
+        assert!(args.contains(&"--auto".to_string()));
+        assert!(!args.contains(&"--admin".to_string()));
+    }
+
+    #[test]
+    fn test_build_gh_merge_args_admin_with_rebase_and_merge_commit() {
+        let rebase = build_gh_merge_args(1, "rebase", "s", "b", true, false);
+        assert!(rebase.contains(&"--rebase".to_string()));
+        assert!(rebase.contains(&"--admin".to_string()));
+
+        let merge = build_gh_merge_args(1, "merge", "s", "b", true, false);
+        assert!(merge.contains(&"--merge".to_string()));
+        assert!(merge.contains(&"--admin".to_string()));
+    }
+
+    #[test]
+    fn test_build_gh_merge_args_admin_does_not_change_subject() {
+        // Auto-close behavior depends on the subject carrying "(#NNN)";
+        // --admin must produce the identical subject as the plain path.
+        let plain = build_gh_merge_args(375, "squash", "Fix the thing (#375)", "b", false, false);
+        let with_admin =
+            build_gh_merge_args(375, "squash", "Fix the thing (#375)", "b", true, false);
+        let plain_subj = &plain[plain.iter().position(|a| a == "--subject").unwrap() + 1];
+        let admin_subj = &with_admin[with_admin.iter().position(|a| a == "--subject").unwrap() + 1];
+        assert_eq!(plain_subj, admin_subj);
+        assert_eq!(plain_subj, "Fix the thing (#375)");
     }
 }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -588,6 +588,16 @@ fn get_pr_diff(number: u32) -> Result<String> {
 /// so the squash subject -- and thus GitHub's "(#NNN)" issue auto-close
 /// behavior -- is unchanged when those flags are present.
 ///
+/// NOTE: the garble protection only actually engages for `squash` and
+/// `merge` (merge-commit) -- the two methods that produce a *new* merge
+/// commit whose message gh would otherwise auto-concatenate. On the
+/// `rebase` path there is no merge commit: gh replays the branch's
+/// per-commit encoded commits verbatim, each of which decodes fine on its
+/// own. Consequently `--subject`/`--body` have nothing to title on rebase
+/// and gh silently ignores them (it does not error). We still pass them
+/// uniformly here for code simplicity; a future reader should not assume
+/// `--subject` takes effect on the rebase path.
+///
 /// `--admin` (immediate, admin-privilege merge that bypasses base-branch
 /// policy such as REVIEW_REQUIRED) and `--auto` (merge once requirements are
 /// met) are simple passthroughs to gh; clap enforces their mutual exclusivity.
@@ -705,10 +715,27 @@ pub fn pr_merge(
         .context("Failed to run gh pr merge")?;
 
     if !output.status.success() {
-        bail!(
-            "gh pr merge failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Surface the raw stderr verbatim, then ADD actionable interpretation
+        // for the two failure modes the new --admin/--auto flags introduce.
+        // Only hint when the relevant flag was actually used and gh's stderr
+        // matches -- substring match is deliberately loose; gh's exact wording
+        // varies, so we key on stable fragments.
+        let lower = stderr.to_lowercase();
+        let mut hint = String::new();
+        if admin
+            && (lower.contains("admin")
+                || lower.contains("permission")
+                || lower.contains("not authorized")
+                || lower.contains("must be a")
+                || lower.contains("forbidden"))
+        {
+            hint = "\nhint: --admin requires admin merge rights on this repository; you appear to lack them.".to_string();
+        } else if auto && (lower.contains("auto-merge") || lower.contains("auto merge")) {
+            hint = "\nhint: --auto requires auto-merge to be enabled in the repository settings."
+                .to_string();
+        }
+        bail!("gh pr merge failed: {}{}", stderr, hint);
     }
 
     if auto {
@@ -716,6 +743,10 @@ pub fn pr_merge(
         // cleanup (the source branch still exists and the target branch is
         // not yet updated). Deleting/switching now would be premature.
         println!("Queued PR #{} for auto-merge ({})", number, method);
+        println!(
+            "Branch cleanup is deferred until the queued merge completes; \
+             re-run cleanup or delete the source branch manually afterward."
+        );
         println!("{}", String::from_utf8_lossy(&output.stdout));
         return Ok(());
     }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -26,8 +26,10 @@ pub(crate) fn handle_pr(cmd: PrCommands) -> Result<()> {
             rebase,
             merge_commit,
             no_cleanup,
+            admin,
+            auto,
         } => {
-            commit::pr_merge(number, rebase, merge_commit, no_cleanup)?;
+            commit::pr_merge(number, rebase, merge_commit, no_cleanup, admin, auto)?;
             Ok(())
         }
     }


### PR DESCRIPTION
Closes #377

## Summary

Adds `--admin` and `--auto` passthrough flags to `mx pr merge`, covering all three merge modes (squash default, `--rebase`, `--merge-commit`).

The flags slot into the **existing** encoded squash-message construction — mx still supplies its encoded `--subject`/`--body` to `gh`, so admin merges no longer produce undecodable concatenated bodies (the `e7ac4c5` / PR #375 garble this issue exists to prevent).

- `--admin` / `--auto` are mutually exclusive at the clap level.
- `--auto` skips post-merge cleanup (the merge is only *queued*; the branch still exists).
- A unit test asserts that `--admin` produces an identical `--subject` to the plain path, preserving `(#NNN)` issue auto-close.

## Files affected

- `src/cli.rs` — flags + `conflicts_with` + new test mod.
- `src/commit.rs` — `pr_merge` threading + extracted pure `build_gh_merge_args` helper + 6 unit tests.
- `src/handlers/mod.rs` — forwarding.

## Test results

- `cargo fmt` clean.
- `clippy -D warnings` clean.
- All tests green (1149 bin/unit + integration suites; `trigger_check` run with `--test-threads=1` per known flake #389, did not trigger).