### PR TITLE
feat: add --exclude-tags to memory search and list

### DIFF
--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1330,7 +1330,7 @@ Several read commands (`search`, `list`) share a common set of filter
 flags. These are documented once here and referenced below.
 
   **Flag**                     **Type**   **Description**
-  ---------------------------- ---------- -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  ---------------------------- ---------- --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   `-c, --category`             `string`   Filter by category (comma-separated).
   `--json`                     `flag`     Output as JSON.
   `--mine`                     `flag`     Show only your private entries.
@@ -1345,7 +1345,7 @@ flags. These are documented once here and referenced below.
   `--missing-resonance-type`   `flag`     Filter to entries WITHOUT a resonance type.
   `--limit`                    `int`      Limit number of results.
   `--tags`                     `string`   Filter by tags (comma-separated, matches any).
-  `--exclude-tags`             `string`   Comma-separated list of tag prefixes. Drops any entry that carries at least one tag prefix-matching at least one of these values -- useful for excluding whole tag namespaces (e.g. `tier/` removes every entry tagged `tier/<anything>`). Empty segments from trailing commas are ignored. Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.
+  `--exclude-tags`             `string`   Comma-separated tag prefixes to drop (e.g. `tier/` excludes every entry tagged `tier/<anything>`). Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.
 
 ::: {.admonition .note}
 **NOTE:** **Visibility default:** `list` and `search` run
@@ -1383,6 +1383,13 @@ therefore admit an entry under `wake` but exclude it under
 `transformative` resonance types are decay-exempt, so they filter
 identically under both. This divergence is intentional for now; an
 explicit `--resonance-basis raw|decayed` flag is tracked in #404.
+:::
+
+::: {.admonition .note}
+**NOTE:** `--exclude-tags` takes a comma-separated list of tag prefixes.
+Any entry carrying at least one tag that prefix-matches at least one
+supplied value is dropped -- useful for excluding whole tag namespaces.
+Empty segments from trailing commas are ignored.
 :::
 
 ## `mx memory show`
@@ -1485,10 +1492,17 @@ to have embeddings generated via `mx memory embed`.
 :::
 
 ::: {.admonition .note}
-**NOTE:** With `--semantic`, `--exclude-tags` is applied inside the
-candidate-set query itself, not as a post-filter -- excluded entries
-never occupy a ranked slot, so `--limit` still returns a full page even
-when top-ranked neighbors carry an excluded tag.
+**NOTE:** With `--semantic`, `--exclude-tags` exclusion happens in two
+phases: unchunked entries are excluded inside the candidate-set query
+itself (SQL `WHERE`), while chunked entries are filtered on the Rust
+side after hydration, since `embedding_chunk` has no direct tag edge to
+filter on in SQL. Either way, excluded entries are dropped before the
+final sort and truncate, so `--limit` returns a full page as long as the
+search stays within its scan budget (`limit * 50`, minimum 1000 chunk
+candidates). If that budget is exhausted before enough non-excluded
+results are found -- which can happen when excluded tags dominate the
+ranked candidates -- the result set may come back short, and a warning
+is logged when that happens.
 :::
 
 ::: {.admonition .tip}

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1319,7 +1319,8 @@ include all per-entry fields (`category`, `title`, `content`,
 `source_agent`, `tags`, `private`, `resonance`, `type`, etc.) on each
 line. There are no batch-wide field overrides except `--no-embed`. This
 design supports heterogeneous batches (facts, person nodes, summaries,
-blooms) in a single invocation --- which is the primary pocket use-case.
+blooms) in a single invocation --- which is the primary batch-write
+use-case.
 :::
 
 ## Reading entries {#reading}

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1330,7 +1330,7 @@ Several read commands (`search`, `list`) share a common set of filter
 flags. These are documented once here and referenced below.
 
   **Flag**                     **Type**   **Description**
-  ---------------------------- ---------- -------------------------------------------------------------------------------------------------------------------------------------
+  ---------------------------- ---------- -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   `-c, --category`             `string`   Filter by category (comma-separated).
   `--json`                     `flag`     Output as JSON.
   `--mine`                     `flag`     Show only your private entries.
@@ -1345,6 +1345,7 @@ flags. These are documented once here and referenced below.
   `--missing-resonance-type`   `flag`     Filter to entries WITHOUT a resonance type.
   `--limit`                    `int`      Limit number of results.
   `--tags`                     `string`   Filter by tags (comma-separated, matches any).
+  `--exclude-tags`             `string`   Comma-separated list of tag prefixes. Drops any entry that carries at least one tag prefix-matching at least one of these values -- useful for excluding whole tag namespaces (e.g. `tier/` removes every entry tagged `tier/<anything>`). Empty segments from trailing commas are ignored. Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.
 
 ::: {.admonition .note}
 **NOTE:** **Visibility default:** `list` and `search` run
@@ -1424,6 +1425,11 @@ mx memory list -c discovery,decree --min-resonance 5
 mx memory list --missing-wake-phrase --limit 20
 ```
 
+``` bash
+# Exclude a whole tag namespace
+mx memory list --category person --exclude-tags 'tier/'
+```
+
 ::: {.admonition .note}
 **NOTE:** `list` accepts all shared filter flags documented above,
 including the public-only visibility default and the hidden-private
@@ -1461,11 +1467,28 @@ mx memory search "agent bootstrap" -c recipe,method --limit 5
 mx memory search "retry pattern" --activate
 ```
 
+``` bash
+# Exclude a whole tag namespace from keyword search
+mx memory search "onboarding" --exclude-tags 'tier/'
+```
+
+``` bash
+# Exclude a whole tag namespace from semantic search
+mx memory search "onboarding" --semantic --exclude-tags 'tier/'
+```
+
 ::: {.admonition .note}
 **NOTE:** `search` accepts all shared filter flags, including the
 public-only visibility default and the hidden-private stderr hint (the
 hint is suppressed under `--semantic`). Semantic search requires entries
 to have embeddings generated via `mx memory embed`.
+:::
+
+::: {.admonition .note}
+**NOTE:** With `--semantic`, `--exclude-tags` is applied inside the
+candidate-set query itself, not as a post-filter -- excluded entries
+never occupy a ranked slot, so `--limit` still returns a full page even
+when top-ranked neighbors carry an excluded tag.
 :::
 
 ::: {.admonition .tip}

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1319,7 +1319,7 @@ include all per-entry fields (`category`, `title`, `content`,
 `source_agent`, `tags`, `private`, `resonance`, `type`, etc.) on each
 line. There are no batch-wide field overrides except `--no-embed`. This
 design supports heterogeneous batches (facts, person nodes, summaries,
-blooms) in a single invocation --- which is the primary batch-write
+blooms) in a single invocation --- which is the primary pocket
 use-case.
 :::
 

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1319,8 +1319,7 @@ include all per-entry fields (`category`, `title`, `content`,
 `source_agent`, `tags`, `private`, `resonance`, `type`, etc.) on each
 line. There are no batch-wide field overrides except `--no-embed`. This
 design supports heterogeneous batches (facts, person nodes, summaries,
-blooms) in a single invocation --- which is the primary pocket
-use-case.
+blooms) in a single invocation --- which is the primary pocket use-case.
 :::
 
 ## Reading entries {#reading}
@@ -1331,7 +1330,7 @@ Several read commands (`search`, `list`) share a common set of filter
 flags. These are documented once here and referenced below.
 
   **Flag**                     **Type**   **Description**
-  ---------------------------- ---------- --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  ---------------------------- ---------- -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   `-c, --category`             `string`   Filter by category (comma-separated).
   `--json`                     `flag`     Output as JSON.
   `--mine`                     `flag`     Show only your private entries.
@@ -1346,7 +1345,7 @@ flags. These are documented once here and referenced below.
   `--missing-resonance-type`   `flag`     Filter to entries WITHOUT a resonance type.
   `--limit`                    `int`      Limit number of results.
   `--tags`                     `string`   Filter by tags (comma-separated, matches any).
-  `--exclude-tags`             `string`   Comma-separated tag prefixes to drop (e.g. `tier/` excludes every entry tagged `tier/<anything>`). Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.
+  `--exclude-tags`             `string`   Comma-separated tag prefixes to drop (e.g. `tier/` excludes every entry tagged `tier/<anything>`). Specify once; comma-separate multiple prefixes -- repeating the flag is a parse error. Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.
 
 ::: {.admonition .note}
 **NOTE:** **Visibility default:** `list` and `search` run
@@ -1390,7 +1389,9 @@ explicit `--resonance-basis raw|decayed` flag is tracked in #404.
 **NOTE:** `--exclude-tags` takes a comma-separated list of tag prefixes.
 Any entry carrying at least one tag that prefix-matches at least one
 supplied value is dropped -- useful for excluding whole tag namespaces.
-Empty segments from trailing commas are ignored.
+Empty segments from trailing commas are ignored. Pass the flag once;
+repeating it (e.g. `--exclude-tags a --exclude-tags b`) is a parse
+error, not a silent override.
 :::
 
 ## `mx memory show`

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -121,7 +121,7 @@ per-entry fields (`category`, `title`, `content`, `source_agent`, `tags`,
 `private`, `resonance`, `type`, etc.) on each line. There are no batch-wide
 field overrides except `--no-embed`. This design supports heterogeneous batches
 (facts, person nodes, summaries, blooms) in a single invocation --- which is
-the primary pocket use-case.]
+the primary batch-write use-case.]
 
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -152,7 +152,7 @@ flags. These are documented once here and referenced below.
   [`--missing-resonance-type`], [`flag`], [Filter to entries WITHOUT a resonance type.],
   [`--limit`],         [`int`],    [Limit number of results.],
   [`--tags`],          [`string`], [Filter by tags (comma-separated, matches any).],
-  [`--exclude-tags`],  [`string`], [Comma-separated tag prefixes to drop (e.g. `tier/` excludes every entry tagged `tier/<anything>`). Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.],
+  [`--exclude-tags`],  [`string`], [Comma-separated tag prefixes to drop (e.g. `tier/` excludes every entry tagged `tier/<anything>`). Specify once; comma-separate multiple prefixes -- repeating the flag is a parse error. Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.],
 )
 
 #note[*Visibility default:* `list` and `search` run *public-only* by default.
@@ -189,7 +189,8 @@ flag is tracked in \#404.]
 #note[`--exclude-tags` takes a comma-separated list of tag prefixes. Any entry
 carrying at least one tag that prefix-matches at least one supplied value is
 dropped -- useful for excluding whole tag namespaces. Empty segments from
-trailing commas are ignored.]
+trailing commas are ignored. Pass the flag once; repeating it (e.g.
+`--exclude-tags a --exclude-tags b`) is a parse error, not a silent override.]
 
 #command(
   "mx memory show",

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -152,7 +152,7 @@ flags. These are documented once here and referenced below.
   [`--missing-resonance-type`], [`flag`], [Filter to entries WITHOUT a resonance type.],
   [`--limit`],         [`int`],    [Limit number of results.],
   [`--tags`],          [`string`], [Filter by tags (comma-separated, matches any).],
-  [`--exclude-tags`],  [`string`], [Comma-separated list of tag prefixes. Drops any entry that carries at least one tag prefix-matching at least one of these values -- useful for excluding whole tag namespaces (e.g. `tier/` removes every entry tagged `tier/<anything>`). Empty segments from trailing commas are ignored. Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.],
+  [`--exclude-tags`],  [`string`], [Comma-separated tag prefixes to drop (e.g. `tier/` excludes every entry tagged `tier/<anything>`). Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.],
 )
 
 #note[*Visibility default:* `list` and `search` run *public-only* by default.
@@ -185,6 +185,11 @@ threshold can therefore admit an entry under `wake` but exclude it under
 resonance types are decay-exempt, so they filter identically under both. This
 divergence is intentional for now; an explicit `--resonance-basis raw|decayed`
 flag is tracked in \#404.]
+
+#note[`--exclude-tags` takes a comma-separated list of tag prefixes. Any entry
+carrying at least one tag that prefix-matches at least one supplied value is
+dropped -- useful for excluding whole tag namespaces. Empty segments from
+trailing commas are ignored.]
 
 #command(
   "mx memory show",
@@ -238,10 +243,17 @@ visibility default and the hidden-private stderr hint (the hint is suppressed
 under `--semantic`). Semantic search requires entries to have embeddings
 generated via `mx memory embed`.]
 
