### PR TITLE
fix: durable memory writes no longer exit 1 when post-write embed/anchor fails

### DIFF
--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -610,8 +610,29 @@ fn dedup_gate(
 /// write. `Skipped` is an `Ok` variant, never `Err` -- an `Err` would abort
 /// the whole batch via `?` for what is, by design, a successful no-op.
 enum WriteOutcome {
-    Written(Box<knowledge::KnowledgeEntry>, DedupProceedReason),
-    Skipped { duplicate_of: String },
+    Written(
+        Box<knowledge::KnowledgeEntry>,
+        DedupProceedReason,
+        WriteSideEffects,
+    ),
+    Skipped {
+        duplicate_of: String,
+    },
+}
+
+/// Outcome of the post-write embed/anchor side-effect steps in [`add_one`]
+/// (Cory's B1, PR #399 re-review). Both steps are non-fatal by design: a
+/// transient failure there must not abort the write or flip the exit code
+/// (the entry is already durable and read-back verified by the time either
+/// runs) -- but it also must not vanish into a stderr-only warning with zero
+/// signal in `--json` output. `None` means the step either succeeded or was
+/// never attempted (skipped via --no-embed / --no-auto-anchor, a deliberate
+/// no-op, not a failure -- those are surfaced separately by the existing
+/// "(embed skipped)" / "(auto-anchor skipped)" notices).
+#[derive(Default)]
+struct WriteSideEffects {
+    embed_deferred: Option<String>,
+    anchor_deferred: Option<String>,
 }
 
 /// Resolved arguments for a single standard-mode `memory add` write.
@@ -776,19 +797,28 @@ fn add_one(
     // Non-fatal: the entry is already durable (upserted + read-back verified
     // above), so a transient embed failure here must not surface as a
     // process exit failure -- that would make callers retry and duplicate
-    // an entry that already landed.
+    // an entry that already landed. The failure is still captured (not just
+    // eprintln'd) so callers building a `--json` payload can surface the
+    // degraded state instead of it vanishing into stderr (B1, PR #399
+    // re-review).
+    let mut side_effects = WriteSideEffects::default();
     if embed {
-        let _ = auto_embed(&id, db)
-            .map_err(|e| eprintln!("Warning: post-write embed failed (entry durable): {e}"));
+        if let Err(e) = auto_embed(&id, db) {
+            eprintln!("Warning: post-write embed failed (entry durable): {e}");
+            side_effects.embed_deferred = Some(e.to_string());
+        }
     } else {
         println!("  (embed skipped)");
     }
 
     // Auto-generate anchors. Gated by --no-auto-anchor / MX_SKIP_WRITE_ANCHOR.
-    // Non-fatal for the same reason as the embed step above.
+    // Non-fatal for the same reason as the embed step above; failure capture
+    // mirrors it too.
     if write_anchor_enabled(no_auto_anchor) {
-        let _ = auto_anchor(&id, db, None)
-            .map_err(|e| eprintln!("Warning: post-write anchor failed (entry durable): {e}"));
+        if let Err(e) = auto_anchor(&id, db, None) {
+            eprintln!("Warning: post-write anchor failed (entry durable): {e}");
+            side_effects.anchor_deferred = Some(e.to_string());
+        }
     } else {
         println!("  (auto-anchor skipped)");
     }
@@ -806,7 +836,11 @@ fn add_one(
         );
     }
 
-    Ok(WriteOutcome::Written(Box::new(entry), proceed_reason))
+    Ok(WriteOutcome::Written(
+        Box::new(entry),
+        proceed_reason,
+        side_effects,
+    ))
 }
 
 pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
@@ -1639,8 +1673,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Skip = success, not failure: an identical entry already exists
             // this session, so there is nothing to write and nothing wrong.
-            let (entry, dedup_reason) = match outcome {
-                WriteOutcome::Written(e, reason) => (e, reason),
+            let (entry, dedup_reason, side_effects) = match outcome {
+                WriteOutcome::Written(e, reason, side_effects) => (e, reason, side_effects),
                 WriteOutcome::Skipped { duplicate_of } => {
                     if json {
                         println!(
@@ -1710,6 +1744,19 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
                 if let DedupProceedReason::LookupFailed { msg } = &dedup_reason {
                     payload["dedup_lookup_warning"] = serde_json::json!(msg);
+                }
+                // B1 (PR #399 re-review): fold post-write embed/anchor
+                // side-effect failures into the same payload shape as the
+                // dedup fields above -- present only when the step actually
+                // failed, absent on success or on a deliberate --no-embed /
+                // --no-auto-anchor skip. This is the entry's only signal
+                // surface in --json mode; the stderr warning above still
+                // fires unconditionally for plain-mode callers.
+                if let Some(msg) = &side_effects.embed_deferred {
+                    payload["embed_deferred"] = serde_json::json!(msg);
+                }
+                if let Some(msg) = &side_effects.anchor_deferred {
+                    payload["anchor_deferred"] = serde_json::json!(msg);
                 }
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
@@ -3157,7 +3204,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     );
 
                     match entry_result {
-                        Ok(WriteOutcome::Written(entry, reason)) => {
+                        // Batch always passes embed=false / no_auto_anchor=true
+                        // (embedding is hoisted below, anchoring deferred to the
+                        // nightly run), so `side_effects` is always empty here --
+                        // ignored, not dropped by accident.
+                        Ok(WriteOutcome::Written(entry, reason, _side_effects)) => {
                             println!("  [{}] Added entry: {} ({})", line_idx + 1, entry.id, title);
                             // Batch has no --json mode -- stderr is the only
                             // signal surface here. Mirrors the standard
@@ -5236,7 +5287,7 @@ mod dedup_gate_tests {
         )
         .unwrap();
         let first_id = match first {
-            WriteOutcome::Written(e, _) => e.id,
+            WriteOutcome::Written(e, _, _) => e.id,
             WriteOutcome::Skipped { .. } => panic!("first write must not be a duplicate"),
         };
 
@@ -5551,7 +5602,7 @@ mod dedup_gate_tests {
         .expect("a dedup lookup failure must fail OPEN, not abort the write with Err");
 
         match outcome {
-            WriteOutcome::Written(entry, reason) => {
+            WriteOutcome::Written(entry, reason, _side_effects) => {
                 assert!(
                     matches!(reason, DedupProceedReason::LookupFailed { .. }),
                     "the proceed reason must record that the gate failed open on a lookup error"

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -772,15 +772,23 @@ fn add_one(
 
     // Auto-generate embedding. Gated by the caller-resolved `embed` flag
     // (which reflects both --no-embed and MX_SKIP_WRITE_EMBED).
+    //
+    // Non-fatal: the entry is already durable (upserted + read-back verified
+    // above), so a transient embed failure here must not surface as a
+    // process exit failure -- that would make callers retry and duplicate
+    // an entry that already landed.
     if embed {
-        auto_embed(&id, db)?;
+        let _ = auto_embed(&id, db)
+            .map_err(|e| eprintln!("Warning: post-write embed failed (entry durable): {e}"));
     } else {
         println!("  (embed skipped)");
     }
 
     // Auto-generate anchors. Gated by --no-auto-anchor / MX_SKIP_WRITE_ANCHOR.
+    // Non-fatal for the same reason as the embed step above.
     if write_anchor_enabled(no_auto_anchor) {
-        auto_anchor(&id, db, None)?;
+        let _ = auto_anchor(&id, db, None)
+            .map_err(|e| eprintln!("Warning: post-write anchor failed (entry durable): {e}"));
     } else {
         println!("  (auto-anchor skipped)");
     }
@@ -1484,8 +1492,14 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 // write_embed_enabled). The entry is already durable here, so
                 // skipping embedding is safe; the explicit `mx memory embed --all`
                 // command is never gated and still embeds deferred entries.
+                //
+                // Non-fatal: a transient embed failure must not exit non-zero
+                // once the fact has already landed, or callers will retry and
+                // duplicate it.
                 if write_embed_enabled(no_embed) {
-                    auto_embed(&id, db.as_ref())?;
+                    let _ = auto_embed(&id, db.as_ref()).map_err(|e| {
+                        eprintln!("Warning: post-write embed failed (entry durable): {e}")
+                    });
                 } else {
                     println!("  (embed skipped)");
                 }
@@ -2222,8 +2236,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Auto-generate embedding if in network SurrealDB mode.
             // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            // Non-fatal: the entry is already durable (upserted above), so a
+            // transient embed failure must not exit non-zero -- that would
+            // make callers retry and duplicate an update that already landed.
             if write_embed_enabled(no_embed) {
-                auto_embed(&id, db.as_ref())?;
+                let _ = auto_embed(&id, db.as_ref()).map_err(|e| {
+                    eprintln!("Warning: post-write embed failed (entry durable): {e}")
+                });
             } else {
                 println!("  (embed skipped)");
             }
@@ -2241,8 +2260,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // write_anchor_enabled). The entry is already durable here, so
             // skipping anchoring is safe; the explicit `mx memory auto-anchor`
             // command is never gated and still anchors deferred writes.
+            // Non-fatal for the same reason as the embed step above.
             if write_anchor_enabled(no_auto_anchor) {
-                auto_anchor(&id, db.as_ref(), removed)?;
+                let _ = auto_anchor(&id, db.as_ref(), removed).map_err(|e| {
+                    eprintln!("Warning: post-write anchor failed (entry durable): {e}")
+                });
             } else {
                 println!("  (auto-anchor skipped)");
             }
@@ -2300,8 +2322,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Auto-generate embedding if in network SurrealDB mode.
             // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            // Non-fatal: the edit already landed via edit_content above, so a
+            // transient embed failure must not exit non-zero -- that would
+            // make callers retry and duplicate the edit.
             if write_embed_enabled(no_embed) {
-                auto_embed(&id, db.as_ref())?;
+                let _ = auto_embed(&id, db.as_ref()).map_err(|e| {
+                    eprintln!("Warning: post-write embed failed (entry durable): {e}")
+                });
             } else {
                 println!("  (embed skipped)");
             }
@@ -2311,8 +2338,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // write_anchor_enabled). The entry is already durable here, so
             // skipping anchoring is safe; the explicit `mx memory auto-anchor`
             // command is never gated and still anchors deferred writes.
+            // Non-fatal for the same reason as the embed step above.
             if write_anchor_enabled(no_auto_anchor) {
-                auto_anchor(&id, db.as_ref(), None)?;
+                let _ = auto_anchor(&id, db.as_ref(), None).map_err(|e| {
+                    eprintln!("Warning: post-write anchor failed (entry durable): {e}")
+                });
             } else {
                 println!("  (auto-anchor skipped)");
             }
@@ -2386,8 +2416,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Auto-generate embedding if in network SurrealDB mode.
             // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            // Non-fatal: the append already landed via append_content above, so
+            // a transient embed failure must not exit non-zero -- that would
+            // make callers retry and duplicate the append.
             if write_embed_enabled(no_embed) {
-                auto_embed(&id, db.as_ref())?;
+                let _ = auto_embed(&id, db.as_ref()).map_err(|e| {
+                    eprintln!("Warning: post-write embed failed (entry durable): {e}")
+                });
             } else {
                 println!("  (embed skipped)");
             }
@@ -2397,8 +2432,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // write_anchor_enabled). The entry is already durable here, so
             // skipping anchoring is safe; the explicit `mx memory auto-anchor`
             // command is never gated and still anchors deferred writes.
+            // Non-fatal for the same reason as the embed step above.
             if write_anchor_enabled(no_auto_anchor) {
-                auto_anchor(&id, db.as_ref(), None)?;
+                let _ = auto_anchor(&id, db.as_ref(), None).map_err(|e| {
+                    eprintln!("Warning: post-write anchor failed (entry durable): {e}")
+                });
             } else {
                 println!("  (auto-anchor skipped)");
             }
@@ -2468,8 +2506,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Auto-generate embedding if in network SurrealDB mode.
             // Gated by --no-embed or MX_SKIP_WRITE_EMBED (see write_embed_enabled).
+            // Non-fatal: the prepend already landed via prepend_content above,
+            // so a transient embed failure must not exit non-zero -- that
+            // would make callers retry and duplicate the prepend.
             if write_embed_enabled(no_embed) {
-                auto_embed(&id, db.as_ref())?;
+                let _ = auto_embed(&id, db.as_ref()).map_err(|e| {
+                    eprintln!("Warning: post-write embed failed (entry durable): {e}")
+                });
             } else {
                 println!("  (embed skipped)");
             }
@@ -2479,8 +2522,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // write_anchor_enabled). The entry is already durable here, so
             // skipping anchoring is safe; the explicit `mx memory auto-anchor`
             // command is never gated and still anchors deferred writes.
+            // Non-fatal for the same reason as the embed step above.
             if write_anchor_enabled(no_auto_anchor) {
-                auto_anchor(&id, db.as_ref(), None)?;
+                let _ = auto_anchor(&id, db.as_ref(), None).map_err(|e| {
+                    eprintln!("Warning: post-write anchor failed (entry durable): {e}")
+                });
             } else {
                 println!("  (auto-anchor skipped)");
             }
@@ -2590,8 +2636,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 // #3: update embeddings and anchors like all other mutation paths.
                 // Embedding gated by --no-embed or MX_SKIP_WRITE_EMBED (see
                 // write_embed_enabled). The entry is already durable here.
+                // Non-fatal: the restore already landed via upsert_knowledge
+                // above, so a transient embed failure must not exit non-zero
+                // -- that would make callers retry and duplicate the restore.
                 if write_embed_enabled(no_embed) {
-                    auto_embed(&id, db.as_ref())?;
+                    let _ = auto_embed(&id, db.as_ref()).map_err(|e| {
+                        eprintln!("Warning: post-write embed failed (entry durable): {e}")
+                    });
                 } else {
                     println!("  (embed skipped)");
                 }
@@ -2600,8 +2651,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 // skipping anchoring is safe; the explicit `mx memory
                 // auto-anchor` command is never gated and still anchors
                 // deferred writes.
+                // Non-fatal for the same reason as the embed step above.
                 if write_anchor_enabled(no_auto_anchor) {
-                    auto_anchor(&id, db.as_ref(), None)?;
+                    let _ = auto_anchor(&id, db.as_ref(), None).map_err(|e| {
+                        eprintln!("Warning: post-write anchor failed (entry durable): {e}")
+                    });
                 } else {
                     println!("  (auto-anchor skipped)");
                 }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -3211,18 +3211,36 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     added_ids.len(),
                     if added_ids.len() == 1 { "y" } else { "ies" }
                 );
-                let provider = TractProvider::new()?;
-                let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
-                for (i, entry_id) in added_ids.iter().enumerate() {
-                    println!("  Embedding {}/{}: {}", i + 1, added_ids.len(), entry_id);
-                    crate::helpers::auto_embed_with(
-                        entry_id,
-                        db.as_ref(),
-                        &provider,
-                        &chunking_tokenizer,
-                    )?;
+                // All added_ids are already durably written above (add_one committed
+                // each entry before this pass runs). A failure anywhere in here —
+                // model cold-load, tokenizer load, or a single entry's embed — must
+                // NOT propagate to exit 1: the batch already landed and a non-zero
+                // exit here would make the caller re-fire and duplicate the whole
+                // batch. Mirrors the non-fatal post-write side-effect pattern used
+                // for the six single-entry commands (Append/Add/Update/Edit/Prepend/
+                // Restore); unembedded entries are reconciled later by
+                // `mx memory embed --all`.
+                let embed_result: anyhow::Result<()> = (|| {
+                    let provider = TractProvider::new()?;
+                    let chunking_tokenizer = crate::embeddings::load_tokenizer()?;
+                    for (i, entry_id) in added_ids.iter().enumerate() {
+                        println!("  Embedding {}/{}: {}", i + 1, added_ids.len(), entry_id);
+                        crate::helpers::auto_embed_with(
+                            entry_id,
+                            db.as_ref(),
+                            &provider,
+                            &chunking_tokenizer,
+                        )?;
+                    }
+                    Ok(())
+                })();
+                match embed_result {
+                    Ok(()) => println!("Embedding complete."),
+                    Err(e) => eprintln!(
+                        "Warning: post-write batch embed failed ({} entries durable): {e}",
+                        added_ids.len()
+                    ),
                 }
-                println!("Embedding complete.");
             } else if no_embed && !added_ids.is_empty() {
                 println!(
                     "\n(embed skipped for {} entries — run `mx memory embed --all` to embed)",

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1188,6 +1188,372 @@ mod auto_anchor_tests {
         assert!(got.is_empty(), "no embedding -> no anchoring");
     }
 
+    /// Wraps a real in-memory SurrealDB store and forces
+    /// `semantic_search_entries_scored` to return `Err` -- simulating a
+    /// transient candidate-fetch failure AFTER the `embedding.is_none()`
+    /// early return, i.e. on an entry that IS embedded. Every other method
+    /// is a real pass-through. Mirrors `handlers::memory::FailingStore`
+    /// (same shape, different failing method).
+    struct FailingScoredStore {
+        inner: Box<dyn KnowledgeStore>,
+    }
+
+    impl FailingScoredStore {
+        fn new() -> Self {
+            Self {
+                inner: Box::new(SurrealDatabase::open_in_memory().unwrap()),
+            }
+        }
+    }
+
+    impl KnowledgeStore for FailingScoredStore {
+        fn upsert_knowledge(&self, entry: &KnowledgeEntry) -> Result<()> {
+            self.inner.upsert_knowledge(entry)
+        }
+        fn get(&self, id: &str, ctx: &AgentContext) -> Result<Option<KnowledgeEntry>> {
+            self.inner.get(id, ctx)
+        }
+        fn delete(&self, id: &str, ctx: &AgentContext) -> Result<bool> {
+            self.inner.delete(id, ctx)
+        }
+        fn search(
+            &self,
+            query: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<KnowledgeEntry>> {
+            self.inner.search(query, ctx, filter)
+        }
+        fn semantic_search(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+            limit: usize,
+        ) -> Result<Vec<KnowledgeEntry>> {
+            self.inner
+                .semantic_search(query_embedding, ctx, filter, limit)
+        }
+        fn semantic_search_scored(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+            limit: usize,
+        ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+            self.inner
+                .semantic_search_scored(query_embedding, ctx, filter, limit)
+        }
+        fn semantic_search_entries_scored(
+            &self,
+            _query_embedding: &[f32],
+            _ctx: &AgentContext,
+            _limit: usize,
+        ) -> Result<Vec<(KnowledgeEntry, f32)>> {
+            anyhow::bail!("simulated transient candidate-fetch failure")
+        }
+        fn list_by_category(
+            &self,
+            category: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<KnowledgeEntry>> {
+            self.inner.list_by_category(category, ctx, filter)
+        }
+        fn count_by_category(
+            &self,
+            category: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<usize> {
+            self.inner.count_by_category(category, ctx, filter)
+        }
+        fn owned_private_matching(
+            &self,
+            agent: &str,
+            query: Option<&str>,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<KnowledgeEntry>> {
+            self.inner.owned_private_matching(agent, query, filter)
+        }
+        fn list_all(&self, ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>> {
+            self.inner.list_all(ctx)
+        }
+        fn list_with_triggers(&self, ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>> {
+            self.inner.list_with_triggers(ctx)
+        }
+        fn count(&self) -> Result<usize> {
+            self.inner.count()
+        }
+        fn wake_cascade(
+            &self,
+            ctx: &AgentContext,
+            limit: usize,
+            min_resonance: Option<i32>,
+            days: i64,
+        ) -> Result<store::WakeCascade> {
+            self.inner.wake_cascade(ctx, limit, min_resonance, days)
+        }
+        fn update_activations(&self, ids: &[String]) -> Result<()> {
+            self.inner.update_activations(ids)
+        }
+        fn update_summary(&self, id: &str, summary: &str, ctx: &AgentContext) -> Result<bool> {
+            self.inner.update_summary(id, summary, ctx)
+        }
+        fn apply_update(
+            &self,
+            id: &str,
+            spec: &crate::store_update::UpdateSpec,
+            ctx: &AgentContext,
+        ) -> Result<crate::store_update::UpdateOutcome> {
+            self.inner.apply_update(id, spec, ctx)
+        }
+        fn increment_activation_count(&self, ids: &[String]) -> Result<()> {
+            self.inner.increment_activation_count(ids)
+        }
+        fn query_recent_facts(&self, days: i32) -> Result<Vec<KnowledgeEntry>> {
+            self.inner.query_recent_facts(days)
+        }
+        fn query_recent_facts_all_types(&self, days: i32) -> Result<Vec<KnowledgeEntry>> {
+            self.inner.query_recent_facts_all_types(days)
+        }
+        fn reinforce(
+            &self,
+            id: &str,
+            amount: i32,
+            cap: Option<i32>,
+            ctx: &AgentContext,
+        ) -> Result<Option<store::ReinforcementResult>> {
+            self.inner.reinforce(id, amount, cap, ctx)
+        }
+        fn delete_embedding_chunks(&self, entry_id: &str) -> Result<()> {
+            self.inner.delete_embedding_chunks(entry_id)
+        }
+        fn insert_embedding_chunk(
+            &self,
+            entry_id: &str,
+            chunk_index: usize,
+            chunk_text: &str,
+            token_offset: usize,
+            token_count: usize,
+            embedding: &[f32],
+            model_id: &str,
+        ) -> Result<()> {
+            self.inner.insert_embedding_chunk(
+                entry_id,
+                chunk_index,
+                chunk_text,
+                token_offset,
+                token_count,
+                embedding,
+                model_id,
+            )
+        }
+        fn semantic_search_chunks(
+            &self,
+            query_embedding: &[f32],
+            limit: usize,
+        ) -> Result<Vec<(String, f32)>> {
+            self.inner.semantic_search_chunks(query_embedding, limit)
+        }
+        fn edit_content(
+            &self,
+            id: &str,
+            ctx: &AgentContext,
+            old_text: &str,
+            new_text: &str,
+            replace_all: bool,
+            nth: Option<usize>,
+        ) -> Result<store::EditResult> {
+            self.inner
+                .edit_content(id, ctx, old_text, new_text, replace_all, nth)
+        }
+        fn append_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()> {
+            self.inner.append_content(id, ctx, content)
+        }
+        fn prepend_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()> {
+            self.inner.prepend_content(id, ctx, content)
+        }
+        fn backup_content(
+            &self,
+            entry: &KnowledgeEntry,
+            operation: &str,
+            agent: Option<&str>,
+        ) -> Result<String> {
+            self.inner.backup_content(entry, operation, agent)
+        }
+        fn list_backups(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
+            self.inner.list_backups(entry_id)
+        }
+        fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>> {
+            self.inner.latest_backup(entry_id)
+        }
+        fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<()> {
+            self.inner.purge_backups(entry_id, keep)
+        }
+        fn get_tags_for_entry(&self, entry_id: &str) -> Result<Vec<String>> {
+            self.inner.get_tags_for_entry(entry_id)
+        }
+        fn set_tags_for_entry(&self, entry_id: &str, tags: &[String]) -> Result<()> {
+            self.inner.set_tags_for_entry(entry_id, tags)
+        }
+        fn list_all_tags(&self, category: Option<&str>) -> Result<Vec<String>> {
+            self.inner.list_all_tags(category)
+        }
+        fn get_applicability_for_entry(&self, entry_id: &str) -> Result<Vec<String>> {
+            self.inner.get_applicability_for_entry(entry_id)
+        }
+        fn set_applicability_for_entry(&self, entry_id: &str, ids: &[String]) -> Result<()> {
+            self.inner.set_applicability_for_entry(entry_id, ids)
+        }
+        fn list_applicability_types(&self) -> Result<Vec<crate::types::ApplicabilityType>> {
+            self.inner.list_applicability_types()
+        }
+        fn upsert_applicability_type(&self, atype: &crate::types::ApplicabilityType) -> Result<()> {
+            self.inner.upsert_applicability_type(atype)
+        }
+        fn list_categories(&self) -> Result<Vec<crate::types::Category>> {
+            self.inner.list_categories()
+        }
+        fn get_category(&self, id: &str) -> Result<Option<crate::types::Category>> {
+            self.inner.get_category(id)
+        }
+        fn upsert_category(&self, category: &crate::types::Category) -> Result<()> {
+            self.inner.upsert_category(category)
+        }
+        fn delete_category(&self, id: &str) -> Result<bool> {
+            self.inner.delete_category(id)
+        }
+        fn list_projects(&self, active_only: bool) -> Result<Vec<crate::types::Project>> {
+            self.inner.list_projects(active_only)
+        }
+        fn get_project(&self, id: &str) -> Result<Option<crate::types::Project>> {
+            self.inner.get_project(id)
+        }
+        fn upsert_project(&self, project: &crate::types::Project) -> Result<()> {
+            self.inner.upsert_project(project)
+        }
+        fn get_tags_for_project(&self, project_id: &str) -> Result<Vec<String>> {
+            self.inner.get_tags_for_project(project_id)
+        }
+        fn set_tags_for_project(&self, project_id: &str, tags: &[String]) -> Result<()> {
+            self.inner.set_tags_for_project(project_id, tags)
+        }
+        fn get_applicability_for_project(&self, project_id: &str) -> Result<Vec<String>> {
+            self.inner.get_applicability_for_project(project_id)
+        }
+        fn set_applicability_for_project(&self, project_id: &str, ids: &[String]) -> Result<()> {
+            self.inner.set_applicability_for_project(project_id, ids)
+        }
+        fn list_agents(&self) -> Result<Vec<crate::types::Agent>> {
+            self.inner.list_agents()
+        }
+        fn get_agent(&self, id: &str) -> Result<Option<crate::types::Agent>> {
+            self.inner.get_agent(id)
+        }
+        fn upsert_agent(&self, agent: &crate::types::Agent) -> Result<()> {
+            self.inner.upsert_agent(agent)
+        }
+        fn list_relationships_for_entry(
+            &self,
+            entry_id: &str,
+        ) -> Result<Vec<crate::types::Relationship>> {
+            self.inner.list_relationships_for_entry(entry_id)
+        }
+        fn add_relationship(&self, from: &str, to: &str, rel_type: &str) -> Result<String> {
+            self.inner.add_relationship(from, to, rel_type)
+        }
+        fn delete_relationship(&self, id: &str) -> Result<bool> {
+            self.inner.delete_relationship(id)
+        }
+        fn get_facts_for_session(&self, session_id: &str) -> Result<Vec<String>> {
+            self.inner.get_facts_for_session(session_id)
+        }
+        fn get_entries_for_session(
+            &self,
+            session_id: &str,
+            owner: Option<&str>,
+            category: &str,
+            ctx: &AgentContext,
+        ) -> Result<Vec<store::DedupCandidate>> {
+            self.inner
+                .get_entries_for_session(session_id, owner, category, ctx)
+        }
+        fn get_session_for_fact(&self, fact_id: &str) -> Result<Option<String>> {
+            self.inner.get_session_for_fact(fact_id)
+        }
+        fn list_sessions(&self, project_id: Option<&str>) -> Result<Vec<crate::types::Session>> {
+            self.inner.list_sessions(project_id)
+        }
+        fn get_session(&self, id: &str) -> Result<Option<crate::types::Session>> {
+            self.inner.get_session(id)
+        }
+        fn upsert_session(&self, session: &crate::types::Session) -> Result<()> {
+            self.inner.upsert_session(session)
+        }
+        fn list_source_types(&self) -> Result<Vec<crate::types::SourceType>> {
+            self.inner.list_source_types()
+        }
+        fn list_entry_types(&self) -> Result<Vec<crate::types::EntryType>> {
+            self.inner.list_entry_types()
+        }
+        fn list_content_types(&self) -> Result<Vec<crate::types::ContentType>> {
+            self.inner.list_content_types()
+        }
+        fn list_session_types(&self) -> Result<Vec<crate::types::SessionType>> {
+            self.inner.list_session_types()
+        }
+        fn list_relationship_types(&self) -> Result<Vec<crate::types::RelationshipType>> {
+            self.inner.list_relationship_types()
+        }
+        fn create_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<String> {
+            self.inner.create_wake_session(session)
+        }
+        fn get_wake_session(
+            &self,
+            session_id: &str,
+        ) -> Result<Option<crate::wake_token::WakeSession>> {
+            self.inner.get_wake_session(session_id)
+        }
+        fn update_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<()> {
+            self.inner.update_wake_session(session)
+        }
+        fn delete_wake_session(&self, session_id: &str) -> Result<()> {
+            self.inner.delete_wake_session(session_id)
+        }
+        fn sweep_ghost_anchors(&self, dry_run: bool) -> Result<store::GhostSweepResult> {
+            self.inner.sweep_ghost_anchors(dry_run)
+        }
+        fn list_tables(&self) -> Result<Vec<String>> {
+            self.inner.list_tables()
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn anchor_failure_on_embedded_entry_propagates_err() {
+        // Cory's B2 (PR #399 re-review): `auto_anchor` early-returns `Ok(())`
+        // when `embedding.is_none()` (covered by `no_embedding_skips_anchoring`
+        // above), but the path PAST that guard -- a candidate-fetch failure on
+        // an entry that IS embedded -- had zero coverage. This forces that
+        // failure and proves it surfaces as `Err`, which is what lets
+        // `add_one` (handlers::memory) catch it non-fatally and record it as
+        // `anchor_deferred` in the write outcome instead of the failure
+        // silently vanishing.
+        clear_agent_env();
+        let db = FailingScoredStore::new();
+        let target = entry_with_embedding("kn-embedded", unit_query(), "public", None, vec![]);
+        db.upsert_knowledge(&target).unwrap();
+
+        let result = auto_anchor("kn-embedded", &db, None);
+
+        assert!(
+            result.is_err(),
+            "a candidate-fetch failure on an already-embedded entry must surface as Err, \
+             not be swallowed inside auto_anchor itself"
+        );
+    }
+
     /// PR #366 hardening: the degenerate near-duplicate-flood case. When MORE
     /// than (K - max_anchors) entries score above the band ceiling, the initial
     /// bounded top-K (= max_anchors * ANCHOR_CANDIDATE_OVERFETCH = 25) is filled

--- a/tests/write_side_effect_nonfatal.rs
+++ b/tests/write_side_effect_nonfatal.rs
@@ -81,6 +81,13 @@ fn mx_with_broken_model_cache(env: &Env, args: &[&str]) -> std::process::Output 
 
 /// Add an entry with embed/anchor skipped, so entry creation itself never
 /// touches the model cache. Returns its `kn-` id.
+///
+/// Deliberately omits `--json`: `add_one`'s `--no-embed`/`--no-auto-anchor`
+/// branches `println!` a "(... skipped)" notice to stdout ahead of whatever
+/// the caller prints, which corrupts `--json`'s stdout-is-JSON contract.
+/// That's a pre-existing bug independent of this test file, so this helper
+/// works around it by parsing the plain-text "Added entry: <id>" line
+/// instead of asking for JSON.
 fn add_plain_no_embed(env: &Env) -> String {
     let out = mx(
         env,
@@ -95,7 +102,6 @@ fn add_plain_no_embed(env: &Env) -> String {
             "original body",
             "--no-embed",
             "--no-auto-anchor",
-            "--json",
         ],
     );
     assert!(
@@ -103,8 +109,12 @@ fn add_plain_no_embed(env: &Env) -> String {
         "setup add failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
-    v["id"].as_str().unwrap().to_string()
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("Added entry: "))
+        .map(|id| id.trim().to_string())
+        .unwrap_or_else(|| panic!("expected an 'Added entry: <id>' line, got: {stdout}"))
 }
 
 fn show_body(env: &Env, id: &str) -> String {

--- a/tests/write_side_effect_nonfatal.rs
+++ b/tests/write_side_effect_nonfatal.rs
@@ -1,0 +1,242 @@
+//! Integration tests for the post-write side-effect non-fatal fix (W446).
+//!
+//! Root cause: durable write commands (Add/Update/Edit/Append/Prepend/Restore)
+//! commit the entry, then run `auto_embed`/`auto_anchor` as best-effort
+//! side-effects. Before this fix those side effects were chained with `?`,
+//! so a transient embed/anchor failure propagated all the way to `main()`
+//! and produced a non-zero exit *after the write had already landed* --
+//! callers would see "failure", retry, and duplicate the entry.
+//!
+//! These tests force `auto_embed` to fail deterministically (no network
+//! flakiness assumed beyond reachability of huggingface.co, which the rest
+//! of this suite already depends on for real embedding) and assert:
+//!   - the process still exits 0,
+//!   - a warning naming the entry as durable is printed to stderr,
+//!   - the write is actually visible afterward.
+//!
+//! A genuine write failure (the write itself never lands) must still exit
+//! non-zero -- that path is untouched by this fix and is asserted here too.
+
+use std::process::Command;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use tempfile::TempDir;
+
+const MX: &str = env!("CARGO_BIN_EXE_mx");
+
+/// Each test spins up a full SurrealDB + embedding engine under its own temp
+/// MX_HOME. Running them concurrently exhausts the (shared) model cache and DB
+/// resources, so serialize the heavyweight binary invocations through one lock.
+/// Mirrors the harness style in `tests/triggers_cli.rs`.
+fn test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct Env {
+    dir: TempDir,
+    _guard: MutexGuard<'static, ()>,
+}
+
+fn setup() -> Env {
+    let guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
+    Env {
+        dir: TempDir::new().unwrap(),
+        _guard: guard,
+    }
+}
+
+fn mx(env: &Env, args: &[&str]) -> std::process::Output {
+    Command::new(MX)
+        .args(args)
+        .env("MX_HOME", env.dir.path())
+        .env("MX_CURRENT_AGENT", "test")
+        .output()
+        .expect("failed to run mx")
+}
+
+/// Runs an `mx` command with the on-write embed step forced to fail.
+///
+/// `MX_ISOLATE_MODELS=1` points the hf-hub model cache at
+/// `$MX_HOME/memory/embed` (see `src/paths.rs::model_cache_dir`). Pre-creating
+/// that path as a plain *file* (not a directory) makes hf-hub's
+/// `create_dir_all(blob_path.parent())` fail as soon as it tries to stage the
+/// downloaded model blob -- deterministic and independent of whether the
+/// model happens to already be warm in the shared cache. The failure occurs
+/// after `metadata()`'s network round-trip, so this still requires
+/// huggingface.co to be reachable, same as every other embedding test in
+/// this suite.
+fn mx_with_broken_model_cache(env: &Env, args: &[&str]) -> std::process::Output {
+    let cache_block = env.dir.path().join("memory").join("embed");
+    std::fs::create_dir_all(cache_block.parent().unwrap()).unwrap();
+    std::fs::write(&cache_block, b"blocking file, not a directory").unwrap();
+
+    Command::new(MX)
+        .args(args)
+        .env("MX_HOME", env.dir.path())
+        .env("MX_CURRENT_AGENT", "test")
+        .env("MX_ISOLATE_MODELS", "1")
+        .output()
+        .expect("failed to run mx")
+}
+
+/// Add an entry with embed/anchor skipped, so entry creation itself never
+/// touches the model cache. Returns its `kn-` id.
+fn add_plain_no_embed(env: &Env) -> String {
+    let out = mx(
+        env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Nonfatal Side-Effect Test",
+            "--content",
+            "original body",
+            "--no-embed",
+            "--no-auto-anchor",
+            "--json",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "setup add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    v["id"].as_str().unwrap().to_string()
+}
+
+fn show_body(env: &Env, id: &str) -> String {
+    let out = mx(env, &["memory", "show", id, "--json"]);
+    assert!(
+        out.status.success(),
+        "show failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    v["body"].as_str().unwrap_or("").to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Post-write side-effect failure is non-fatal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn append_embed_failure_is_non_fatal_and_content_persists() {
+    let dir = setup();
+    let id = add_plain_no_embed(&dir);
+
+    let out = mx_with_broken_model_cache(
+        &dir,
+        &["memory", "append", &id, "--content", "appended text"],
+    );
+
+    assert!(
+        out.status.success(),
+        "append must exit 0 even when the post-write embed fails: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("post-write embed failed") && stderr.contains("entry durable"),
+        "expected a non-fatal embed warning naming the entry as durable: {stderr}"
+    );
+
+    // The append landed despite the embed step failing.
+    assert!(
+        show_body(&dir, &id).contains("appended text"),
+        "appended content should be durable even though embed failed"
+    );
+}
+
+#[test]
+fn add_embed_failure_is_non_fatal_and_entry_persists() {
+    let dir = setup();
+
+    let out = mx_with_broken_model_cache(
+        &dir,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Add Nonfatal Embed Test",
+            "--content",
+            "brand new entry",
+            "--json",
+        ],
+    );
+
+    assert!(
+        out.status.success(),
+        "add must exit 0 even when the post-write embed fails: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("post-write embed failed") && stderr.contains("entry durable"),
+        "expected a non-fatal embed warning naming the entry as durable: {stderr}"
+    );
+
+    // The entry actually landed despite the embed step failing. `add --json`
+    // still reports the id on the (now non-fatal) embed-failure path.
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .expect("add --json output should still parse on the non-fatal embed path");
+    let id = v["id"].as_str().expect("id present").to_string();
+    assert_eq!(show_body(&dir, &id), "brand new entry");
+}
+
+// ---------------------------------------------------------------------------
+// A genuine write failure must still exit non-zero
+// ---------------------------------------------------------------------------
+
+#[test]
+fn append_to_missing_entry_still_exits_nonzero() {
+    let dir = setup();
+
+    let out = mx(
+        &dir,
+        &["memory", "append", "kn-does-not-exist", "--content", "x"],
+    );
+
+    assert!(
+        !out.status.success(),
+        "appending to a nonexistent entry must still fail -- the write itself never lands"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.to_lowercase().contains("not found"),
+        "expected a not-found error, got: {stderr}"
+    );
+}
+
+#[test]
+fn add_with_invalid_category_still_exits_nonzero() {
+    let dir = setup();
+
+    let out = mx(
+        &dir,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "not-a-real-category",
+            "--title",
+            "Should Not Land",
+            "--content",
+            "body",
+        ],
+    );
+
+    assert!(
+        !out.status.success(),
+        "an invalid category must still fail before any write is attempted"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Invalid category"),
+        "expected the category validation error, got: {stderr}"
+    );
+}

--- a/tests/write_side_effect_nonfatal.rs
+++ b/tests/write_side_effect_nonfatal.rs
@@ -188,6 +188,65 @@ fn add_embed_failure_is_non_fatal_and_entry_persists() {
     assert_eq!(show_body(&dir, &id), "brand new entry");
 }
 
+#[test]
+fn add_batch_embed_failure_is_non_fatal_and_entries_persist() {
+    let dir = setup();
+
+    let batch_file = dir.dir.path().join("batch.jsonl");
+    std::fs::write(
+        &batch_file,
+        concat!(
+            r#"{"category":"insight","title":"Batch Nonfatal 1","content":"first entry","source_agent":"test"}"#,
+            "\n",
+            r#"{"category":"insight","title":"Batch Nonfatal 2","content":"second entry","source_agent":"test"}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+
+    let out = mx_with_broken_model_cache(
+        &dir,
+        &[
+            "memory",
+            "add-batch",
+            "--file",
+            batch_file.to_str().unwrap(),
+        ],
+    );
+
+    assert!(
+        out.status.success(),
+        "add-batch must exit 0 even when the hoisted post-write embed pass fails: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("post-write batch embed failed") && stderr.contains("entries durable"),
+        "expected a non-fatal batch embed warning naming the entries as durable: {stderr}"
+    );
+
+    // Both entries landed despite the hoisted embed pass failing entirely
+    // (the model cold-load itself is what's broken here, so no entry embeds).
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let ids: Vec<&str> = stdout
+        .lines()
+        .filter_map(|l| l.split_whitespace().find(|w| w.starts_with("kn-")))
+        .map(|w| w.trim_end_matches(':').trim_start_matches('[').trim())
+        .collect();
+    assert_eq!(
+        ids.len(),
+        2,
+        "expected both batch entries to report an id in stdout, got: {stdout}"
+    );
+    for id in ids {
+        let body = show_body(&dir, id);
+        assert!(
+            body == "first entry" || body == "second entry",
+            "batch entry {id} should be durable with its content, got body: {body}"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // A genuine write failure must still exit non-zero
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

`mx memory append` (and its siblings) reported exit 1 on writes that had already landed. Callers treating exit 1 as "the write failed" re-fired — and the re-fire created duplicates. Hit in real use: a backgrounded `append` reported failure on a write that was already durable, the caller retried, and the entry got written twice.

## Root cause

The durable write commits first, then post-write side effects run: `auto_embed(...)?` and `auto_anchor(...)?`. Those `?` operators propagate *transient* side-effect failures — model cold-load, a websocket blip — straight to a non-zero exit, **after** the entry is already durable. So a fully-successful, committed write surfaced as a failure because an optional follow-up step hiccupped.

Diagnosis was trace-level: walking iteration counts and the exact `?` operators in the post-write blocks of `src/handlers/memory.rs`.

## Fix

Post-write embed/anchor is now non-fatal: on failure it logs a stderr warning noting that the entry itself is durable, and exits 0. This mirrors the existing non-fatal backup pattern already in the codebase. Applied symmetrically across **Append / Add / Update / Edit / Prepend / Restore**. Genuine write failures — where the durable write itself fails — still exit non-zero.

## Validation

Adversarial repro against the patched build: corrupted the cached ONNX blob to force `TractProvider::new` to fail at the exact diagnosed line.

- Transient side-effect failure → exit 0 + stderr warning + durable write confirmed by a follow-up graph read.
- Genuine failure (append to a nonexistent ID) → still exits 1.

New test file `tests/write_side_effect_nonfatal.rs`, 5/5 passing. `cargo fmt` and `cargo clippy` clean.

## Known follow-up (not in this PR)

`--no-embed` / `--no-auto-anchor` emit their "(... skipped)" skip-notices via `println!` to **stdout**, ahead of the JSON payload under `--json` — which corrupts the "stdout is JSON" contract. Surfaced by the new tests (the `add_plain_no_embed` helper drops `--json` to work around it). Pre-existing, independent of this change. Left for a separate call on the broader "human-facing notices never touch stdout under `--json`" rule.

## Note

The local test environment couldn't run `tests/trigger_check.rs` (SurrealDB IAM permissions — environmental, not a code issue). CI should exercise it properly.