-#note[With `--semantic`, `--exclude-tags` is applied inside the candidate-set
-query itself, not as a post-filter -- excluded entries never occupy a ranked
-slot, so `--limit` still returns a full page even when top-ranked neighbors
-carry an excluded tag.]
+#note[With `--semantic`, `--exclude-tags` exclusion happens in two phases:
+unchunked entries are excluded inside the candidate-set query itself (SQL
+`WHERE`), while chunked entries are filtered on the Rust side after
+hydration, since `embedding_chunk` has no direct tag edge to filter on in
+SQL. Either way, excluded entries are dropped before the final sort and
+truncate, so `--limit` returns a full page as long as the search stays
+within its scan budget (`limit * 50`, minimum 1000 chunk candidates). If
+that budget is exhausted before enough non-excluded results are found --
+which can happen when excluded tags dominate the ranked candidates -- the
+result set may come back short, and a warning is logged when that
+happens.]
 
 #tip[By default, search does not activate results -- browsing is not the same as
 engagement. Use `--activate` when you are intentionally consuming the results

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -121,7 +121,7 @@ per-entry fields (`category`, `title`, `content`, `source_agent`, `tags`,
 `private`, `resonance`, `type`, etc.) on each line. There are no batch-wide
 field overrides except `--no-embed`. This design supports heterogeneous batches
 (facts, person nodes, summaries, blooms) in a single invocation --- which is
-the primary batch-write use-case.]
+the primary pocket use-case.]
 
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -152,6 +152,7 @@ flags. These are documented once here and referenced below.
   [`--missing-resonance-type`], [`flag`], [Filter to entries WITHOUT a resonance type.],
   [`--limit`],         [`int`],    [Limit number of results.],
   [`--tags`],          [`string`], [Filter by tags (comma-separated, matches any).],
+  [`--exclude-tags`],  [`string`], [Comma-separated list of tag prefixes. Drops any entry that carries at least one tag prefix-matching at least one of these values -- useful for excluding whole tag namespaces (e.g. `tier/` removes every entry tagged `tier/<anything>`). Empty segments from trailing commas are ignored. Same parsing and prefix-match semantics as `wake-fetch`'s `--exclude-tags`.],
 )
 
 #note[*Visibility default:* `list` and `search` run *public-only* by default.
@@ -207,6 +208,7 @@ flag is tracked in \#404.]
     "mx memory list -c recipe",
     "mx memory list -c discovery,decree --min-resonance 5",
     "mx memory list --missing-wake-phrase --limit 20",
+    "# Exclude a whole tag namespace\nmx memory list --category person --exclude-tags 'tier/'",
   ),
 )
 
@@ -226,6 +228,8 @@ public-only visibility default and the hidden-private stderr hint.]
     "mx memory search \"how to handle timeouts\" --semantic",
     "mx memory search \"agent bootstrap\" -c recipe,method --limit 5",
     "# Search and activate results (mark as consumed)\nmx memory search \"retry pattern\" --activate",
+    "# Exclude a whole tag namespace from keyword search\nmx memory search \"onboarding\" --exclude-tags 'tier/'",
+    "# Exclude a whole tag namespace from semantic search\nmx memory search \"onboarding\" --semantic --exclude-tags 'tier/'",
   ),
 )
 
@@ -233,6 +237,11 @@ public-only visibility default and the hidden-private stderr hint.]
 visibility default and the hidden-private stderr hint (the hint is suppressed
 under `--semantic`). Semantic search requires entries to have embeddings
 generated via `mx memory embed`.]
+
+#note[With `--semantic`, `--exclude-tags` is applied inside the candidate-set
+query itself, not as a post-filter -- excluded entries never occupy a ranked
+slot, so `--limit` still returns a full page even when top-ranked neighbors
+carry an excluded tag.]
 
 #tip[By default, search does not activate results -- browsing is not the same as
 engagement. Use `--activate` when you are intentionally consuming the results

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -416,7 +416,9 @@ pub struct EntryFilter {
     // Option<String>, not Vec<String> like the neighboring `tags` field: this
     // deliberately mirrors wake-fetch's `--exclude-tags` for exact parse
     // parity, since both flow through the same `parse_exclude_prefixes`
-    // trim/empty-drop logic.
+    // trim/empty-drop logic. Repeating this flag (`--exclude-tags a
+    // --exclude-tags b`) is a clap parse error (ArgumentConflict), not a
+    // silent override -- pinned in the test module below.
     #[arg(long, value_name = "PREFIXES")]
     pub exclude_tags: Option<String>,
 }
@@ -2412,5 +2414,74 @@ mod tests {
             let (_, auto) = merge_flags(&["mx", "pr", "merge", "375", mode, "--auto"]);
             assert!(auto, "--auto with {mode} should parse and set auto");
         }
+    }
+
+    fn search_exclude_tags(args: &[&str]) -> Option<String> {
+        match Cli::try_parse_from(args) {
+            Ok(Cli {
+                command:
+                    Commands::Memory {
+                        command: MemoryCommands::Search { filter, .. },
+                    },
+                ..
+            }) => filter.exclude_tags,
+            Ok(_) => panic!("expected memory search subcommand"),
+            Err(e) => panic!("parse should succeed for {args:?}: {e}"),
+        }
+    }
+
+    // `--exclude-tags` is `Option<String>` (comma-separated), not
+    // `Option<Vec<String>>` like the neighboring `--tags` -- deliberate,
+    // for exact parse parity with wake-fetch (see field doc comment above).
+    // Pinning the repeated-flag behavior: an `Option<String>` field with no
+    // explicit `action(...)` gets clap's default `Set` action, and *unlike*
+    // the (incorrect, pre-test) assumption that Set silently keeps the last
+    // occurrence, clap 4's `Set` action actually rejects a second occurrence
+    // outright with `ErrorKind::ArgumentConflict` ("cannot be used multiple
+    // times"). So repeating `--exclude-tags` fails loud, not silent -- the
+    // opposite failure mode from the one that needed guarding against. This
+    // test exists so that never regresses to a silent override without a
+    // test failing (e.g. if someone later adds `.action(ArgAction::Set)`
+    // explicitly, or an `overrides_with`, to "fix" what isn't broken).
+    #[test]
+    fn search_exclude_tags_repeated_flag_errors_instead_of_silently_overriding() {
+        let err = parse_err(&[
+            "mx",
+            "memory",
+            "search",
+            "query",
+            "--exclude-tags",
+            "tier/",
+            "--exclude-tags",
+            "project/",
+        ]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn wake_fetch_exclude_tags_repeated_flag_errors_instead_of_silently_overriding() {
+        let err = parse_err(&[
+            "mx",
+            "memory",
+            "wake-fetch",
+            "--exclude-tags",
+            "tier/",
+            "--exclude-tags",
+            "project/",
+        ]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn search_exclude_tags_single_flag_carries_comma_separated_prefixes() {
+        let value = search_exclude_tags(&[
+            "mx",
+            "memory",
+            "search",
+            "query",
+            "--exclude-tags",
+            "tier/,project/",
+        ]);
+        assert_eq!(value.as_deref(), Some("tier/,project/"));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -412,11 +412,11 @@ pub struct EntryFilter {
     #[arg(long, value_delimiter = ',')]
     pub tags: Option<Vec<String>>,
 
-    /// Exclude entries whose tags prefix-match any of these comma-separated values.
-    /// E.g. --exclude-tags 'tier/' drops every entry tagged tier/<anything>.
-    /// Deliberately mirrors wake-fetch's `--exclude-tags` (Option<String>, not
-    /// Vec<String> like the neighboring `tags` field) for exact parse parity —
-    /// both flow through the same `parse_exclude_prefixes` trim/empty-drop logic.
+    /// Exclude entries whose tags prefix-match any of these comma-separated values (e.g. 'tier/' drops every entry tagged tier/<anything>).
+    // Option<String>, not Vec<String> like the neighboring `tags` field: this
+    // deliberately mirrors wake-fetch's `--exclude-tags` for exact parse
+    // parity, since both flow through the same `parse_exclude_prefixes`
+    // trim/empty-drop logic.
     #[arg(long, value_name = "PREFIXES")]
     pub exclude_tags: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -347,7 +347,7 @@ pub enum SyncCommands {
 }
 
 /// Shared filter flags for search/list commands (extracted from duplicated definitions)
-#[derive(Debug, Clone, clap::Args)]
+#[derive(Debug, Clone, Default, clap::Args)]
 pub struct EntryFilter {
     /// Filter by category (comma-separated, see 'mx memory categories list' for valid names)
     #[arg(short, long, value_delimiter = ',')]
@@ -411,6 +411,14 @@ pub struct EntryFilter {
     /// Filter by tags (can specify multiple: focus,rust) (matches any)
     #[arg(long, value_delimiter = ',')]
     pub tags: Option<Vec<String>>,
+
+    /// Exclude entries whose tags prefix-match any of these comma-separated values.
+    /// E.g. --exclude-tags 'tier/' drops every entry tagged tier/<anything>.
+    /// Deliberately mirrors wake-fetch's `--exclude-tags` (Option<String>, not
+    /// Vec<String> like the neighboring `tags` field) for exact parse parity —
+    /// both flow through the same `parse_exclude_prefixes` trim/empty-drop logic.
+    #[arg(long, value_name = "PREFIXES")]
+    pub exclude_tags: Option<String>,
 }
 
 /// Sort order for `memory recent` results.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -412,7 +412,7 @@ pub struct EntryFilter {
     #[arg(long, value_delimiter = ',')]
     pub tags: Option<Vec<String>>,
 
-    /// Exclude entries whose tags prefix-match any of these comma-separated values (e.g. 'tier/' drops every entry tagged tier/<anything>).
+    /// Exclude entries whose tags prefix-match any of these comma-separated values (e.g. 'tier/' drops every entry tagged tier/<anything>). Specify once; comma-separate multiple prefixes -- repeating the flag is a parse error.
     // Option<String>, not Vec<String> like the neighboring `tags` field: this
     // deliberately mirrors wake-fetch's `--exclude-tags` for exact parse
     // parity, since both flow through the same `parse_exclude_prefixes`
@@ -1238,7 +1238,8 @@ pub enum MemoryCommands {
 
         /// Exclude entries whose tags prefix-match any of these comma-separated values.
         /// E.g. --exclude-tags 'project/' drops every entry tagged project/<anything>.
-        /// Multiple prefixes: --exclude-tags 'project/,foo/'
+        /// Specify once; comma-separate multiple prefixes: --exclude-tags 'project/,foo/'.
+        /// Repeating the flag is a parse error.
         #[arg(long, value_name = "PREFIXES")]
         exclude_tags: Option<String>,
     },

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -274,35 +274,6 @@ fn handle_trigger_check(
     Ok(())
 }
 
-/// Parse a `--exclude-tags` CSV value into a list of prefix strings.
-///
-/// Segments are trimmed; empty segments (from trailing commas, repeated commas,
-/// or whitespace-only input) are dropped. A `None` input yields an empty list.
-fn parse_exclude_prefixes(exclude_tags: Option<&str>) -> Vec<String> {
-    exclude_tags
-        .unwrap_or("")
-        .split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(String::from)
-        .collect()
-}
-
-/// Whether a wake-fetch entry should be KEPT given the active exclude prefixes.
-///
-/// Returns `false` (exclude) when ANY of the entry's tags prefix-matches ANY of
-/// the requested exclude prefixes. An empty prefix list keeps every entry.
-fn keep_after_exclude(tags: &[String], exclude_prefixes: &[String]) -> bool {
-    if exclude_prefixes.is_empty() {
-        return true;
-    }
-    !tags.iter().any(|tag| {
-        exclude_prefixes
-            .iter()
-            .any(|prefix| tag.starts_with(prefix.as_str()))
-    })
-}
-
 /// Resolve the display `fact_type` label for a wake-fetch entry.
 ///
 /// Older entries carry `fact_type` inside their `summary` JSON; newer entries
@@ -520,11 +491,20 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Note: Search doesn't activate facts by default - discovery != engagement
             // Use --activate to explicitly mark results as intentionally consumed.
-            // Build filter for database query (resonance and category)
+            // Build filter for database query (resonance, category, and exclusion).
+            let exclude_prefixes = parse_exclude_prefixes(filter.exclude_tags.as_deref());
             let db_filter = store::KnowledgeFilter {
                 min_resonance: filter.min_resonance,
                 max_resonance: filter.max_resonance,
                 categories: filter.category.clone(),
+                // Panel Fix #1: pushed into the semantic candidate-set WHERE
+                // clause (src/surreal_db/knowledge.rs) rather than relied on
+                // via the over-fetch guard below, so tier/archived (a default
+                // exclusion designed to GROW) never silently thins results
+                // below the requested limit. The keyword path (`db.search`)
+                // ignores this field — it has no DB-level LIMIT, so the
+                // post-filter in `apply_entry_filters` is already exact.
+                exclude_tag_prefixes: exclude_prefixes,
             };
 
             // Get results from database with resonance filtering
@@ -540,6 +520,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 // Tradeoff: 5x multiplier works well at typical limits (10-50) but does
                 // not scale for very large limits. The cap (limit + 200) prevents runaway
                 // fetches when the caller requests hundreds of entries.
+                //
+                // NOTE: --exclude-tags deliberately does NOT extend this trigger.
+                // Unlike --tags (an inclusion filter still applied in Rust via
+                // apply_entry_filters), exclusion is filtered at the SQL
+                // candidate-set level BEFORE the DB applies its own LIMIT
+                // (Panel Fix #1), so it never thins an already-limited result
+                // set and needs no over-fetch multiplier of its own.
                 let requested_limit = filter.limit.unwrap_or(20);
                 let db_limit = if filter.tags.is_some() {
                     (requested_limit * 5).min(requested_limit + 200)
@@ -602,11 +589,15 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
             }
 
-            // Build filter for database query (resonance only - category handled below)
+            // Build filter for database query (resonance only - category handled below).
+            // Exclusion is applied Rust-side in apply_entry_filters (list_by_category
+            // issues no DB-level LIMIT, so post-filter is already exact) — no
+            // exclude_tag_prefixes needed here.
             let db_filter = store::KnowledgeFilter {
                 min_resonance: filter.min_resonance,
                 max_resonance: filter.max_resonance,
                 categories: None,
+                exclude_tag_prefixes: Vec::new(),
             };
 
             // Get results from database with resonance filtering
@@ -3686,69 +3677,11 @@ mod show_divert_tests {
 mod wake_fetch_filter_tests {
     use super::*;
 
-    // ---- parse_exclude_prefixes / keep_after_exclude (pure) ----
-
-    fn prefixes(raw: &str) -> Vec<String> {
-        parse_exclude_prefixes(Some(raw))
-    }
-
-    fn tags(t: &[&str]) -> Vec<String> {
-        t.iter().map(|s| s.to_string()).collect()
-    }
-
-    #[test]
-    fn single_prefix_drops_matching_tag_keeps_others() {
-        let ex = prefixes("project/");
-        // An entry tagged project/x is excluded.
-        assert!(!keep_after_exclude(&tags(&["project/x"]), &ex));
-        // An untagged entry survives.
-        assert!(keep_after_exclude(&[], &ex));
-        // An entry whose tags don't match the prefix survives.
-        assert!(keep_after_exclude(&tags(&["scratch/y", "notes"]), &ex));
-        // Mixed: one matching tag is enough to exclude the whole entry.
-        assert!(!keep_after_exclude(&tags(&["notes", "project/deep"]), &ex));
-    }
-
-    #[test]
-    fn multiple_prefixes_exclude_any_match() {
-        let ex = prefixes("project/,scratch/");
-        assert!(!keep_after_exclude(&tags(&["project/a"]), &ex));
-        assert!(!keep_after_exclude(&tags(&["scratch/b"]), &ex));
-        assert!(keep_after_exclude(&tags(&["docs/c"]), &ex));
-    }
-
-    #[test]
-    fn empty_whitespace_and_trailing_comma_input_yields_no_prefixes() {
-        // Each of these parses to an empty prefix list -> nothing is excluded.
-        for raw in ["", "   ", ",", ",,", "project/,", " , project/ "] {
-            let ex = parse_exclude_prefixes(Some(raw));
-            // Trailing/empty segments are dropped; only real prefixes remain.
-            let expected_excludes = raw.contains("project/");
-            // A project/ tag is excluded only when a real prefix survived parsing.
-            assert_eq!(
-                !keep_after_exclude(&tags(&["project/x"]), &ex),
-                expected_excludes,
-                "raw input {raw:?} produced prefixes {ex:?}"
-            );
-        }
-        // Pure empty/whitespace cases produce zero prefixes.
-        assert!(parse_exclude_prefixes(Some("")).is_empty());
-        assert!(parse_exclude_prefixes(Some("   ")).is_empty());
-        assert!(parse_exclude_prefixes(Some(",,")).is_empty());
-        // Trailing comma drops the empty segment but keeps the real one.
-        assert_eq!(parse_exclude_prefixes(Some("project/,")), vec!["project/"]);
-    }
-
-    #[test]
-    fn none_input_is_empty_prefix_list_and_keeps_everything() {
-        let ex = parse_exclude_prefixes(None);
-        assert!(ex.is_empty());
-        // Empty prefix list keeps every entry, even ones with tags.
-        assert!(keep_after_exclude(&tags(&["project/x", "anything"]), &ex));
-        assert!(keep_after_exclude(&[], &ex));
-    }
-
     // ---- resolve_fact_type fallback (pure) ----
+    //
+    // parse_exclude_prefixes/keep_after_exclude tests moved to
+    // src/helpers.rs (entry_exclude_tests) alongside their relocated
+    // definitions — single definition, tests live with it.
 
     #[test]
     fn fact_type_falls_back_to_category_when_summary_is_none() {

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -497,7 +497,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 min_resonance: filter.min_resonance,
                 max_resonance: filter.max_resonance,
                 categories: filter.category.clone(),
-                // Panel Fix #1: pushed into the semantic candidate-set WHERE
+                // Review fix: pushed into the semantic candidate-set WHERE
                 // clause (src/surreal_db/knowledge.rs) rather than relied on
                 // via the over-fetch guard below, so tier/archived (a default
                 // exclusion designed to GROW) never silently thins results
@@ -531,7 +531,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 // Unlike --tags (an inclusion filter still applied in Rust via
                 // apply_entry_filters), exclusion is filtered at the SQL
                 // candidate-set level BEFORE the DB applies its own LIMIT
-                // (Panel Fix #1), so it never thins an already-limited result
+                // (review fix), so it never thins an already-limited result
                 // set and needs no over-fetch multiplier of its own.
                 let requested_limit = filter.limit.unwrap_or(20);
                 let db_limit = if filter.tags.is_some() {

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -501,9 +501,15 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 // clause (src/surreal_db/knowledge.rs) rather than relied on
                 // via the over-fetch guard below, so tier/archived (a default
                 // exclusion designed to GROW) never silently thins results
-                // below the requested limit. The keyword path (`db.search`)
-                // ignores this field — it has no DB-level LIMIT, so the
-                // post-filter in `apply_entry_filters` is already exact.
+                // below the requested limit. The keyword path (`db.search` ->
+                // `search_knowledge_async`) deliberately leaves this field
+                // unread — exclusion there runs only in `apply_entry_filters`,
+                // which is exact *because* `search_knowledge_async` issues no
+                // DB-level LIMIT (see landmine test:
+                // `keyword_search_exclude_survives_past_hypothetical_limit`).
+                // If a LIMIT is ever added to that query for a growing store,
+                // this field must be wired into its WHERE clause too, or
+                // exclusion silently thins results below the requested count.
                 exclude_tag_prefixes: exclude_prefixes,
             };
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,11 +6,47 @@ use crate::knowledge;
 use crate::store;
 use crate::surreal_db::SurrealDatabase;
 
+/// Parse a `--exclude-tags` CSV value into a list of prefix strings.
+///
+/// Segments are trimmed; empty segments (from trailing commas, repeated commas,
+/// or whitespace-only input) are dropped. A `None` input yields an empty list.
+///
+/// Single definition shared by wake-fetch, `memory search`, and `memory list` —
+/// do not duplicate this in a handler.
+pub(crate) fn parse_exclude_prefixes(exclude_tags: Option<&str>) -> Vec<String> {
+    exclude_tags
+        .unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Whether an entry should be KEPT given the active exclude prefixes.
+///
+/// Returns `false` (exclude) when ANY of the entry's tags prefix-matches ANY of
+/// the requested exclude prefixes. An empty prefix list keeps every entry.
+///
+/// Single definition shared by wake-fetch, `memory search`, and `memory list`.
+pub(crate) fn keep_after_exclude(tags: &[String], exclude_prefixes: &[String]) -> bool {
+    if exclude_prefixes.is_empty() {
+        return true;
+    }
+    !tags.iter().any(|tag| {
+        exclude_prefixes
+            .iter()
+            .any(|prefix| tag.starts_with(prefix.as_str()))
+    })
+}
+
 /// Apply in-memory field presence filters to a list of entries
 pub(crate) fn apply_entry_filters(
     entries: Vec<knowledge::KnowledgeEntry>,
     filter: &EntryFilter,
 ) -> Vec<knowledge::KnowledgeEntry> {
+    let exclude_prefixes = parse_exclude_prefixes(filter.exclude_tags.as_deref());
+
     let mut entries: Vec<_> = entries
         .into_iter()
         .filter(|e| !filter.has_wake_phrase || e.has_any_wake_phrase())
@@ -29,6 +65,10 @@ pub(crate) fn apply_entry_filters(
                 .as_ref()
                 .is_none_or(|filter_tags| filter_tags.iter().any(|t| e.tags.contains(t)))
         })
+        // Exclusion runs before the limit truncate so a caller always gets up to
+        // `limit` non-excluded entries on the keyword/list paths (neither issues a
+        // DB-level LIMIT, so filter-then-truncate here is exact, not a heuristic).
+        .filter(|e| keep_after_exclude(&e.tags, &exclude_prefixes))
         .collect();
 
     // Apply limit if specified
@@ -1948,5 +1988,196 @@ mod hidden_private_hint_tests {
                 "no MX_CURRENT_AGENT -> agent_id None -> hint suppressed"
             );
         });
+    }
+}
+
+#[cfg(test)]
+mod entry_exclude_tests {
+    //! Tests for `parse_exclude_prefixes` / `keep_after_exclude` (relocated from
+    //! `src/handlers/memory.rs`'s wake-fetch tests — this is the single shared
+    //! definition consumed by wake-fetch, `memory search`, and `memory list`)
+    //! and for their wiring into `apply_entry_filters`.
+
+    use super::*;
+    use crate::knowledge::KnowledgeEntry;
+
+    fn prefixes(raw: &str) -> Vec<String> {
+        parse_exclude_prefixes(Some(raw))
+    }
+
+    fn tags(t: &[&str]) -> Vec<String> {
+        t.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ---- parse_exclude_prefixes / keep_after_exclude (pure) ----
+
+    #[test]
+    fn single_prefix_drops_matching_tag_keeps_others() {
+        let ex = prefixes("project/");
+        // An entry tagged project/x is excluded.
+        assert!(!keep_after_exclude(&tags(&["project/x"]), &ex));
+        // An untagged entry survives.
+        assert!(keep_after_exclude(&[], &ex));
+        // An entry whose tags don't match the prefix survives.
+        assert!(keep_after_exclude(&tags(&["scratch/y", "notes"]), &ex));
+        // Mixed: one matching tag is enough to exclude the whole entry.
+        assert!(!keep_after_exclude(&tags(&["notes", "project/deep"]), &ex));
+    }
+
+    #[test]
+    fn multiple_prefixes_exclude_any_match() {
+        let ex = prefixes("project/,scratch/");
+        assert!(!keep_after_exclude(&tags(&["project/a"]), &ex));
+        assert!(!keep_after_exclude(&tags(&["scratch/b"]), &ex));
+        assert!(keep_after_exclude(&tags(&["docs/c"]), &ex));
+    }
+
+    #[test]
+    fn empty_whitespace_and_trailing_comma_input_yields_no_prefixes() {
+        // Each of these parses to an empty prefix list -> nothing is excluded.
+        for raw in ["", "   ", ",", ",,", "project/,", " , project/ "] {
+            let ex = parse_exclude_prefixes(Some(raw));
+            // Trailing/empty segments are dropped; only real prefixes remain.
+            let expected_excludes = raw.contains("project/");
+            // A project/ tag is excluded only when a real prefix survived parsing.
+            assert_eq!(
+                !keep_after_exclude(&tags(&["project/x"]), &ex),
+                expected_excludes,
+                "raw input {raw:?} produced prefixes {ex:?}"
+            );
+        }
+        // Pure empty/whitespace cases produce zero prefixes.
+        assert!(parse_exclude_prefixes(Some("")).is_empty());
+        assert!(parse_exclude_prefixes(Some("   ")).is_empty());
+        assert!(parse_exclude_prefixes(Some(",,")).is_empty());
+        // Trailing comma drops the empty segment but keeps the real one.
+        assert_eq!(parse_exclude_prefixes(Some("project/,")), vec!["project/"]);
+    }
+
+    #[test]
+    fn none_input_is_empty_prefix_list_and_keeps_everything() {
+        let ex = parse_exclude_prefixes(None);
+        assert!(ex.is_empty());
+        // Empty prefix list keeps every entry, even ones with tags.
+        assert!(keep_after_exclude(&tags(&["project/x", "anything"]), &ex));
+        assert!(keep_after_exclude(&[], &ex));
+    }
+
+    // ---- apply_entry_filters wiring (list + keyword-search merge point) ----
+
+    /// Minimal fixture entry carrying only an id and tags — every other field
+    /// takes an inert default, since apply_entry_filters's exclusion step reads
+    /// only `tags`.
+    fn entry(id: &str, tags: &[&str]) -> KnowledgeEntry {
+        let now = chrono::Utc::now().to_rfc3339();
+        KnowledgeEntry {
+            id: id.to_string(),
+            category_id: "test".to_string(),
+            title: format!("Entry {id}"),
+            body: Some("body".to_string()),
+            summary: None,
+            applicability: vec![],
+            source_project_id: None,
+            source_agent_id: None,
+            file_path: None,
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            created_at: Some(now.clone()),
+            updated_at: Some(now.clone()),
+            content_hash: Some(format!("hash-{id}")),
+            source_type_id: Some("manual".to_string()),
+            entry_type_id: Some("primary".to_string()),
+            session_id: None,
+            ephemeral: false,
+            content_type_id: Some("text".to_string()),
+            owner: None,
+            visibility: "public".to_string(),
+            resonance: 5,
+            resonance_type: None,
+            last_activated: Some(now),
+            activation_count: 0,
+            decay_rate: 0.0,
+            anchors: vec![],
+            wake_phrases: vec![],
+            triggers: vec![],
+            wake_order: None,
+            wake_phrase: None,
+            embedding: None,
+            embedding_model: None,
+            embedded_at: None,
+            chunk_count: 0,
+            format: "markdown".to_string(),
+            effective_resonance: None,
+        }
+    }
+
+    #[test]
+    fn list_path_excludes_prefix_tagged_entries_keeps_untagged() {
+        // Criterion: `mx memory list --exclude-tags 'tier/'` omits every entry
+        // tagged tier/archived and includes an untagged entry.
+        let entries = vec![
+            entry("kn-1", &["tier/archived"]),
+            entry("kn-2", &[]),
+            entry("kn-3", &["project/x"]),
+        ];
+        let filter = EntryFilter {
+            exclude_tags: Some("tier/".to_string()),
+            ..Default::default()
+        };
+        let kept = apply_entry_filters(entries, &filter);
+        let ids: Vec<_> = kept.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, vec!["kn-2", "kn-3"]);
+    }
+
+    #[test]
+    fn no_flag_behavior_is_unchanged() {
+        // A None exclude_tags (the pre-existing default) must not drop anything
+        // that the prior filter set wouldn't already have dropped.
+        let entries = vec![entry("kn-1", &["tier/archived"]), entry("kn-2", &[])];
+        let filter = EntryFilter::default();
+        let kept = apply_entry_filters(entries, &filter);
+        assert_eq!(kept.len(), 2, "no --exclude-tags means nothing is excluded");
+    }
+
+    #[test]
+    fn exclusion_wins_over_overlapping_include_tag() {
+        // An entry tagged both project/x (matches --tags) AND tier/archived
+        // (matches --exclude-tags) must be excluded: exclusion wins over
+        // inclusion when both filters are active.
+        let entries = vec![
+            entry("kn-1", &["project/x", "tier/archived"]),
+            entry("kn-2", &["project/x"]),
+        ];
+        let filter = EntryFilter {
+            tags: Some(vec!["project/x".to_string()]),
+            exclude_tags: Some("tier/".to_string()),
+            ..Default::default()
+        };
+        let kept = apply_entry_filters(entries, &filter);
+        let ids: Vec<_> = kept.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["kn-2"],
+            "an entry matching both --tags and --exclude-tags must be excluded"
+        );
+    }
+
+    #[test]
+    fn exclusion_runs_before_limit_truncate() {
+        // If exclusion ran AFTER the limit truncate instead of before, a
+        // --limit 1 request whose first candidate is excluded would return
+        // zero results instead of the next non-excluded entry.
+        let entries = vec![
+            entry("kn-1", &["tier/archived"]),
+            entry("kn-2", &[]),
+            entry("kn-3", &[]),
+        ];
+        let filter = EntryFilter {
+            exclude_tags: Some("tier/".to_string()),
+            limit: Some(1),
+            ..Default::default()
+        };
+        let kept = apply_entry_filters(entries, &filter);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, "kn-2");
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -68,6 +68,10 @@ pub(crate) fn apply_entry_filters(
         // Exclusion runs before the limit truncate so a caller always gets up to
         // `limit` non-excluded entries on the keyword/list paths (neither issues a
         // DB-level LIMIT, so filter-then-truncate here is exact, not a heuristic).
+        // This is the sole enforcement point for keyword/list. The semantic
+        // search path already excludes at the DB/hydration layer, so running
+        // this filter again there is a harmless no-op safety net, not a
+        // second independent gate.
         .filter(|e| keep_after_exclude(&e.tags, &exclude_prefixes))
         .collect();
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -277,6 +277,11 @@ pub(crate) fn hidden_private_hint(
         min_resonance: filter.min_resonance,
         max_resonance: filter.max_resonance,
         categories: filter.category.clone(),
+        // Not pushed down here: this is the candidate-fetch query, and the
+        // in-memory `apply_entry_filters` call below (which DOES honor
+        // `exclude_tags`) runs over every candidate before the count is
+        // taken, so exclusion is still applied before the hint fires.
+        exclude_tag_prefixes: Vec::new(),
     };
 
     // Best-effort: on ANY error, stay silent. The hint must never turn a
@@ -1689,6 +1694,7 @@ mod hidden_private_hint_tests {
             missing_resonance_type: false,
             limit: None,
             tags: None,
+            exclude_tags: None,
         }
     }
 
@@ -1905,6 +1911,42 @@ mod hidden_private_hint_tests {
         assert!(
             hidden_private_hint(&db, &ctx, &f2, None, false).is_some(),
             "a matching tag filter must still surface the hidden owned-private entry"
+        );
+    }
+
+    #[test]
+    fn hint_respects_exclude_tags_filter() {
+        // The hint's count runs the SAME `apply_entry_filters` chokepoint the
+        // main query uses (see `filter_no_limit` above), so `--exclude-tags`
+        // must drop an owned-private candidate from the hint count exactly as
+        // it would from a visible (public) result set.
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry(
+            "kn-a",
+            "agent-a",
+            "note",
+            "b",
+            vec!["tier/archived".to_string()],
+        ))
+        .unwrap();
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+
+        // The only owned-private match carries an excluded prefix -> no hint,
+        // even though it would otherwise be hidden-and-countable.
+        let mut f = base_filter();
+        f.exclude_tags = Some("tier/".to_string());
+        assert!(
+            hidden_private_hint(&db, &ctx, &f, None, false).is_none(),
+            "an owned-private match excluded by --exclude-tags must not count toward the hint"
+        );
+
+        // A non-matching exclude prefix leaves the entry countable -> hint fires.
+        let mut f2 = base_filter();
+        f2.exclude_tags = Some("project/".to_string());
+        assert!(
+            hidden_private_hint(&db, &ctx, &f2, None, false).is_some(),
+            "--exclude-tags that doesn't match the entry's tags must not suppress the hint"
         );
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -49,6 +49,15 @@ pub struct KnowledgeFilter {
     pub min_resonance: Option<i32>,
     pub max_resonance: Option<i32>,
     pub categories: Option<Vec<String>>,
+    /// Pre-parsed `--exclude-tags` prefixes (see `parse_exclude_prefixes` in
+    /// `src/helpers.rs`). Unlike the CLI-facing `EntryFilter::exclude_tags`
+    /// (`Option<String>`, kept as a raw CSV string for exact wake-fetch parse
+    /// parity), this DB-layer filter takes the already-parsed prefix list
+    /// directly, since the SQL builder has no reason to re-parse it. Pushed
+    /// into the semantic search candidate-set WHERE clause (Panel Fix #1) so
+    /// exclusion happens BEFORE the DB-side `LIMIT`, instead of thinning an
+    /// already-limited result set after the fact. Empty = no exclusion.
+    pub exclude_tag_prefixes: Vec<String>,
 }
 
 /// Result of a wake-up cascade query

--- a/src/store.rs
+++ b/src/store.rs
@@ -54,7 +54,7 @@ pub struct KnowledgeFilter {
     /// (`Option<String>`, kept as a raw CSV string for exact wake-fetch parse
     /// parity), this DB-layer filter takes the already-parsed prefix list
     /// directly, since the SQL builder has no reason to re-parse it. Pushed
-    /// into the semantic search candidate-set WHERE clause (Panel Fix #1) so
+    /// into the semantic search candidate-set WHERE clause (review fix) so
     /// exclusion happens BEFORE the DB-side `LIMIT`, instead of thinning an
     /// already-limited result set after the fact. Empty = no exclusion.
     pub exclude_tag_prefixes: Vec<String>,

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -400,6 +400,44 @@ impl SurrealDatabase {
         }
     }
 
+    /// Build a WHERE-clause fragment (candidate-set level, applied BEFORE any
+    /// `LIMIT`) that excludes any `knowledge` row carrying a tag whose name
+    /// prefix-matches one of `exclude_prefixes`.
+    ///
+    /// Returns `("", vec![])` (no exclusion) when `exclude_prefixes` is empty.
+    /// Otherwise returns the SQL fragment plus the `(param_name, value)` pairs
+    /// the caller MUST bind — one bound parameter per prefix (`exclude_prefix_0`,
+    /// `exclude_prefix_1`, ...). Only parameter NAMES are interpolated into the
+    /// SQL text; prefix VALUES are always bound, never string-interpolated
+    /// (Panel Fix #1 — this is the archive-tier exclusion filter and prefixes
+    /// are caller-controlled input).
+    ///
+    /// Traverses the same `->tagged_with->tag` graph edge already used to
+    /// project the `tags` field (see `knowledge_select_fields` callers), so
+    /// this reuses a verified traversal direction rather than inventing a new
+    /// one.
+    pub(super) fn build_exclude_tags_filter(
+        exclude_prefixes: &[String],
+    ) -> (String, Vec<(String, String)>) {
+        if exclude_prefixes.is_empty() {
+            return (String::new(), Vec::new());
+        }
+
+        let mut bindings = Vec::with_capacity(exclude_prefixes.len());
+        let mut conditions = Vec::with_capacity(exclude_prefixes.len());
+        for (i, prefix) in exclude_prefixes.iter().enumerate() {
+            let param = format!("exclude_prefix_{i}");
+            conditions.push(format!("string::starts_with(name, ${param})"));
+            bindings.push((param, prefix.clone()));
+        }
+
+        let clause = format!(
+            "AND array::len(->tagged_with->tag[WHERE {}]) = 0",
+            conditions.join(" OR ")
+        );
+        (clause, bindings)
+    }
+
     // =========================================================================
     // KNOWLEDGE CRUD OPERATIONS
     // =========================================================================
@@ -902,6 +940,12 @@ impl SurrealDatabase {
         let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
         let resonance_clause = Self::build_resonance_filter(filter);
         let category_clause = Self::build_category_filter(filter);
+        // Panel Fix #1: exclude archived (or any prefix-matched) tags at the
+        // candidate-set level, BEFORE the unchunked query's own `LIMIT`, so a
+        // ranked-but-excluded neighbor never displaces a non-excluded one out
+        // of the top `limit` rows the DB returns.
+        let (exclude_clause, exclude_bindings) =
+            Self::build_exclude_tags_filter(&filter.exclude_tag_prefixes);
 
         // Dimension guard ($dim, bound below): SurrealDB's
         // vector::similarity::cosine ABORTS THE ENTIRE SCAN when it hits any
@@ -913,115 +957,195 @@ impl SurrealDatabase {
         // only mismatched rows are filtered out instead of aborting the scan.
         let query_dim = query_embedding.len();
 
-        // Phase 1a: Search unchunked entries (chunk_count <= 0 or absent)
+        // Phase 1a: Search unchunked entries (chunk_count <= 0 or absent).
+        // Exclusion is pushed into this query's own WHERE (bound params, see
+        // build_exclude_tags_filter), so an excluded row never occupies a
+        // slot in the DB's own LIMIT.
         let unchunked_sql = format!(
             "SELECT {}, vector::similarity::cosine(embedding, $query_vec) AS score
             FROM knowledge
-            WHERE embedding IS NOT NONE AND array::len(embedding) = $dim AND (chunk_count IS NONE OR chunk_count <= 0) {} {} {}
+            WHERE embedding IS NOT NONE AND array::len(embedding) = $dim AND (chunk_count IS NONE OR chunk_count <= 0) {} {} {} {}
             ORDER BY score DESC
             LIMIT $limit",
             Self::knowledge_select_fields(),
             visibility_clause,
             resonance_clause,
-            category_clause
+            category_clause,
+            exclude_clause
         );
 
-        // Phase 1b: Search chunks (no visibility filter — applied after dedup).
-        // Same dimension guard so an off-dim chunk embedding can't abort the scan.
-        let chunk_sql =
-            "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
-            FROM embedding_chunk
-            WHERE array::len(embedding) = $dim
-            ORDER BY score DESC
-            LIMIT $chunk_limit";
-
-        let chunk_limit = limit * 3; // over-fetch for dedup
-
-        let mut response = with_db!(self, db, {
+        let mut unchunked_response = with_db!(self, db, {
             let mut query_builder = db
                 .query(&unchunked_sql)
-                .query(chunk_sql)
                 .bind(("query_vec", query_embedding.to_vec()))
                 .bind(("dim", query_dim))
-                .bind(("limit", limit))
-                .bind(("chunk_limit", chunk_limit));
+                .bind(("limit", limit));
             if let Some(agent) = current_agent.clone() {
                 query_builder = query_builder.bind(("current_agent", agent));
+            }
+            for (param, value) in exclude_bindings.clone() {
+                query_builder = query_builder.bind((param, value));
             }
             query_builder
                 .await
                 .context("Failed to execute semantic search query")
         })?;
 
-        // Parse unchunked results (statement 0)
-        let unchunked_results: Vec<serde_json::Value> = response
+        let unchunked_results: Vec<serde_json::Value> = unchunked_response
             .take(0)
             .context("Failed to parse unchunked search results")?;
 
-        // Parse chunk results (statement 1)
-        let chunk_results: Vec<serde_json::Value> = response
-            .take(1)
-            .context("Failed to parse chunk search results")?;
-
-        // Phase 2: Merge results
-        // Collect unchunked entries with their scores
+        // Phase 2a: Collect unchunked entries with their scores.
         let mut scored_entries: std::collections::HashMap<String, (f32, Option<KnowledgeEntry>)> =
             std::collections::HashMap::new();
-
         for obj in unchunked_results {
             let entry = self.value_to_knowledge_entry(obj.clone()).await?;
             let score = obj["score"].as_f64().unwrap_or(0.0) as f32;
             scored_entries.insert(entry.id.clone(), (score, Some(entry)));
         }
 
-        // Deduplicate chunks: keep max score per entry_id
-        let mut chunk_scores: std::collections::HashMap<String, f32> =
-            std::collections::HashMap::new();
-        for obj in &chunk_results {
-            let entry_id = obj["entry_id"].as_str().unwrap_or_default().to_string();
-            let score = obj["score"].as_f64().unwrap_or(0.0) as f32;
-            let current = chunk_scores.entry(entry_id).or_insert(0.0f32);
-            if score > *current {
-                *current = score;
-            }
-        }
+        // Phase 1b/2b: Search chunks (no visibility filter — applied after
+        // hydration below) and merge into `scored_entries`.
+        //
+        // `embedding_chunk` has no direct tag link (it's keyed on a plain
+        // `entry_id` string, not a graph edge to `knowledge`), so exclusion
+        // can't be pushed into this query's own WHERE the way it is for the
+        // unchunked phase above. A single fixed-size over-fetch (`limit * N`)
+        // is a fixed-ratio post-filter: it silently returns fewer than
+        // `limit` non-excluded results once the excluded (e.g. archived)
+        // share of chunk candidates exceeds that ratio — and the archive
+        // tier is a default exclusion designed to GROW without bound (per
+        // work order), so a static ratio isn't safe long-term.
+        //
+        // Instead, over-fetch iteratively: start at `limit * 3`, hydrate and
+        // filter each newly-seen candidate, and if the merged non-excluded
+        // count is still short of `limit` AND the table had more chunk rows
+        // to give (`returned_count == chunk_fetch`, i.e. we weren't already
+        // at the end of the table), double the fetch window and try again —
+        // up to a hard cap so a pathological query can't force an unbounded
+        // scan.
+        let mut chunk_fetch = limit.saturating_mul(3).max(1);
+        let max_chunk_fetch = limit.saturating_mul(50).max(1000);
+        // Cache of every embedding_chunk entry_id already resolved (kept,
+        // with its score, or dropped by a filter) so growing the over-fetch
+        // window never re-hydrates or re-filters the same entry twice.
+        let mut resolved_chunk_entries: std::collections::HashMap<
+            String,
+            Option<(f32, KnowledgeEntry)>,
+        > = std::collections::HashMap::new();
 
-        // For each unique chunk entry_id, fetch the full entry (with visibility/filter check)
-        for (entry_id, score) in &chunk_scores {
-            if scored_entries.contains_key(entry_id) {
-                // Entry already in results from unchunked path — take max score
-                if let Some((existing_score, _)) = scored_entries.get_mut(entry_id)
-                    && *score > *existing_score
-                {
-                    *existing_score = *score;
+        loop {
+            // Same dimension guard as the unchunked phase so an off-dim
+            // chunk embedding can't abort the scan.
+            let chunk_sql =
+                "SELECT entry_id, vector::similarity::cosine(embedding, $query_vec) AS score
+                FROM embedding_chunk
+                WHERE array::len(embedding) = $dim
+                ORDER BY score DESC
+                LIMIT $chunk_limit";
+
+            let mut chunk_response = with_db!(self, db, {
+                db.query(chunk_sql)
+                    .bind(("query_vec", query_embedding.to_vec()))
+                    .bind(("dim", query_dim))
+                    .bind(("chunk_limit", chunk_fetch))
+                    .await
+                    .context("Failed to execute chunk semantic search query")
+            })?;
+
+            let chunk_results: Vec<serde_json::Value> = chunk_response
+                .take(0)
+                .context("Failed to parse chunk search results")?;
+            let returned_count = chunk_results.len();
+
+            // Deduplicate chunks: keep max score per entry_id, over this
+            // fetch window.
+            let mut chunk_scores: std::collections::HashMap<String, f32> =
+                std::collections::HashMap::new();
+            for obj in &chunk_results {
+                let entry_id = obj["entry_id"].as_str().unwrap_or_default().to_string();
+                let score = obj["score"].as_f64().unwrap_or(0.0) as f32;
+                let current = chunk_scores.entry(entry_id).or_insert(0.0f32);
+                if score > *current {
+                    *current = score;
                 }
-                continue;
             }
 
-            // Fetch full entry with visibility/category/resonance filtering
-            if let Some(entry) = self.get_knowledge_async(entry_id, ctx).await? {
-                // Apply decay-adjusted resonance filter (matching the SQL in effective_resonance_expr)
-                let effective = Self::compute_effective_resonance(&entry);
-                if let Some(min) = filter.min_resonance
-                    && effective < min as f64
-                {
+            // For each unique chunk entry_id not yet accounted for, fetch
+            // the full entry (with visibility/category/resonance/exclude
+            // filtering), exactly once per entry_id across all iterations.
+            for (entry_id, score) in &chunk_scores {
+                if scored_entries.contains_key(entry_id) {
+                    // Entry already in results from unchunked path — take max score
+                    if let Some((existing_score, _)) = scored_entries.get_mut(entry_id)
+                        && *score > *existing_score
+                    {
+                        *existing_score = *score;
+                    }
                     continue;
                 }
-                if let Some(max) = filter.max_resonance
-                    && effective > max as f64
-                {
+                if resolved_chunk_entries.contains_key(entry_id) {
+                    // Already hydrated and filtered in a prior (smaller)
+                    // fetch window — the verdict doesn't change, skip.
                     continue;
                 }
-                // Apply category filter
-                if let Some(cats) = &filter.categories
-                    && !cats.is_empty()
-                    && !cats.contains(&entry.category_id)
-                {
-                    continue;
-                }
-                scored_entries.insert(entry_id.clone(), (*score, Some(entry)));
+
+                let resolved = if let Some(entry) = self.get_knowledge_async(entry_id, ctx).await? {
+                    // Apply decay-adjusted resonance filter (matching the SQL in effective_resonance_expr)
+                    let effective = Self::compute_effective_resonance(&entry);
+                    let passes_resonance = filter
+                        .min_resonance
+                        .is_none_or(|min| effective >= min as f64)
+                        && filter
+                            .max_resonance
+                            .is_none_or(|max| effective <= max as f64);
+                    // Apply category filter
+                    let passes_category = filter
+                        .categories
+                        .as_ref()
+                        .is_none_or(|cats| cats.is_empty() || cats.contains(&entry.category_id));
+                    // Panel Fix #1, embedding_chunk phase: filter here, before
+                    // this candidate enters `scored_entries`, using the
+                    // now-hydrated entry's tags. This keeps exclusion at
+                    // candidate-set-construction time, before the final
+                    // sort+truncate(limit) below, matching the
+                    // resonance/category filters above.
+                    let passes_exclude = crate::helpers::keep_after_exclude(
+                        &entry.tags,
+                        &filter.exclude_tag_prefixes,
+                    );
+                    if passes_resonance && passes_category && passes_exclude {
+                        Some((*score, entry))
+                    } else {
+                        None
+                    }
+                } else {
+                    // Entry not found or not visible.
+                    None
+                };
+                resolved_chunk_entries.insert(entry_id.clone(), resolved);
             }
-            // If entry not found or not visible, skip silently
+
+            // Merge every kept, resolved chunk entry into `scored_entries`.
+            for (entry_id, resolved) in &resolved_chunk_entries {
+                if let Some((score, entry)) = resolved {
+                    scored_entries
+                        .entry(entry_id.clone())
+                        .and_modify(|(existing_score, _)| {
+                            if *score > *existing_score {
+                                *existing_score = *score;
+                            }
+                        })
+                        .or_insert_with(|| (*score, Some(entry.clone())));
+                }
+            }
+
+            let have_enough = scored_entries.len() >= limit;
+            let exhausted = returned_count < chunk_fetch; // fewer rows than asked => table has no more
+            if have_enough || exhausted || chunk_fetch >= max_chunk_fetch {
+                break;
+            }
+            chunk_fetch = chunk_fetch.saturating_mul(2).min(max_chunk_fetch);
         }
 
         // Sort by score DESC and take limit

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -812,7 +812,9 @@ impl SurrealDatabase {
 
         let record_ids: Vec<String> = records.iter().map(|r| format!("kn-{}", r.id)).collect();
         let mut tags_by_id = self.get_tags_for_entries_async(&record_ids).await?;
-        let mut applicability_by_id = self.get_applicability_for_entries_async(&record_ids).await?;
+        let mut applicability_by_id = self
+            .get_applicability_for_entries_async(&record_ids)
+            .await?;
 
         for record in records {
             let full_id = format!("kn-{}", record.id);

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -756,6 +756,77 @@ impl SurrealDatabase {
         Ok(Some(record.into_knowledge_entry(tags, applicability)))
     }
 
+    /// Batch-fetch knowledge entries by ID in a single round trip (plus one
+    /// batched round trip each for tags and applicability), keyed by full
+    /// `kn-` id.
+    ///
+    /// Review fix: the embedding_chunk semantic-search fill loop was calling
+    /// `get_knowledge_async` once per unique chunk entry_id to decide
+    /// keep/drop, which is a sequential single-row round trip per candidate
+    /// (up to `limit * 50` of them in the excluded-tag-dominance case). This
+    /// hydrates a whole window of candidates with one query instead.
+    /// Entries that don't exist, or aren't visible under `ctx`, are simply
+    /// absent from the returned map.
+    pub(super) async fn get_knowledge_batch_async(
+        &self,
+        ids: &[String],
+        ctx: &crate::store::AgentContext,
+    ) -> Result<std::collections::HashMap<String, KnowledgeEntry>> {
+        let mut out = std::collections::HashMap::new();
+        if ids.is_empty() {
+            return Ok(out);
+        }
+
+        let things: Vec<Thing> = ids
+            .iter()
+            .map(|id| {
+                let id_part = id.strip_prefix("kn-").unwrap_or(id);
+                Thing::from(("knowledge", id_part))
+            })
+            .collect();
+
+        let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
+
+        let sql = format!(
+            "SELECT {}
+            FROM knowledge
+            WHERE id IN $ids {}",
+            Self::knowledge_select_fields(),
+            visibility_clause
+        );
+
+        let mut response = with_db!(self, db, {
+            let mut query = db.query(&sql).bind(("ids", things));
+            if let Some(agent) = current_agent {
+                query = query.bind(("current_agent", agent));
+            }
+            query
+                .await
+                .context("Failed to batch-query knowledge records")
+        })?;
+
+        let records: Vec<SurrealKnowledgeRecord> = response.take(0)?;
+        if records.is_empty() {
+            return Ok(out);
+        }
+
+        let record_ids: Vec<String> = records.iter().map(|r| format!("kn-{}", r.id)).collect();
+        let mut tags_by_id = self.get_tags_for_entries_async(&record_ids).await?;
+        let mut applicability_by_id = self.get_applicability_for_entries_async(&record_ids).await?;
+
+        for record in records {
+            let full_id = format!("kn-{}", record.id);
+            let tags = tags_by_id.remove(&full_id).unwrap_or_default();
+            let applicability = applicability_by_id.remove(&full_id).unwrap_or_default();
+            out.insert(
+                full_id.clone(),
+                record.into_knowledge_entry(tags, applicability),
+            );
+        }
+
+        Ok(out)
+    }
+
     /// Delete a knowledge entry (edges cascade automatically).
     /// Respects visibility: agents can only delete entries they can see.
     /// Returns Ok(false) for entries that don't exist OR that the agent can't see
@@ -1071,9 +1142,10 @@ impl SurrealDatabase {
                 }
             }
 
-            // For each unique chunk entry_id not yet accounted for, fetch
-            // the full entry (with visibility/category/resonance/exclude
-            // filtering), exactly once per entry_id across all iterations.
+            // Split this window's unique chunk entry_ids into "already
+            // accounted for" (just needs a max-score bump, no DB work) and
+            // "needs hydration" (unseen so far).
+            let mut ids_to_hydrate: Vec<String> = Vec::new();
             for (entry_id, score) in &chunk_scores {
                 if scored_entries.contains_key(entry_id) {
                     // Entry already in results from unchunked path — take max score
@@ -1089,41 +1161,53 @@ impl SurrealDatabase {
                     // fetch window — the verdict doesn't change, skip.
                     continue;
                 }
+                ids_to_hydrate.push(entry_id.clone());
+            }
 
-                let resolved = if let Some(entry) = self.get_knowledge_async(entry_id, ctx).await? {
-                    // Apply decay-adjusted resonance filter (matching the SQL in effective_resonance_expr)
-                    let effective = Self::compute_effective_resonance(&entry);
-                    let passes_resonance = filter
-                        .min_resonance
-                        .is_none_or(|min| effective >= min as f64)
-                        && filter
-                            .max_resonance
-                            .is_none_or(|max| effective <= max as f64);
-                    // Apply category filter
-                    let passes_category = filter
-                        .categories
-                        .as_ref()
-                        .is_none_or(|cats| cats.is_empty() || cats.contains(&entry.category_id));
-                    // Review fix, embedding_chunk phase: filter here, before
-                    // this candidate enters `scored_entries`, using the
-                    // now-hydrated entry's tags. This keeps exclusion at
-                    // candidate-set-construction time, before the final
-                    // sort+truncate(limit) below, matching the
-                    // resonance/category filters above.
-                    let passes_exclude = crate::helpers::keep_after_exclude(
-                        &entry.tags,
-                        &filter.exclude_tag_prefixes,
-                    );
-                    if passes_resonance && passes_category && passes_exclude {
-                        Some((*score, entry))
+            // Review fix: batch-hydrate the whole window in one query
+            // instead of one `get_knowledge_async` round trip per entry_id.
+            // The excluded-tag-dominance case can push `ids_to_hydrate` into
+            // the hundreds or thousands per fill, and most of those get
+            // discarded by `keep_after_exclude` below — no reason to pay a
+            // sequential round trip for each one just to read its tags.
+            if !ids_to_hydrate.is_empty() {
+                let hydrated = self.get_knowledge_batch_async(&ids_to_hydrate, ctx).await?;
+                for entry_id in &ids_to_hydrate {
+                    let score = chunk_scores[entry_id];
+                    let resolved = if let Some(entry) = hydrated.get(entry_id) {
+                        // Apply decay-adjusted resonance filter (matching the SQL in effective_resonance_expr)
+                        let effective = Self::compute_effective_resonance(entry);
+                        let passes_resonance = filter
+                            .min_resonance
+                            .is_none_or(|min| effective >= min as f64)
+                            && filter
+                                .max_resonance
+                                .is_none_or(|max| effective <= max as f64);
+                        // Apply category filter
+                        let passes_category = filter.categories.as_ref().is_none_or(|cats| {
+                            cats.is_empty() || cats.contains(&entry.category_id)
+                        });
+                        // Review fix, embedding_chunk phase: filter here, before
+                        // this candidate enters `scored_entries`, using the
+                        // now-hydrated entry's tags. This keeps exclusion at
+                        // candidate-set-construction time, before the final
+                        // sort+truncate(limit) below, matching the
+                        // resonance/category filters above.
+                        let passes_exclude = crate::helpers::keep_after_exclude(
+                            &entry.tags,
+                            &filter.exclude_tag_prefixes,
+                        );
+                        if passes_resonance && passes_category && passes_exclude {
+                            Some((score, entry.clone()))
+                        } else {
+                            None
+                        }
                     } else {
+                        // Entry not found or not visible.
                         None
-                    }
-                } else {
-                    // Entry not found or not visible.
-                    None
-                };
-                resolved_chunk_entries.insert(entry_id.clone(), resolved);
+                    };
+                    resolved_chunk_entries.insert(entry_id.clone(), resolved);
+                }
             }
 
             // Merge every kept, resolved chunk entry into `scored_entries`.

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -409,7 +409,7 @@ impl SurrealDatabase {
     /// the caller MUST bind — one bound parameter per prefix (`exclude_prefix_0`,
     /// `exclude_prefix_1`, ...). Only parameter NAMES are interpolated into the
     /// SQL text; prefix VALUES are always bound, never string-interpolated
-    /// (Panel Fix #1 — this is the archive-tier exclusion filter and prefixes
+    /// (review fix — this is the archive-tier exclusion filter and prefixes
     /// are caller-controlled input).
     ///
     /// Traverses the same `->tagged_with->tag` graph edge already used to
@@ -940,7 +940,7 @@ impl SurrealDatabase {
         let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
         let resonance_clause = Self::build_resonance_filter(filter);
         let category_clause = Self::build_category_filter(filter);
-        // Panel Fix #1: exclude archived (or any prefix-matched) tags at the
+        // Review fix: exclude archived (or any prefix-matched) tags at the
         // candidate-set level, BEFORE the unchunked query's own `LIMIT`, so a
         // ranked-but-excluded neighbor never displaces a non-excluded one out
         // of the top `limit` rows the DB returns.
@@ -1104,7 +1104,7 @@ impl SurrealDatabase {
                         .categories
                         .as_ref()
                         .is_none_or(|cats| cats.is_empty() || cats.contains(&entry.category_id));
-                    // Panel Fix #1, embedding_chunk phase: filter here, before
+                    // Review fix, embedding_chunk phase: filter here, before
                     // this candidate enters `scored_entries`, using the
                     // now-hydrated entry's tags. This keeps exclusion at
                     // candidate-set-construction time, before the final

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -413,9 +413,9 @@ impl SurrealDatabase {
     /// are caller-controlled input).
     ///
     /// Traverses the same `->tagged_with->tag` graph edge already used to
-    /// project the `tags` field (see `knowledge_select_fields` callers), so
-    /// this reuses a verified traversal direction rather than inventing a new
-    /// one.
+    /// project the `tags` field (see the `SELECT VALUE out.name FROM
+    /// tagged_with` subquery at :1317), so this reuses a verified traversal
+    /// direction rather than inventing a new one.
     pub(super) fn build_exclude_tags_filter(
         exclude_prefixes: &[String],
     ) -> (String, Vec<(String, String)>) {
@@ -1142,7 +1142,23 @@ impl SurrealDatabase {
 
             let have_enough = scored_entries.len() >= limit;
             let exhausted = returned_count < chunk_fetch; // fewer rows than asked => table has no more
-            if have_enough || exhausted || chunk_fetch >= max_chunk_fetch {
+            let capped = chunk_fetch >= max_chunk_fetch;
+            if capped && !have_enough && !exhausted {
+                // The scan budget ran out before the candidate set filled to
+                // `limit` — distinct from `exhausted` (table genuinely has no
+                // more rows). This is the excluded-tag-dominance case: enough
+                // chunk candidates outrank the eligible ones that `limit*50`
+                // over-fetch iterations never surface `limit` non-excluded
+                // entries. Callers relying on a full page need to know the
+                // result is short.
+                eprintln!(
+                    "Warning: semantic search hit chunk scan cap ({max_chunk_fetch} candidates) \
+                     with only {} of {limit} requested results — likely excluded-tag dominance \
+                     in the candidate set",
+                    scored_entries.len()
+                );
+            }
+            if have_enough || exhausted || capped {
                 break;
             }
             chunk_fetch = chunk_fetch.saturating_mul(2).min(max_chunk_fetch);

--- a/src/surreal_db/relationships.rs
+++ b/src/surreal_db/relationships.rs
@@ -261,6 +261,58 @@ impl SurrealDatabase {
         Ok(())
     }
 
+    /// Batch-fetch tags for many entries in a single round trip.
+    ///
+    /// Review fix (N+1 hydration in embedding_chunk search, see knowledge.rs
+    /// semantic_search): hydrating chunk candidates one at a time via
+    /// `get_tags_for_entry_async` per entry means one DB round trip per
+    /// unique chunk entry_id, which can run to the thousands under the
+    /// archive-tier exclusion case. This collects tags for a whole window of
+    /// entry_ids with one query instead.
+    pub(super) async fn get_tags_for_entries_async(
+        &self,
+        entry_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<String>>> {
+        let mut out: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        if entry_ids.is_empty() {
+            return Ok(out);
+        }
+
+        let things: Vec<Thing> = entry_ids
+            .iter()
+            .map(|id| {
+                let id_part = id.strip_prefix("kn-").unwrap_or(id);
+                Thing::from(("knowledge", id_part))
+            })
+            .collect();
+
+        #[derive(Deserialize)]
+        struct TagRow {
+            entry_id: String,
+            tag: String,
+        }
+
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(in) AS entry_id, out.name AS tag \
+                 FROM tagged_with WHERE in IN $knowledge",
+            )
+            .bind(("knowledge", things))
+            .await
+            .context("Failed to batch-query tags")
+        })?;
+
+        let rows: Vec<TagRow> = response.take(0).unwrap_or_default();
+        for row in rows {
+            out.entry(format!("kn-{}", row.entry_id))
+                .or_default()
+                .push(row.tag);
+        }
+
+        Ok(out)
+    }
+
     /// Get applicability for an entry
     pub fn get_applicability_for_entry(&self, entry_id: &str) -> Result<Vec<String>> {
         Self::runtime().block_on(self.get_applicability_for_entry_async(entry_id))
@@ -293,5 +345,51 @@ impl SurrealDatabase {
     pub fn set_applicability_for_entry(&self, _entry_id: &str, _ids: &[String]) -> Result<()> {
         // Applicability is managed via upsert_knowledge, this is a no-op for compatibility
         Ok(())
+    }
+
+    /// Batch-fetch applicability for many entries in a single round trip.
+    /// See `get_tags_for_entries_async` for why this exists.
+    pub(super) async fn get_applicability_for_entries_async(
+        &self,
+        entry_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<String>>> {
+        let mut out: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        if entry_ids.is_empty() {
+            return Ok(out);
+        }
+
+        let things: Vec<Thing> = entry_ids
+            .iter()
+            .map(|id| {
+                let id_part = id.strip_prefix("kn-").unwrap_or(id);
+                Thing::from(("knowledge", id_part))
+            })
+            .collect();
+
+        #[derive(Deserialize)]
+        struct ApplicabilityRow {
+            entry_id: String,
+            applies_id: String,
+        }
+
+        let mut response = with_db!(self, db, {
+            db.query(
+                "SELECT meta::id(in) AS entry_id, meta::id(out) AS applies_id \
+                 FROM applies_to WHERE in IN $knowledge",
+            )
+            .bind(("knowledge", things))
+            .await
+            .context("Failed to batch-query applicability")
+        })?;
+
+        let rows: Vec<ApplicabilityRow> = response.take(0).unwrap_or_default();
+        for row in rows {
+            out.entry(format!("kn-{}", row.entry_id))
+                .or_default()
+                .push(row.applies_id);
+        }
+
+        Ok(out)
     }
 }

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -2446,6 +2446,64 @@ fn test_search_exclude_tags_drops_archived_keyword_match() {
 }
 
 #[test]
+fn keyword_search_exclude_survives_past_hypothetical_limit() {
+    // Landmine test (report finding, handlers/memory.rs:495 /
+    // knowledge.rs:846): `search_knowledge_async` currently issues NO
+    // DB-level LIMIT, which is the ONLY reason `exclude_tag_prefixes` can be
+    // left unwired there while `apply_entry_filters` stays exact. If a future
+    // engineer adds a LIMIT to that query (natural for a growing store),
+    // this test catches it two ways: (1) the raw result count must equal
+    // every seeded matching row -- a LIMIT smaller than that count shrinks
+    // this assertion immediately, regardless of row ordering; and (2) the
+    // live entry (seeded last, so it would fall past any hypothetical small
+    // LIMIT window under natural insertion order) must still survive
+    // exclusion + truncation to the final output.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let ctx = crate::store::AgentContext::public_only();
+
+    const N_ARCHIVED: usize = 50;
+    for i in 0..N_ARCHIVED {
+        let mut e = make_test_entry(&format!("kn-landmine-archived-{i:03}"), 5, 0.0);
+        e.title = "widget landmine archived".to_string();
+        e.body = Some("unique widget landmine content, archived tier".to_string());
+        e.tags = vec!["tier/archived".to_string()];
+        db.upsert_knowledge(&e).unwrap();
+    }
+
+    let mut live = make_test_entry("kn-landmine-live", 5, 0.0);
+    live.title = "widget landmine live".to_string();
+    live.body = Some("unique widget landmine content, still live".to_string());
+    db.upsert_knowledge(&live).unwrap();
+
+    let db_filter = crate::store::KnowledgeFilter::default();
+    let raw_results = db.search("widget landmine", &ctx, &db_filter).unwrap();
+    assert_eq!(
+        raw_results.len(),
+        N_ARCHIVED + 1,
+        "search_knowledge_async must return every matching row uncapped -- a \
+         future LIMIT smaller than the seeded set would shrink this count \
+         and silently break the no-DB-LIMIT contract apply_entry_filters \
+         relies on for exact exclusion"
+    );
+
+    // Even with a small requested limit, exclusion must run BEFORE the
+    // truncate -- the live entry must still survive.
+    let entry_filter = crate::cli::EntryFilter {
+        exclude_tags: Some("tier/".to_string()),
+        limit: Some(1),
+        ..Default::default()
+    };
+    let filtered = crate::helpers::apply_entry_filters(raw_results, &entry_filter);
+    let filtered_ids: Vec<&str> = filtered.iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(
+        filtered_ids,
+        vec!["kn-landmine-live"],
+        "the live entry must survive exclusion + limit truncation even \
+         though it sorts last among the seeded rows; got {filtered_ids:?}"
+    );
+}
+
+#[test]
 fn test_search_select_no_results_is_noop() {
     // --select with no results should not error or attempt any activations.
     let db = SurrealDatabase::open_in_memory().unwrap();
@@ -3595,6 +3653,60 @@ fn semantic_search_exclude_tags_prefix_match_drops_tier_archived_only() {
 }
 
 #[test]
+fn semantic_search_multi_prefix_exclusion_drops_both_namespaces_at_db_level() {
+    // Criterion: `build_exclude_tags_filter`'s multi-prefix OR-join (one bound
+    // param per prefix) is only exercised end-to-end here — every other DB
+    // fixture uses a single prefix, so a bug in the OR-join or the per-prefix
+    // bind loop would ship undetected otherwise.
+    use crate::store::{AgentContext, KnowledgeFilter};
+
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    const N: usize = 8;
+    let mut query = vec![0.0f32; N];
+    query[0] = 1.0;
+
+    db.upsert_knowledge(&entry_with_embedding_and_tags(
+        "kn-tier-archived",
+        query.clone(),
+        &["tier/archived"],
+    ))
+    .unwrap();
+    db.upsert_knowledge(&entry_with_embedding_and_tags(
+        "kn-scratch-x",
+        query.clone(),
+        &["scratch/x"],
+    ))
+    .unwrap();
+    db.upsert_knowledge(&entry_with_embedding_and_tags(
+        "kn-unrelated",
+        query.clone(),
+        &["project/y"],
+    ))
+    .unwrap();
+
+    let ctx = AgentContext::public_only();
+    let filter = KnowledgeFilter {
+        exclude_tag_prefixes: vec!["tier/".to_string(), "scratch/".to_string()],
+        ..Default::default()
+    };
+    let results = db.semantic_search(&query, &ctx, &filter, 10).unwrap();
+    let ids: Vec<&str> = results.iter().map(|e| e.id.as_str()).collect();
+
+    assert!(
+        !ids.contains(&"kn-tier-archived"),
+        "tier/archived must be dropped by a multi-prefix exclusion including 'tier/'; got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"kn-scratch-x"),
+        "scratch/x must be dropped by a multi-prefix exclusion including 'scratch/'; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"kn-unrelated"),
+        "an entry tagged project/y must survive a ['tier/', 'scratch/'] exclusion; got {ids:?}"
+    );
+}
+
+#[test]
 fn semantic_search_no_exclude_tags_behavior_unchanged() {
     // Criterion: default (no --exclude-tags) behavior is byte-identical to
     // before this rider — an archived-tagged entry is still returned.
@@ -3620,4 +3732,79 @@ fn semantic_search_no_exclude_tags_behavior_unchanged() {
         ids.contains(&"kn-archived"),
         "with no --exclude-tags, an archived entry must still be returned; got {ids:?}"
     );
+}
+
+#[test]
+fn semantic_search_no_flag_category_thinned_chunk_query_fills_to_limit() {
+    // Criterion (report finding, knowledge.rs:1010): the iterative over-fetch
+    // loop replaced a fixed `limit * 3` window for EVERY semantic search, not
+    // just `--exclude-tags` ones — but the only no-flag test on record
+    // (`semantic_search_no_exclude_tags_behavior_unchanged`, above) just
+    // checks a single archived entry still surfaces. It never exercises the
+    // resonance/category-thinned case the original fixed window was built
+    // for. This test issues NO `--exclude-tags` at all: category filtering
+    // alone must thin the embedding_chunk candidate set enough that a fixed
+    // `limit * 3` window would have starved the fill, while the adaptive
+    // loop still reaches the requested limit.
+    use crate::store::{AgentContext, KnowledgeFilter};
+
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    const N: usize = 8;
+    const LIMIT: usize = 2;
+
+    let mut query = vec![0.0f32; N];
+    query[0] = 1.0;
+
+    // 8 "noise"-category chunked entries, perfectly aligned (score == 1.0).
+    // With LIMIT=2, a fixed `limit * 3` = 6 over-fetch window would return
+    // only these 8 (top 6 of the table), never reaching the "good" pair
+    // ranked below them.
+    for i in 0..8 {
+        let mut e = make_test_entry(&format!("kn-noise-{i}"), 5, 0.0);
+        e.content_hash = Some(format!("hash-kn-noise-{i}"));
+        e.category_id = "noise".to_string();
+        e.chunk_count = 1;
+        db.upsert_knowledge(&e).unwrap();
+        db.insert_embedding_chunk(&e.id, 0, "chunk text", 0, 10, &query, "test-model")
+            .unwrap();
+    }
+
+    // 2 "good"-category chunked entries, well- but imperfectly-aligned, so
+    // they rank below the noise pack on an unfiltered scan.
+    for i in 0..LIMIT {
+        let mut v = vec![0.0f32; N];
+        v[0] = 0.9;
+        v[1 + i] = (1.0f32 - 0.81f32).sqrt(); // unit-length, cos with query = 0.9
+        let mut e = make_test_entry(&format!("kn-good-{i}"), 5, 0.0);
+        e.content_hash = Some(format!("hash-kn-good-{i}"));
+        e.category_id = "good".to_string();
+        e.chunk_count = 1;
+        db.upsert_knowledge(&e).unwrap();
+        db.insert_embedding_chunk(&e.id, 0, "chunk text", 0, 10, &v, "test-model")
+            .unwrap();
+    }
+
+    let ctx = AgentContext::public_only();
+    // No `exclude_tag_prefixes` set at all -- this is the no-flag case.
+    let filter = KnowledgeFilter {
+        categories: Some(vec!["good".to_string()]),
+        ..Default::default()
+    };
+    let results = db.semantic_search(&query, &ctx, &filter, LIMIT).unwrap();
+
+    assert_eq!(
+        results.len(),
+        LIMIT,
+        "full requested limit must be reached via category filtering alone \
+         (no --exclude-tags) even when a fixed over-fetch window would have \
+         been entirely consumed by out-of-category candidates; got {:?}",
+        results.iter().map(|e| e.id.as_str()).collect::<Vec<_>>()
+    );
+    for entry in &results {
+        assert_eq!(
+            entry.category_id, "good",
+            "an out-of-category entry leaked into category-filtered results: {}",
+            entry.id
+        );
+    }
 }

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -3408,7 +3408,7 @@ fn off_dim_row_does_not_abort_cosine_scan() {
 
 // =========================================================================
 // W447 retrieval-exclusion rider — `--exclude-tags` on semantic search
-// (Panel Fix #1).
+// (review fix).
 //
 // The archive tier (`tier/archived`) is a DEFAULT exclusion designed to
 // GROW, unlike an ordinary `--tags` inclusion filter. If exclusion only ran

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -2399,6 +2399,53 @@ fn test_search_select_activates_results() {
 }
 
 #[test]
+fn test_search_exclude_tags_drops_archived_keyword_match() {
+    // W447 rider, keyword-search path: `mx memory search <q> --exclude-tags
+    // 'tier/'` must omit a tier/-tagged entry that otherwise matches the
+    // full-text query, while an untagged match with the same query survives.
+    // Keyword search issues no DB-level LIMIT, so exclusion lives entirely in
+    // apply_entry_filters (the same merge point `list` uses) — this test
+    // exercises that real merge point end-to-end, not just the pure helper.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let ctx = crate::store::AgentContext::public_only();
+
+    let mut archived = make_test_entry("kn-search-archived", 5, 0.0);
+    archived.title = "widget gadget archived".to_string();
+    archived.body = Some("unique widget content, archived tier".to_string());
+    archived.tags = vec!["tier/archived".to_string()];
+    db.upsert_knowledge(&archived).unwrap();
+
+    let mut live = make_test_entry("kn-search-live", 5, 0.0);
+    live.title = "widget gadget live".to_string();
+    live.body = Some("unique widget content, still live".to_string());
+    db.upsert_knowledge(&live).unwrap();
+
+    let db_filter = crate::store::KnowledgeFilter::default();
+    let raw_results = db.search("widget", &ctx, &db_filter).unwrap();
+    let raw_ids: Vec<&str> = raw_results.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        raw_ids.contains(&"kn-search-archived") && raw_ids.contains(&"kn-search-live"),
+        "fixture sanity check failed: both entries should match 'widget' \
+         before exclusion is applied, got {raw_ids:?}"
+    );
+
+    let entry_filter = crate::cli::EntryFilter {
+        exclude_tags: Some("tier/".to_string()),
+        ..Default::default()
+    };
+    let filtered = crate::helpers::apply_entry_filters(raw_results, &entry_filter);
+    let filtered_ids: Vec<&str> = filtered.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        !filtered_ids.contains(&"kn-search-archived"),
+        "tier/archived entry must be dropped from keyword search results; got {filtered_ids:?}"
+    );
+    assert!(
+        filtered_ids.contains(&"kn-search-live"),
+        "the untagged match must survive exclusion; got {filtered_ids:?}"
+    );
+}
+
+#[test]
 fn test_search_select_no_results_is_noop() {
     // --select with no results should not error or attempt any activations.
     let db = SurrealDatabase::open_in_memory().unwrap();
@@ -3298,5 +3345,279 @@ fn off_dim_row_does_not_abort_cosine_scan() {
     assert!(
         !scored_ids.contains(&"kn-poison-dim4"),
         "entry-level scored search must skip the off-dim row; got {scored_ids:?}"
+    );
+}
+
+// =========================================================================
+// W447 retrieval-exclusion rider — `--exclude-tags` on semantic search
+// (Panel Fix #1).
+//
+// The archive tier (`tier/archived`) is a DEFAULT exclusion designed to
+// GROW, unlike an ordinary `--tags` inclusion filter. If exclusion only ran
+// as a post-filter after the DB's own `ORDER BY score DESC LIMIT $limit`,
+// a query whose top-ranked neighbors are all archived would have the DB
+// truncate to `limit` BEFORE the archived rows are ever dropped — silently
+// returning fewer than `limit` non-archived results, with no signal. This
+// test seeds archived entries that rank ABOVE the non-archived ones and
+// asserts the full requested limit still comes back non-archived, proving
+// exclusion is applied at the SQL candidate-set level (before LIMIT), not
+// as a post-filter.
+// =========================================================================
+
+/// Build a knowledge entry with a synthetic embedding and explicit tags —
+/// mirrors `entry_with_dim_embedding` but also sets `tags` so archived-tier
+/// exclusion fixtures can be built without a real embedding model.
+fn entry_with_embedding_and_tags(
+    id: &str,
+    embedding: Vec<f32>,
+    tags: &[&str],
+) -> crate::knowledge::KnowledgeEntry {
+    let mut e = make_test_entry(id, 5, 0.0);
+    e.content_hash = Some(format!("hash-{id}"));
+    e.embedding = Some(embedding);
+    e.embedding_model = Some("test-model".to_string());
+    e.embedded_at = Some(chrono::Utc::now().to_rfc3339());
+    e.tags = tags.iter().map(|s| s.to_string()).collect();
+    e
+}
+
+#[test]
+fn semantic_search_excludes_top_ranked_archived_neighbors_returns_full_limit() {
+    use crate::store::{AgentContext, KnowledgeFilter};
+
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    const N: usize = 8;
+
+    // Query vector aligned with axis 0.
+    let mut query = vec![0.0f32; N];
+    query[0] = 1.0;
+
+    // Two archived entries, PERFECTLY aligned with the query (score == 1.0) —
+    // these must rank above every non-archived entry.
+    for id in ["kn-archived-1", "kn-archived-2"] {
+        db.upsert_knowledge(&entry_with_embedding_and_tags(
+            id,
+            query.clone(),
+            &["tier/archived"],
+        ))
+        .unwrap();
+    }
+
+    // Three non-archived entries, still well-aligned (positive but imperfect
+    // score) so they rank below the archived pair on an unfiltered scan, but
+    // must fill the result set once archived rows are excluded.
+    let mut good_vecs = Vec::new();
+    for i in 0..3usize {
+        let mut v = vec![0.0f32; N];
+        v[0] = 0.9;
+        v[1 + i] = (1.0f32 - 0.81f32).sqrt(); // unit-length, cos with query = 0.9
+        good_vecs.push(v);
+    }
+    for (i, v) in good_vecs.into_iter().enumerate() {
+        db.upsert_knowledge(&entry_with_embedding_and_tags(
+            &format!("kn-good-{i}"),
+            v,
+            &[],
+        ))
+        .unwrap();
+    }
+
+    let ctx = AgentContext::public_only();
+
+    // Sanity check: WITHOUT exclusion, the archived pair ranks in the top 2
+    // (score 1.0 beats the good entries' 0.9), proving the fixture actually
+    // exercises the "excluded neighbors rank highest" scenario.
+    let unfiltered_filter = KnowledgeFilter::default();
+    let unfiltered = db
+        .semantic_search(&query, &ctx, &unfiltered_filter, 2)
+        .unwrap();
+    let unfiltered_ids: Vec<&str> = unfiltered.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        unfiltered_ids.contains(&"kn-archived-1") && unfiltered_ids.contains(&"kn-archived-2"),
+        "fixture sanity check failed: archived entries should rank in the \
+         unfiltered top 2, got {unfiltered_ids:?}"
+    );
+
+    // With --exclude-tags 'tier/' and limit 2: if exclusion were a post-filter
+    // after the DB's own LIMIT, the DB would already have truncated to the
+    // two archived rows and both would be dropped, returning 0 results. The
+    // fix must return the full requested limit (2), both non-archived.
+    let exclude_filter = KnowledgeFilter {
+        exclude_tag_prefixes: vec!["tier/".to_string()],
+        ..Default::default()
+    };
+    let results = db
+        .semantic_search(&query, &ctx, &exclude_filter, 2)
+        .unwrap();
+    assert_eq!(
+        results.len(),
+        2,
+        "full requested limit must survive exclusion even when the top-ranked \
+         neighbors are all archived; got {:?}",
+        results.iter().map(|e| e.id.as_str()).collect::<Vec<_>>()
+    );
+    for entry in &results {
+        assert!(
+            !entry.tags.iter().any(|t| t.starts_with("tier/")),
+            "an archived entry leaked into exclusion-filtered results: {}",
+            entry.id
+        );
+    }
+}
+
+/// Seed a CHUNKED knowledge entry (`chunk_count > 0`, no entry-level
+/// `embedding`) with a single synthetic `embedding_chunk` row, so semantic
+/// search can only find it via the `embedding_chunk` phase (Phase 1b) — the
+/// unchunked phase's WHERE requires `chunk_count IS NONE OR chunk_count <= 0`
+/// and `embedding IS NOT NONE`, both of which this fixture fails on purpose.
+fn seed_chunked_entry_with_tags(
+    db: &SurrealDatabase,
+    id: &str,
+    chunk_embedding: Vec<f32>,
+    tags: &[&str],
+) {
+    let mut e = make_test_entry(id, 5, 0.0);
+    e.content_hash = Some(format!("hash-{id}"));
+    e.tags = tags.iter().map(|s| s.to_string()).collect();
+    e.chunk_count = 1;
+    db.upsert_knowledge(&e).unwrap();
+    db.insert_embedding_chunk(id, 0, "chunk text", 0, 10, &chunk_embedding, "test-model")
+        .unwrap();
+}
+
+#[test]
+fn semantic_search_excludes_top_ranked_archived_chunk_neighbors_returns_full_limit() {
+    // Criterion 1 named BOTH the unchunked and the embedding_chunk phase.
+    // `semantic_search_excludes_top_ranked_archived_neighbors_returns_full_limit`
+    // above only seeds unchunked entries, so it never exercises the
+    // embedding_chunk phase's exclusion (the Rust post-filter behind an
+    // iterative over-fetch loop, replacing a fixed `limit * 3` window that
+    // silently thinned results once excluded candidates outnumbered it).
+    //
+    // This fixture seeds enough archived, CHUNKED entries ranking above the
+    // non-archived chunked ones that a fixed `limit * 3` fetch window would
+    // have returned ONLY archived candidates on its first (and only) pass —
+    // proving this test attaches to the chunk-phase contract specifically.
+    use crate::store::{AgentContext, KnowledgeFilter};
+
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    const N: usize = 8;
+    const LIMIT: usize = 2;
+
+    let mut query = vec![0.0f32; N];
+    query[0] = 1.0;
+
+    // 8 archived, chunked entries perfectly aligned with the query
+    // (score == 1.0). With LIMIT=2, a fixed `limit * 3` = 6 over-fetch
+    // window would return only these 8 (top 6 of the table are all
+    // archived), never reaching the 2 good entries ranked below them.
+    for i in 0..8 {
+        seed_chunked_entry_with_tags(
+            &db,
+            &format!("kn-chunk-archived-{i}"),
+            query.clone(),
+            &["tier/archived"],
+        );
+    }
+
+    // 2 non-archived, chunked entries, well- but imperfectly-aligned, so
+    // they rank below the archived pack on an unfiltered scan.
+    for i in 0..LIMIT {
+        let mut v = vec![0.0f32; N];
+        v[0] = 0.9;
+        v[1 + i] = (1.0f32 - 0.81f32).sqrt(); // unit-length, cos with query = 0.9
+        seed_chunked_entry_with_tags(&db, &format!("kn-chunk-good-{i}"), v, &[]);
+    }
+
+    let ctx = AgentContext::public_only();
+    let filter = KnowledgeFilter {
+        exclude_tag_prefixes: vec!["tier/".to_string()],
+        ..Default::default()
+    };
+    let results = db.semantic_search(&query, &ctx, &filter, LIMIT).unwrap();
+
+    assert_eq!(
+        results.len(),
+        LIMIT,
+        "full requested limit must survive exclusion in the embedding_chunk \
+         phase even when a fixed over-fetch window would have been entirely \
+         consumed by archived candidates; got {:?}",
+        results.iter().map(|e| e.id.as_str()).collect::<Vec<_>>()
+    );
+    for entry in &results {
+        assert!(
+            !entry.tags.iter().any(|t| t.starts_with("tier/")),
+            "an archived chunked entry leaked into exclusion-filtered results: {}",
+            entry.id
+        );
+    }
+}
+
+#[test]
+fn semantic_search_exclude_tags_prefix_match_drops_tier_archived_only() {
+    // Criterion: 'tier/' drops 'tier/archived' specifically (prefix match),
+    // and leaves an entry tagged something else untouched.
+    use crate::store::{AgentContext, KnowledgeFilter};
+
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    const N: usize = 8;
+    let mut query = vec![0.0f32; N];
+    query[0] = 1.0;
+
+    db.upsert_knowledge(&entry_with_embedding_and_tags(
+        "kn-archived",
+        query.clone(),
+        &["tier/archived"],
+    ))
+    .unwrap();
+    db.upsert_knowledge(&entry_with_embedding_and_tags(
+        "kn-project",
+        query.clone(),
+        &["project/x"],
+    ))
+    .unwrap();
+
+    let ctx = AgentContext::public_only();
+    let filter = KnowledgeFilter {
+        exclude_tag_prefixes: vec!["tier/".to_string()],
+        ..Default::default()
+    };
+    let results = db.semantic_search(&query, &ctx, &filter, 10).unwrap();
+    let ids: Vec<&str> = results.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        !ids.contains(&"kn-archived"),
+        "tier/archived must be dropped by --exclude-tags 'tier/'; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&"kn-project"),
+        "an entry tagged project/x must survive a 'tier/' exclusion; got {ids:?}"
+    );
+}
+
+#[test]
+fn semantic_search_no_exclude_tags_behavior_unchanged() {
+    // Criterion: default (no --exclude-tags) behavior is byte-identical to
+    // before this rider — an archived-tagged entry is still returned.
+    use crate::store::{AgentContext, KnowledgeFilter};
+
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    const N: usize = 8;
+    let mut query = vec![0.0f32; N];
+    query[0] = 1.0;
+
+    db.upsert_knowledge(&entry_with_embedding_and_tags(
+        "kn-archived",
+        query.clone(),
+        &["tier/archived"],
+    ))
+    .unwrap();
+
+    let ctx = AgentContext::public_only();
+    let filter = KnowledgeFilter::default();
+    let results = db.semantic_search(&query, &ctx, &filter, 10).unwrap();
+    let ids: Vec<&str> = results.iter().map(|e| e.id.as_str()).collect();
+    assert!(
+        ids.contains(&"kn-archived"),
+        "with no --exclude-tags, an archived entry must still be returned; got {ids:?}"
     );
 }


### PR DESCRIPTION
## Summary

Adds `--exclude-tags <PREFIXES>` (comma-separated, prefix-match) to `memory search` (both keyword and semantic paths) and `memory list`. Parse semantics match wake-fetch parity, so the same prefix syntax you already use for wake exclusion works here.

Motivation: the hearth just grew an archive tier (`tier/archived`), and archived entries should be excluded from retrieval by default. This flag is the retrieval-side lever for that — pull the archive back in only when you ask for it.

## Design notes

Semantic exclusion is pushed down to the **candidate-set level**, not applied as an after-the-fact filter on an already-limited result set:

- **Unchunked phase** filters in the SQL `WHERE` via bound params *before* `LIMIT`, so exclusion narrows the candidate set the database ranks, not the tail.
- **Embedding-chunk phase** has no tag edge to join against, so it uses a **bounded iterative over-fetch loop**: it grows the fetch window and re-scans until the limit is filled or the scan budget is exhausted. This guarantees an all-archived top window can't silently thin results below the requested limit.

The DB-layer `KnowledgeFilter` carries a pre-parsed `exclude_tag_prefixes: Vec<String>` (parsed once via `parse_exclude_prefixes` in `helpers.rs`); the CLI-facing `EntryFilter::exclude_tags` stays a raw CSV `Option<String>` to keep exact wake-fetch parse parity.

## Two honest behavior notes

1. **No-flag chunk path now grows its fetch window to fill the limit.** Previously the chunk path used a fixed `limit * 3` window. It now over-fetches iteratively to fill the requested limit. This is a strict improvement (fewer silently-short result sets), but it is **not byte-identical** to the old fixed-window behavior — a no-flag query may now return chunks the old fixed window would have dropped.

2. **Capacity characteristic under archive-dominated rankings.** When archived chunks dominate the top rankings, an excluded semantic query can run up to ~5 bounded scans instead of 1 to fill the limit. It's bounded, so no runaway — but it's more DB work in that specific case. The future fix, if it ever matters in practice, is to denormalize a tier flag directly onto `embedding_chunk` so the chunk phase can filter in SQL like the unchunked phase does.

## Sibling note

A separate store-boundary dedup PR (W447-mx-dedup) follows this one. Landing order is your call — this PR is deliberately minimal, scoped only to retrieval exclusion, to unblock the archive tier without dragging the dedup change along with it.

## Docs regeneration note

`docs/out/llm/mx-docs.md` was regenerated (`docs/build.sh`) as part of this change, which pulls in the already-merged `MX_SURREAL_*` env-var section move from `getting-started.typ` — main's committed copy of the generated file was stale relative to that prior merge. That's why the diff on this file is larger than the `--exclude-tags` additions alone; it's unrelated churn made correct, not unrelated churn left unexplained.

## Test plan

- 1166/1166 unit tests pass (includes new coverage in `src/surreal_db/tests.rs` for both exclusion phases and the over-fetch loop)
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt -- --check` clean
- Manual verification of keyword, semantic, and list exclusion paths against the archive tier

