### PR TITLE
feat: store-boundary write dedup (normalized dedup_hash, both add paths)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,5 +11,12 @@ The `--mine` flag scopes queries to the calling agent (`MX_CURRENT_AGENT`).
 
 ## Maintenance Rule
 
-If you change behavior of existing commands, note it in the CHANGELOG and
+If you change behavior of existing commands, note it in the PR description
+(this repo has no CHANGELOG file -- release notes live in PR bodies) and
 verify companion-facing usage in `~/.soren/config/agents/` still holds.
+
+Write-boundary dedup (W447, `mx memory add` / `add-batch`) is documented as
+in-process, best-effort duplicate prevention: read-then-write within a
+single invocation, no DB-level unique constraint backing it, and not wired
+to the legacy `content_hash` field. See `docs/src/memory.typ`'s
+"Write-boundary deduplication" section for the full behavior contract.

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1325,53 +1325,94 @@ include all per-entry fields (`category`, `title`, `content`,
 `source_agent`, `tags`, `private`, `resonance`, `type`, etc.) on each
 line. There are no batch-wide field overrides except `--no-embed`. This
 design supports heterogeneous batches (facts, person nodes, summaries,
-blooms) in a single invocation --- which is the primary pocket use-case.
-Per line, `allow_duplicate: true` mirrors `--allow-duplicate` on the
-single-add path -- see below.
+blooms) in a single invocation --- which is the primary batch-write
+use-case. Per line, `allow_duplicate: true` mirrors `--allow-duplicate`
+on the single-add path -- see below.
 :::
 
 ### Write-boundary deduplication {#dedup}
 
-Both write paths (`mx memory add` and `mx memory add-batch`, including
-its `--type`/fact-routing lines) check a normalized `dedup_hash` of
-`title+body` (lowercase, punctuation stripped, whitespace collapsed)
-against the writing agent's OWN entries in the SAME session before
-writing. A regenerated duplicate that differs only by case, punctuation,
-or whitespace -- the common shape when an LLM re-derives the same fact
-across turns -- is detected and the write is SKIPPED rather than landing
-as a second row.
+All four new-entry write funnels -- `mx memory add` (standard),
+`mx memory
+add --type` (fact-routing), and both lines of `mx memory add-batch`
+(standard and `--type`) -- check a normalized `dedup_hash` of
+`title+body` (lowercase, ASCII punctuation and common Unicode
+punctuation stripped -- smart quotes, en/em dash, horizontal ellipsis --
+whitespace collapsed) against the writing agent's OWN entries in the
+SAME session before writing. A regenerated duplicate that differs only
+by case, punctuation, or whitespace -- the common shape when an LLM
+re-derives the same fact across turns -- is detected and the write is
+SKIPPED rather than landing as a second row. Title and body are hashed
+as a length-prefixed pair, so a duplicate that shifts the split point
+(e.g. a sentence folded into the title one turn, split title+body the
+next) is still caught.
 
 A skip is treated as **success, not failure**: it means the content is
 already durably saved, and there is nothing further to do.
 
 - **Plain mode:**
   `Already saved as kn-XXXX (identical entry this session — nothing to do).`
+  Deliberately distinct from the success line (`Added entry: kn-XXXX`)
+  -- a caller regexing on `Added entry: (kn-\S+)` should switch to
+  `--json` rather than assume this line matches that pattern.
 
 - `--json` **mode:**
-  `{"skipped": true, "duplicate_of": "kn-XXXX", "status": "already_persisted", "note": "..."}`,
-  with clean JSON on stdout (no other text) and exit code `0`.
+  `{"id": "kn-XXXX", "skipped": true, "duplicate_of": "kn-XXXX", "status": "already_persisted", "note": "..."}`,
+  with clean JSON on stdout (no other text) and exit code `0`. `id`
+  mirrors every success payload's `id` key so a caller reading `.id`
+  unconditionally never gets a silent `null` on a skip.
 
 - **`add-batch` per-entry line:**
   `[N] Already saved: kn-XXXX (title) — identical this session, no action`
   -- never the bare words "skipped" or "duplicate" -- and the batch
   summary carries its own `K already saved (no action needed)` category,
-  separate from `added` and `failed`.
+  separate from `added` and `failed`. `add-batch` has no `--json` mode,
+  so this is stdout text only.
 
 - Pass `--allow-duplicate` (single add) or `allow_duplicate: true` (per
   JSONL line) to force the write through when a re-add is deliberate.
+  **Caveat:** on the fact-routing paths (and on the standard path when
+  `title` is byte-identical to an existing entry's), the write's id is
+  derived from `path_hint:title` (`generate_id`), so a byte-identical
+  forced re-add overwrites the SAME row in place (new `updated_at`, same
+  id) instead of creating a second entry -- `--allow-duplicate` only
+  produces a genuinely distinct row for a recased/reworded
+  near-duplicate, not an exact repeat. This is accepted, not fixed:
+  perturbing the id on a forced write was considered and rejected (it
+  would make `--allow-duplicate` non-idempotent in a different, more
+  surprising way). If you need a second row for byte-identical content,
+  vary the title.
+
+- On a candidate-lookup failure (a transient DB read blip), the gate
+  FAILS OPEN: it warns to stderr (`--json` mode also gets a
+  `"dedup_lookup_warning"` field) and proceeds with the write rather
+  than aborting it. A dedup mechanism that already tolerates a
+  check-then-write race between two concurrent writers tolerates a
+  lookup blip the same way -- the write always wins.
 
 ::: {.admonition .note}
 **NOTE:** **Coverage boundary, read this before assuming full
 coverage:** the gate catches recased/repunctuated re-adds within the
 SAME session and SAME owner. It does NOT catch: cross-session
 regenerations (a fact re-derived in a later wake under a different
-`session_id`), reworded duplicates (different words, same meaning --
-e.g. "shipped" vs "published"), or writes with no `session_id` at all
-(dedup is bypassed entirely when `session_id` is absent -- a bypass
-signal, `"dedup": "bypassed_no_session"`, is emitted in `--json` mode,
-and a stderr note in plain mode, so the bypass is never silent). Keep
-marking back captured entries; this is a store-boundary backstop, not a
-substitute for careful write discipline.
+`session_id` -- **open question, not yet confirmed:** the  20
+double-write pairs (W342--W445) that motivated this feature have not
+been checked against this scope; if most of them are cross-session
+rather than same-session, this fix closes only a minority of the
+motivating class, and owner-scoped matching with a bounded time window
+would be the sharper mechanism -- flagged for follow-up, not resolved
+here), reworded duplicates (different words, same meaning -- e.g.
+"shipped" vs "published"), a public+owned entry vs. a later
+public+unowned entry with identical content (owner is a hard
+AND-conjoined predicate, so these two visible-to-everyone rows never
+dedup against each other even though both are public), or writes with no
+`session_id` at all (dedup is bypassed entirely when `session_id` is
+absent -- a bypass signal is emitted on EVERY funnel: `"dedup":
+"bypassed_no_session"` in `--json` mode on the standard single-add path
+(mutually exclusive with the stderr note -- json mode never prints
+both), a stderr note on all four funnels in every other mode, so the
+bypass is never silent). Keep marking back captured entries; this is a
+store-boundary backstop, not a substitute for careful write discipline.
 :::
 
 ::: {.admonition .note}
@@ -1381,7 +1422,30 @@ process invocation (TOCTOU: two concurrent `mx` invocations can still
 both write the same normalized content). It is NOT wired to the legacy
 `content_hash` field (title-only, import-time change detection,
 unenforced) and there is no `DEFINE INDEX ... UNIQUE` backing it at the
-schema level.
+schema level -- a persisted `dedup_hash` plus a compound unique index
+would close the TOCTOU gap and make the "store-boundary" framing
+literally true, at the cost of mapping a constraint violation to a skip;
+this is a design option for a future PR, not implemented here. The
+candidate query has no result limit, so a very long-lived session pays
+an O(n) rehash of every row ever written to its `(session, owner)` group
+on every future write in that group -- bounded in practice (memory
+sessions aren't usually thousands of rows), a follow-up if it ever
+isn't.
+:::
+
+::: {.admonition .note}
+**NOTE:** **The write boundary confirms content existence under a
+claimed owner.** A `duplicate_of` hit tells the caller "an entry with
+this exact normalized content already exists under this owner" --
+bounded to the pre-existing owner-claim authz (a caller can already
+assert their own owner scope; this exposes no more than that), but it is
+a new confirmation surface worth naming, and it is sharper on
+`add-batch`: each JSONL line supplies its own `source_agent`/`owner`, so
+one batch invocation can probe many owner+content combinations at once.
+When more than one pre-existing entry under a group already shares a
+hash (only possible from data written before this gate existed),
+`duplicate_of` reports whichever one iteration order happens to surface
+last -- not the earliest or a canonical row.
 :::
 
 ## Reading entries {#reading}

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -1175,6 +1175,8 @@ schema (it ignores `MX_SKIP_SCHEMA`).
 
 - Adding entries
 
+- Write-boundary deduplication
+
 - Reading entries
 
 - Updating entries
@@ -1210,7 +1212,7 @@ the category and generates a title from content).
 ### Flags
 
   **Flag**                **Type**   **Description**
-  ----------------------- ---------- ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  ----------------------- ---------- ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   `--category`            `string`   Category name (run `mx memory categories list` for valid names). Required unless `--type` is provided.
   `-t, --title`           `string`   Entry title. Required unless `--type` is provided.
   `--content`             `string`   Inline content. Conflicts with `--file`.
@@ -1239,6 +1241,7 @@ the category and generates a title from content).
   `--thread-id`           `string`   Thread ID for `thread_closed` operations. Requires `--type`.
   `--no-auto-anchor`      `flag`     Skip automatic anchor generation.
   `--no-embed`            `flag`     Skip synchronous embedding generation on write.
+  `--allow-duplicate`     `flag`     Write through even if an identical (same session, same owner) entry already exists this session. Without this flag, a recased/repunctuated near-duplicate is skipped (exit 0) rather than written -- see Write-boundary deduplication below.
   `--json`                `flag`     Output as JSON.
 
 ### Examples
@@ -1281,8 +1284,11 @@ Each line is a JSON object whose fields match `mx memory add` arguments
 The store is opened once and the  435 MB embedding model is loaded once
 for the whole batch, so a 30-entry bulk caller pays one cold-load
 instead of thirty. Malformed lines are skipped and reported at the end;
-one bad entry does not abort the rest (partial-success semantics). Exits
-non-zero when any entry failed.
+one bad entry does not abort the rest (partial-success semantics). A
+duplicate-skip (write-boundary dedup) is NOT a malformed-line failure --
+it counts toward "already saved," not "failed." Exits non-zero only when
+a line was malformed or the write itself errored; exits 0 when every
+line either wrote or was a legitimate duplicate-skip.
 
 **Recommended delivery:** pass a JSONL file via `--file` when calling
 through a `sudo` wrapper (e.g. the hearth `_secret-exec` proxy) --- a
@@ -1320,6 +1326,62 @@ include all per-entry fields (`category`, `title`, `content`,
 line. There are no batch-wide field overrides except `--no-embed`. This
 design supports heterogeneous batches (facts, person nodes, summaries,
 blooms) in a single invocation --- which is the primary pocket use-case.
+Per line, `allow_duplicate: true` mirrors `--allow-duplicate` on the
+single-add path -- see below.
+:::
+
+### Write-boundary deduplication {#dedup}
+
+Both write paths (`mx memory add` and `mx memory add-batch`, including
+its `--type`/fact-routing lines) check a normalized `dedup_hash` of
+`title+body` (lowercase, punctuation stripped, whitespace collapsed)
+against the writing agent's OWN entries in the SAME session before
+writing. A regenerated duplicate that differs only by case, punctuation,
+or whitespace -- the common shape when an LLM re-derives the same fact
+across turns -- is detected and the write is SKIPPED rather than landing
+as a second row.
+
+A skip is treated as **success, not failure**: it means the content is
+already durably saved, and there is nothing further to do.
+
+- **Plain mode:**
+  `Already saved as kn-XXXX (identical entry this session — nothing to do).`
+
+- `--json` **mode:**
+  `{"skipped": true, "duplicate_of": "kn-XXXX", "status": "already_persisted", "note": "..."}`,
+  with clean JSON on stdout (no other text) and exit code `0`.
+
+- **`add-batch` per-entry line:**
+  `[N] Already saved: kn-XXXX (title) — identical this session, no action`
+  -- never the bare words "skipped" or "duplicate" -- and the batch
+  summary carries its own `K already saved (no action needed)` category,
+  separate from `added` and `failed`.
+
+- Pass `--allow-duplicate` (single add) or `allow_duplicate: true` (per
+  JSONL line) to force the write through when a re-add is deliberate.
+
+::: {.admonition .note}
+**NOTE:** **Coverage boundary, read this before assuming full
+coverage:** the gate catches recased/repunctuated re-adds within the
+SAME session and SAME owner. It does NOT catch: cross-session
+regenerations (a fact re-derived in a later wake under a different
+`session_id`), reworded duplicates (different words, same meaning --
+e.g. "shipped" vs "published"), or writes with no `session_id` at all
+(dedup is bypassed entirely when `session_id` is absent -- a bypass
+signal, `"dedup": "bypassed_no_session"`, is emitted in `--json` mode,
+and a stderr note in plain mode, so the bypass is never silent). Keep
+marking back captured entries; this is a store-boundary backstop, not a
+substitute for careful write discipline.
+:::
+
+::: {.admonition .note}
+**NOTE:** **In-process, best-effort -- not a database-level uniqueness
+guarantee.** The dedup index is read-then-write within a single `mx`
+process invocation (TOCTOU: two concurrent `mx` invocations can still
+both write the same normalized content). It is NOT wired to the legacy
+`content_hash` field (title-only, import-time change detection,
+unenforced) and there is no `DEFINE INDEX ... UNIQUE` backing it at the
+schema level.
 :::
 
 ## Reading entries {#reading}
@@ -8279,6 +8341,18 @@ message is passed to `gh pr merge --subject ... --body ...`.
 `KnowledgeEntry` uses base-d's hash encoding for content hashing (via
 `base_d::hash` and `base_d::encode`), producing the `content_hash` field
 used for change detection during seed/import operations.
+
+::: {.admonition .note}
+**NOTE:** This is distinct from the runtime write-boundary `dedup_hash`
+(`knowledge::dedup_hash`, W447): `content_hash` is **title-only**,
+computed at import/seed time, and never enforced (no write-time check
+reads it back). `dedup_hash` is **title+body**, computed on every
+`mx memory add` / `add-batch` write, checked against the writer's own
+same-session entries BEFORE the write lands, and normalizes
+case/punctuation/whitespace so regenerated near-duplicates collapse to
+the same hash. See "Write-boundary deduplication" in the Memory
+reference. The two hashes are unrelated and neither replaces the other.
+:::
 
 ## Testing patterns
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -943,6 +943,16 @@ passed to `gh pr merge --subject ... --body ...`.
 `base_d::hash` and `base_d::encode`), producing the `content_hash` field used
 for change detection during seed/import operations.
 
+#note[This is distinct from the runtime write-boundary `dedup_hash`
+(`knowledge::dedup_hash`, W447): `content_hash` is *title-only*, computed at
+import/seed time, and never enforced (no write-time check reads it back).
+`dedup_hash` is *title+body*, computed on every `mx memory add` /
+`add-batch` write, checked against the writer's own same-session entries
+BEFORE the write lands, and normalizes case/punctuation/whitespace so
+regenerated near-duplicates collapse to the same hash. See "Write-boundary
+deduplication" in the #link("memory.html")[Memory] reference. The two hashes
+are unrelated and neither replaces the other.]
+
 
 // =========================================================================
 // TESTING PATTERNS

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -24,6 +24,7 @@ explicitly apply the schema (it ignores `MX_SKIP_SCHEMA`).]
 == Table of contents
 
 - #link(<adding>)[Adding entries]
+- #link(<dedup>)[Write-boundary deduplication]
 - #link(<reading>)[Reading entries]
 - #link(<updating>)[Updating entries]
 - #link(<deleting>)[Deleting entries]
@@ -77,6 +78,7 @@ explicitly apply the schema (it ignores `MX_SKIP_SCHEMA`).]
     ([`--thread-id`],  [`string`], [Thread ID for `thread_closed` operations. Requires `--type`.]),
     ([`--no-auto-anchor`], [`flag`], [Skip automatic anchor generation.]),
     ([`--no-embed`],   [`flag`],   [Skip synchronous embedding generation on write.]),
+    ([`--allow-duplicate`], [`flag`], [Write through even if an identical (same session, same owner) entry already exists this session. Without this flag, a recased/repunctuated near-duplicate is skipped (exit 0) rather than written -- see #link(<dedup>)[Write-boundary deduplication] below.]),
     ([`--json`],       [`flag`],   [Output as JSON.]),
   ),
   examples: (
@@ -99,8 +101,11 @@ content automatically.]
   The store is opened once and the ~435 MB embedding model is loaded once for
   the whole batch, so a 30-entry bulk caller pays one cold-load instead of
   thirty. Malformed lines are skipped and reported at the end; one bad entry
-  does not abort the rest (partial-success semantics). Exits non-zero when any
-  entry failed.
+  does not abort the rest (partial-success semantics). A duplicate-skip
+  (#link(<dedup>)[write-boundary dedup]) is NOT a malformed-line failure --
+  it counts toward "already saved," not "failed." Exits non-zero only when a
+  line was malformed or the write itself errored; exits 0 when every line
+  either wrote or was a legitimate duplicate-skip.
 
   *Recommended delivery:* pass a JSONL file via `--file` when calling through
   a `sudo` wrapper (e.g. the hearth `_secret-exec` proxy) — a file path
@@ -121,7 +126,53 @@ per-entry fields (`category`, `title`, `content`, `source_agent`, `tags`,
 `private`, `resonance`, `type`, etc.) on each line. There are no batch-wide
 field overrides except `--no-embed`. This design supports heterogeneous batches
 (facts, person nodes, summaries, blooms) in a single invocation --- which is
-the primary pocket use-case.]
+the primary pocket use-case. Per line, `allow_duplicate: true` mirrors
+`--allow-duplicate` on the single-add path -- see below.]
+
+// ═══════════════════════════════════════════════════════════════════════
+// WRITE-BOUNDARY DEDUPLICATION
+// ═══════════════════════════════════════════════════════════════════════
+
+=== Write-boundary deduplication <dedup>
+
+Both write paths (`mx memory add` and `mx memory add-batch`, including its
+`--type`/fact-routing lines) check a normalized `dedup_hash` of `title+body`
+(lowercase, punctuation stripped, whitespace collapsed) against the writing
+agent's OWN entries in the SAME session before writing. A regenerated
+duplicate that differs only by case, punctuation, or whitespace -- the
+common shape when an LLM re-derives the same fact across turns -- is
+detected and the write is SKIPPED rather than landing as a second row.
+
+A skip is treated as *success, not failure*: it means the content is already
+durably saved, and there is nothing further to do.
+
+- *Plain mode:* `Already saved as kn-XXXX (identical entry this session — nothing to do).`
+- `--json` *mode:* `{"skipped": true, "duplicate_of": "kn-XXXX", "status": "already_persisted", "note": "..."}`,
+  with clean JSON on stdout (no other text) and exit code `0`.
+- *`add-batch` per-entry line:* `[N] Already saved: kn-XXXX (title) — identical this session, no action` --
+  never the bare words "skipped" or "duplicate" -- and the batch summary
+  carries its own `K already saved (no action needed)` category, separate
+  from `added` and `failed`.
+- Pass `--allow-duplicate` (single add) or `allow_duplicate: true` (per JSONL
+  line) to force the write through when a re-add is deliberate.
+
+#note[*Coverage boundary, read this before assuming full coverage:* the gate
+catches recased/repunctuated re-adds within the SAME session and SAME owner.
+It does NOT catch: cross-session regenerations (a fact re-derived in a later
+wake under a different `session_id`), reworded duplicates (different words,
+same meaning -- e.g. "shipped" vs "published"), or writes with no
+`session_id` at all (dedup is bypassed entirely when `session_id` is absent
+-- a bypass signal, `"dedup": "bypassed_no_session"`, is emitted in `--json`
+mode, and a stderr note in plain mode, so the bypass is never silent). Keep
+marking back captured entries; this is a store-boundary backstop, not a
+substitute for careful write discipline.]
+
+#note[*In-process, best-effort -- not a database-level uniqueness guarantee.*
+The dedup index is read-then-write within a single `mx` process invocation
+(TOCTOU: two concurrent `mx` invocations can still both write the same
+normalized content). It is NOT wired to the legacy `content_hash` field
+(title-only, import-time change detection, unenforced) and there is no
+`DEFINE INDEX ... UNIQUE` backing it at the schema level.]
 
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -140,7 +140,11 @@ add --type` (fact-routing), and both lines of `mx memory add-batch`
 (standard and `--type`) -- check a normalized `dedup_hash` of `title+body`
 (lowercase, ASCII punctuation and common Unicode punctuation stripped --
 smart quotes, en/em dash, horizontal ellipsis -- whitespace collapsed)
-against the writing agent's OWN entries in the SAME session before writing.
+against the writing agent's OWN entries in the SAME session AND SAME
+CATEGORY before writing. Category is enforced by scoping the candidate
+query, not by folding it into `dedup_hash` itself -- identical title+body
+re-filed under a different category is a distinct fact (a different shelf),
+never a dedup candidate, so it always lands as its own entry.
 A regenerated duplicate that differs only by case, punctuation, or
 whitespace -- the common shape when an LLM re-derives the same fact across
 turns -- is detected and the write is SKIPPED rather than landing as a
@@ -184,25 +188,32 @@ durably saved, and there is nothing further to do.
   -- the write always wins.
 
 #note[*Coverage boundary, read this before assuming full coverage:* the gate
-catches recased/repunctuated re-adds within the SAME session and SAME owner.
-It does NOT catch: cross-session regenerations (a fact re-derived in a later
-wake under a different `session_id` -- *open question, not yet confirmed:*
-the ~20 double-write pairs (W342–W445) that motivated this feature have not
-been checked against this scope; if most of them are cross-session rather
-than same-session, this fix closes only a minority of the motivating class,
-and owner-scoped matching with a bounded time window would be the sharper
-mechanism -- flagged for follow-up, not resolved here), reworded duplicates
-(different words, same meaning -- e.g. "shipped" vs "published"), a
-public+owned entry vs. a later public+unowned entry with identical content
-(owner is a hard AND-conjoined predicate, so these two visible-to-everyone
-rows never dedup against each other even though both are public), or writes
-with no `session_id` at all (dedup is bypassed entirely when `session_id` is
-absent -- a bypass signal is emitted on EVERY funnel: `"dedup":
-"bypassed_no_session"` in `--json` mode on the standard single-add path
-(mutually exclusive with the stderr note -- json mode never prints both), a
-stderr note on all four funnels in every other mode, so the bypass is never
-silent). Keep marking back captured entries; this is a store-boundary
-backstop, not a substitute for careful write discipline.]
+catches recased/repunctuated re-adds within the SAME session, SAME owner,
+and SAME category. It does NOT catch: cross-session regenerations (a fact
+re-derived in a later wake under a different `session_id` -- *open question,
+not yet confirmed:* the ~20 double-write pairs (W342–W445) that motivated
+this feature have not been checked against this scope; if most of them are
+cross-session rather than same-session, this fix closes only a minority of
+the motivating class, and owner-scoped matching with a bounded time window
+would be the sharper mechanism -- flagged for follow-up, not resolved
+here), reworded duplicates (different words, same meaning -- e.g. "shipped"
+vs "published"), a public+owned entry vs. a later public+unowned entry with
+identical content (owner is a hard AND-conjoined predicate, so these two
+visible-to-everyone rows never dedup against each other even though both
+are public), identical title+body filed under a DIFFERENT category
+(category is a hard AND-conjoined predicate too -- a re-file under a new
+category is treated as a distinct fact, deliberately, never a duplicate),
+identical title+body with DIFFERENT tags (tags are edge-modeled, not a
+scalar field on the row, and are deliberately excluded from the dedup
+identity entirely -- a tag-only-differing re-add still dedupes, same as any
+other identical-content re-add), or writes with no `session_id` at all
+(dedup is bypassed entirely when `session_id` is absent -- a bypass signal
+is emitted on EVERY funnel: `"dedup": "bypassed_no_session"` in `--json`
+mode on the standard single-add path (mutually exclusive with the stderr
+note -- json mode never prints both), a stderr note on all four funnels in
+every other mode, so the bypass is never silent). Keep marking back
+captured entries; this is a store-boundary backstop, not a substitute for
+careful write discipline.]
 
 #note[*In-process, best-effort -- not a database-level uniqueness guarantee.*
 The dedup index is read-then-write within a single `mx` process invocation
@@ -213,11 +224,14 @@ normalized content). It is NOT wired to the legacy `content_hash` field
 `dedup_hash` plus a compound unique index would close the TOCTOU gap and
 make the "store-boundary" framing literally true, at the cost of mapping a
 constraint violation to a skip; this is a design option for a future PR, not
-implemented here. The candidate query has no result limit, so a very
+implemented here -- and, per finding 1, that unique index must key on
+`(session, owner, category, dedup_hash)`, not just `(session, owner,
+dedup_hash)`, to match the same category scope this fix adds to the
+in-process gate. The candidate query has no result limit, so a very
 long-lived session pays an O(n) rehash of every row ever written to its
-`(session, owner)` group on every future write in that group -- bounded in
-practice (memory sessions aren't usually thousands of rows), a follow-up if
-it ever isn't.]
+`(session, owner, category)` group on every future write in that group --
+bounded in practice (memory sessions aren't usually thousands of rows), a
+follow-up if it ever isn't.]
 
 #note[*The write boundary confirms content existence under a claimed
 owner.* A `duplicate_of` hit tells the caller "an entry with this exact

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -126,7 +126,7 @@ per-entry fields (`category`, `title`, `content`, `source_agent`, `tags`,
 `private`, `resonance`, `type`, etc.) on each line. There are no batch-wide
 field overrides except `--no-embed`. This design supports heterogeneous batches
 (facts, person nodes, summaries, blooms) in a single invocation --- which is
-the primary pocket use-case. Per line, `allow_duplicate: true` mirrors
+the primary batch-write use-case. Per line, `allow_duplicate: true` mirrors
 `--allow-duplicate` on the single-add path -- see below.]
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -135,44 +135,101 @@ the primary pocket use-case. Per line, `allow_duplicate: true` mirrors
 
 === Write-boundary deduplication <dedup>
 
-Both write paths (`mx memory add` and `mx memory add-batch`, including its
-`--type`/fact-routing lines) check a normalized `dedup_hash` of `title+body`
-(lowercase, punctuation stripped, whitespace collapsed) against the writing
-agent's OWN entries in the SAME session before writing. A regenerated
-duplicate that differs only by case, punctuation, or whitespace -- the
-common shape when an LLM re-derives the same fact across turns -- is
-detected and the write is SKIPPED rather than landing as a second row.
+All four new-entry write funnels -- `mx memory add` (standard), `mx memory
+add --type` (fact-routing), and both lines of `mx memory add-batch`
+(standard and `--type`) -- check a normalized `dedup_hash` of `title+body`
+(lowercase, ASCII punctuation and common Unicode punctuation stripped --
+smart quotes, en/em dash, horizontal ellipsis -- whitespace collapsed)
+against the writing agent's OWN entries in the SAME session before writing.
+A regenerated duplicate that differs only by case, punctuation, or
+whitespace -- the common shape when an LLM re-derives the same fact across
+turns -- is detected and the write is SKIPPED rather than landing as a
+second row. Title and body are hashed as a length-prefixed pair, so a
+duplicate that shifts the split point (e.g. a sentence folded into the
+title one turn, split title+body the next) is still caught.
 
 A skip is treated as *success, not failure*: it means the content is already
 durably saved, and there is nothing further to do.
 
 - *Plain mode:* `Already saved as kn-XXXX (identical entry this session — nothing to do).`
-- `--json` *mode:* `{"skipped": true, "duplicate_of": "kn-XXXX", "status": "already_persisted", "note": "..."}`,
-  with clean JSON on stdout (no other text) and exit code `0`.
+  Deliberately distinct from the success line (`Added entry: kn-XXXX`) --
+  a caller regexing on `Added entry: (kn-\S+)` should switch to `--json`
+  rather than assume this line matches that pattern.
+- `--json` *mode:* `{"id": "kn-XXXX", "skipped": true, "duplicate_of": "kn-XXXX", "status": "already_persisted", "note": "..."}`,
+  with clean JSON on stdout (no other text) and exit code `0`. `id` mirrors
+  every success payload's `id` key so a caller reading `.id` unconditionally
+  never gets a silent `null` on a skip.
 - *`add-batch` per-entry line:* `[N] Already saved: kn-XXXX (title) — identical this session, no action` --
   never the bare words "skipped" or "duplicate" -- and the batch summary
   carries its own `K already saved (no action needed)` category, separate
-  from `added` and `failed`.
+  from `added` and `failed`. `add-batch` has no `--json` mode, so this is
+  stdout text only.
 - Pass `--allow-duplicate` (single add) or `allow_duplicate: true` (per JSONL
-  line) to force the write through when a re-add is deliberate.
+  line) to force the write through when a re-add is deliberate. *Caveat:* on
+  the fact-routing paths (and on the standard path when `title` is
+  byte-identical to an existing entry's), the write's id is derived from
+  `path_hint:title` (`generate_id`), so a byte-identical forced re-add
+  overwrites the SAME row in place (new `updated_at`, same id) instead of
+  creating a second entry -- `--allow-duplicate` only produces a genuinely
+  distinct row for a recased/reworded near-duplicate, not an exact repeat.
+  This is accepted, not fixed: perturbing the id on a forced write was
+  considered and rejected (it would make `--allow-duplicate` non-idempotent
+  in a different, more surprising way). If you need a second row for
+  byte-identical content, vary the title.
+- On a candidate-lookup failure (a transient DB read blip), the gate FAILS
+  OPEN: it warns to stderr (`--json` mode also gets a
+  `"dedup_lookup_warning"` field) and proceeds with the write rather than
+  aborting it. A dedup mechanism that already tolerates a check-then-write
+  race between two concurrent writers tolerates a lookup blip the same way
+  -- the write always wins.
 
 #note[*Coverage boundary, read this before assuming full coverage:* the gate
 catches recased/repunctuated re-adds within the SAME session and SAME owner.
 It does NOT catch: cross-session regenerations (a fact re-derived in a later
-wake under a different `session_id`), reworded duplicates (different words,
-same meaning -- e.g. "shipped" vs "published"), or writes with no
-`session_id` at all (dedup is bypassed entirely when `session_id` is absent
--- a bypass signal, `"dedup": "bypassed_no_session"`, is emitted in `--json`
-mode, and a stderr note in plain mode, so the bypass is never silent). Keep
-marking back captured entries; this is a store-boundary backstop, not a
-substitute for careful write discipline.]
+wake under a different `session_id` -- *open question, not yet confirmed:*
+the ~20 double-write pairs (W342–W445) that motivated this feature have not
+been checked against this scope; if most of them are cross-session rather
+than same-session, this fix closes only a minority of the motivating class,
+and owner-scoped matching with a bounded time window would be the sharper
+mechanism -- flagged for follow-up, not resolved here), reworded duplicates
+(different words, same meaning -- e.g. "shipped" vs "published"), a
+public+owned entry vs. a later public+unowned entry with identical content
+(owner is a hard AND-conjoined predicate, so these two visible-to-everyone
+rows never dedup against each other even though both are public), or writes
+with no `session_id` at all (dedup is bypassed entirely when `session_id` is
+absent -- a bypass signal is emitted on EVERY funnel: `"dedup":
+"bypassed_no_session"` in `--json` mode on the standard single-add path
+(mutually exclusive with the stderr note -- json mode never prints both), a
+stderr note on all four funnels in every other mode, so the bypass is never
+silent). Keep marking back captured entries; this is a store-boundary
+backstop, not a substitute for careful write discipline.]
 
 #note[*In-process, best-effort -- not a database-level uniqueness guarantee.*
 The dedup index is read-then-write within a single `mx` process invocation
 (TOCTOU: two concurrent `mx` invocations can still both write the same
 normalized content). It is NOT wired to the legacy `content_hash` field
 (title-only, import-time change detection, unenforced) and there is no
-`DEFINE INDEX ... UNIQUE` backing it at the schema level.]
+`DEFINE INDEX ... UNIQUE` backing it at the schema level -- a persisted
+`dedup_hash` plus a compound unique index would close the TOCTOU gap and
+make the "store-boundary" framing literally true, at the cost of mapping a
+constraint violation to a skip; this is a design option for a future PR, not
+implemented here. The candidate query has no result limit, so a very
+long-lived session pays an O(n) rehash of every row ever written to its
+`(session, owner)` group on every future write in that group -- bounded in
+practice (memory sessions aren't usually thousands of rows), a follow-up if
+it ever isn't.]
+
+#note[*The write boundary confirms content existence under a claimed
+owner.* A `duplicate_of` hit tells the caller "an entry with this exact
+normalized content already exists under this owner" -- bounded to the
+pre-existing owner-claim authz (a caller can already assert their own owner
+scope; this exposes no more than that), but it is a new confirmation surface
+worth naming, and it is sharper on `add-batch`: each JSONL line supplies its
+own `source_agent`/`owner`, so one batch invocation can probe many
+owner+content combinations at once. When more than one pre-existing entry
+under a group already shares a hash (only possible from data written before
+this gate existed), `duplicate_of` reports whichever one iteration order
+happens to surface last -- not the earliest or a canonical row.]
 
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -700,6 +700,13 @@ pub enum MemoryCommands {
         /// recased/repunctuated near-duplicate is skipped (exit 0) rather
         /// than written -- this is a deliberate override for an intentional
         /// re-add, not "permission" for an accidental one.
+        ///
+        /// Caveat: entry ids are derived from path/title (`generate_id`), so
+        /// a byte-identical re-add with this flag set overwrites the SAME
+        /// row in place (new `updated_at`, same id) rather than creating a
+        /// second entry -- this only produces a genuinely distinct row for a
+        /// recased/reworded near-duplicate, not an exact repeat. Vary the
+        /// title if you need a second row for identical content.
         #[arg(long)]
         allow_duplicate: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -694,6 +694,14 @@ pub enum MemoryCommands {
         /// Skip synchronous embedding generation on write
         #[arg(long)]
         no_embed: bool,
+
+        /// Write through even if an identical (same session, same owner)
+        /// entry already exists this session. Without this flag, a
+        /// recased/repunctuated near-duplicate is skipped (exit 0) rather
+        /// than written -- this is a deliberate override for an intentional
+        /// re-add, not "permission" for an accidental one.
+        #[arg(long)]
+        allow_duplicate: bool,
     },
 
     /// Update an existing entry in the database

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -1247,6 +1247,33 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     effective_resonance: None,
                 };
 
+                // Write-boundary dedup gate (W447). This single-add `--type`
+                // fact-routing path is a THIRD new-entry write funnel the
+                // round-1/round-2 census missed: it never touches add_one and
+                // never consulted the shared DedupIndex before this fix. Mirror
+                // the batch fact-type gate (below, near :2587) exactly: bind
+                // `entry.owner.as_deref()` (= `agent:{agent_id}`), never the
+                // bare `agent_id`, or the candidate query's owner predicate
+                // returns empty and dedup silently no-ops. Bind `session`
+                // RAW, never the `kn-`-prefixed `session_ref` built below for
+                // the EXTRACTED_FROM edge.
+                if !allow_duplicate {
+                    let mut dedup = DedupIndex::default();
+                    dedup.ensure_group(db.as_ref(), session.as_deref(), entry.owner.as_deref())?;
+                    if let DedupDecision::Duplicate { existing_id } = dedup.check(
+                        session.as_deref(),
+                        entry.owner.as_deref(),
+                        &entry.title,
+                        entry.body.as_deref().unwrap_or(""),
+                    ) {
+                        println!(
+                            "Already saved: {} ({}) — identical this session, no action",
+                            existing_id, entry.title
+                        );
+                        return Ok(());
+                    }
+                }
+
                 // Insert the fact
                 db.upsert_knowledge(&entry)?;
 

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -4500,6 +4500,14 @@ mod dedup_gate_tests {
         ) -> Result<usize> {
             self.inner.count_by_category(category, ctx, filter)
         }
+        fn owned_private_matching(
+            &self,
+            agent: &str,
+            query: Option<&str>,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.owned_private_matching(agent, query, filter)
+        }
         fn list_all(&self, ctx: &AgentContext) -> Result<Vec<knowledge::KnowledgeEntry>> {
             self.inner.list_all(ctx)
         }
@@ -4836,6 +4844,14 @@ mod dedup_gate_tests {
             filter: &store::KnowledgeFilter,
         ) -> Result<usize> {
             self.inner.count_by_category(category, ctx, filter)
+        }
+        fn owned_private_matching(
+            &self,
+            agent: &str,
+            query: Option<&str>,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.owned_private_matching(agent, query, filter)
         }
         fn list_all(&self, ctx: &AgentContext) -> Result<Vec<knowledge::KnowledgeEntry>> {
             self.inner.list_all(ctx)

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -339,6 +339,135 @@ fn write_verification_ctx(
     }
 }
 
+/// Write-boundary dedup decision (W447): either the content is fresh, or a
+/// same-(session, owner) entry with an equal `dedup_hash` already exists.
+enum DedupDecision {
+    Fresh,
+    Duplicate { existing_id: String },
+}
+
+/// In-process, best-effort write-boundary dedup index for a single `mx
+/// memory add` / `add-batch` invocation (W447).
+///
+/// Candidates are fetched from the store LAZILY, one query per distinct
+/// `(session_id, owner)` group actually encountered -- not one per entry.
+/// For the common case (a whole batch sharing one session and one owner,
+/// which is how the pocket writes it) this is exactly one query, satisfying
+/// the "single query per batch" perf goal. For a batch that legitimately
+/// spans multiple sessions and/or owners (add-batch resolves both per line),
+/// this issues one query per distinct group instead of either (a) a single
+/// query that silently mis-scopes every other group, or (b) one query per
+/// entry -- resolving the tension the round-2 panel (Wren/Vale) flagged
+/// between "exactly one query" and correct per-line owner/session scoping.
+///
+/// Keyed by `(session_id, owner, dedup_hash)`: owner is part of the key so a
+/// hash collision under one owner never shadows a distinct write by another
+/// owner (W447 rulings #2); session is part of the key so the same hash in a
+/// DIFFERENT session is never treated as a duplicate.
+///
+/// TOCTOU: read-then-write, per-process, with no DB-level unique constraint
+/// backing it. Two concurrent `mx` invocations can still both write the same
+/// normalized content. Accepted (W447 rulings #8): prevention, not a
+/// store-level uniqueness guarantee.
+#[derive(Default)]
+struct DedupIndex {
+    seen: std::collections::HashMap<(String, Option<String>, String), String>,
+    fetched_groups: std::collections::HashSet<(String, Option<String>)>,
+}
+
+impl DedupIndex {
+    /// Ensure the `(session_id, owner)` group's DB candidates are loaded.
+    /// No query at all when `session_id` is `None` -- dedup is bypassed
+    /// entirely for session-less writes (settled, W447 rulings #6) -- and no
+    /// REPEAT query when the group was already fetched by an earlier line in
+    /// this run.
+    fn ensure_group(
+        &mut self,
+        db: &dyn store::KnowledgeStore,
+        session_id: Option<&str>,
+        owner: Option<&str>,
+    ) -> Result<()> {
+        let Some(sid) = session_id else {
+            return Ok(());
+        };
+        let group = (sid.to_string(), owner.map(String::from));
+        if self.fetched_groups.contains(&group) {
+            return Ok(());
+        }
+        // ctx is only the visibility-filter BACKSTOP -- the hard owner scope
+        // lives in the SQL predicate (`owner = $owner` / `owner IS NONE`).
+        // A `Some(owner)` entry may be private, so ctx must be for_agent(the
+        // SAME owner string) or the private branch of the backstop degrades
+        // to public-only. A `None`-owner row is always public in this
+        // codebase (private writes always set an owner), so public_only()
+        // is correct and honest there -- never a fabricated agent id.
+        let ctx = match owner {
+            Some(o) => store::AgentContext::for_agent(o.to_string()),
+            None => store::AgentContext::public_only(),
+        };
+        let candidates = db.get_entries_for_session(sid, owner, &ctx)?;
+        for c in candidates {
+            let hash = knowledge::dedup_hash(&c.title, &c.body);
+            self.seen
+                .insert((sid.to_string(), owner.map(String::from), hash), c.id);
+        }
+        self.fetched_groups.insert(group);
+        Ok(())
+    }
+
+    /// Check whether `(session_id, owner)` already has an entry whose
+    /// title+body normalizes to the same hash. Always `Fresh` when
+    /// `session_id` is `None` (dedup bypassed by design).
+    fn check(
+        &self,
+        session_id: Option<&str>,
+        owner: Option<&str>,
+        title: &str,
+        body: &str,
+    ) -> DedupDecision {
+        let Some(sid) = session_id else {
+            return DedupDecision::Fresh;
+        };
+        let hash = knowledge::dedup_hash(title, body);
+        let key = (sid.to_string(), owner.map(String::from), hash);
+        match self.seen.get(&key) {
+            Some(existing_id) => DedupDecision::Duplicate {
+                existing_id: existing_id.clone(),
+            },
+            None => DedupDecision::Fresh,
+        }
+    }
+
+    /// Record a just-written entry so LATER lines in the same run dedup
+    /// against it too. Call ONLY after a successful upsert + read-back
+    /// verify -- never on the skip path, never before the write actually
+    /// landed (a poisoned record would drop a real, distinct later write).
+    /// No-op when `session_id` is `None` (nothing to key it by).
+    fn record(
+        &mut self,
+        session_id: Option<&str>,
+        owner: Option<&str>,
+        title: &str,
+        body: &str,
+        id: String,
+    ) {
+        if let Some(sid) = session_id {
+            let hash = knowledge::dedup_hash(title, body);
+            self.seen
+                .insert((sid.to_string(), owner.map(String::from), hash), id);
+        }
+    }
+}
+
+/// Result of [`add_one`]: either the entry was written, or the write-boundary
+/// dedup gate (W447) found a same-owner, same-session match and skipped the
+/// write. `Skipped` is an `Ok` variant, never `Err` -- an `Err` would abort
+/// the whole batch via `?` for what is, by design, a successful no-op.
+enum WriteOutcome {
+    Written(Box<knowledge::KnowledgeEntry>),
+    Skipped { duplicate_of: String },
+}
+
 /// Resolved arguments for a single standard-mode `memory add` write.
 ///
 /// Both the `Add` CLI arm and `AddBatch` JSONL path construct this struct from
@@ -382,12 +511,23 @@ struct AddOneArgs {
 ///                     `write_embed_enabled(no_embed)` from the caller.
 /// `no_auto_anchor`  — passed through to `write_anchor_enabled`; mirrors the
 ///                     same flag on the single-add path.
+/// `dedup`           — write-boundary dedup index (W447), threaded `&mut`
+///                     across a whole add/add-batch run so later lines
+///                     dedup against earlier ones too.
+/// `allow_duplicate` — caller's explicit override (`--allow-duplicate` /
+///                     JSONL `allow_duplicate`); when `true` the dedup gate
+///                     is bypassed entirely for this write (no check, no
+///                     record -- the write is not offered as a future
+///                     dedup candidate either, since the caller asked for it
+///                     deliberately).
 fn add_one(
     args: AddOneArgs,
     db: &dyn store::KnowledgeStore,
     embed: bool,
     no_auto_anchor: bool,
-) -> Result<knowledge::KnowledgeEntry> {
+    dedup: &mut DedupIndex,
+    allow_duplicate: bool,
+) -> Result<WriteOutcome> {
     let path_hint = args.domain.unwrap_or_else(|| args.category.clone());
     let id = knowledge::KnowledgeEntry::generate_id(&path_hint, &args.title);
     let now = chrono::Utc::now().to_rfc3339();
@@ -430,6 +570,22 @@ fn add_one(
         format: "markdown".to_string(),
         effective_resonance: None,
     };
+
+    // Write-boundary dedup gate (W447). Runs BEFORE any side effect (upsert,
+    // edge, embed, anchor) so a skip is a true no-op -- not a partial write.
+    if !allow_duplicate {
+        dedup.ensure_group(db, args.session_id.as_deref(), args.entry_owner.as_deref())?;
+        if let DedupDecision::Duplicate { existing_id } = dedup.check(
+            args.session_id.as_deref(),
+            args.entry_owner.as_deref(),
+            &args.title,
+            &args.body,
+        ) {
+            return Ok(WriteOutcome::Skipped {
+                duplicate_of: existing_id,
+            });
+        }
+    }
 
     // Insert into database.
     db.upsert_knowledge(&entry)?;
@@ -481,7 +637,19 @@ fn add_one(
         println!("  (auto-anchor skipped)");
     }
 
-    Ok(entry)
+    // Record AFTER the write is durable and verified -- never before, and
+    // never on the skip path above (which returns early).
+    if !allow_duplicate {
+        dedup.record(
+            args.session_id.as_deref(),
+            args.entry_owner.as_deref(),
+            &args.title,
+            &args.body,
+            id.clone(),
+        );
+    }
+
+    Ok(WriteOutcome::Written(Box::new(entry)))
 }
 
 pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
@@ -901,6 +1069,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             thread_id,
             no_auto_anchor,
             no_embed,
+            allow_duplicate,
         } => {
             use anyhow::Context;
             use std::fs;
@@ -1230,7 +1399,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
             // Delegate to the shared single-entry write path. Both `Add` and
             // `AddBatch` route through `add_one` so the write contract (insert,
             // verify, edge, embed, anchor) stays in one place.
-            let entry = add_one(
+            let mut dedup = DedupIndex::default();
+            let outcome = add_one(
                 AddOneArgs {
                     agent_id: agent_id.clone(),
                     category: category.clone(),
@@ -1258,29 +1428,65 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 db.as_ref(),
                 write_embed_enabled(no_embed),
                 no_auto_anchor,
+                &mut dedup,
+                allow_duplicate,
             )?;
+
+            // Skip = success, not failure: an identical entry already exists
+            // this session, so there is nothing to write and nothing wrong.
+            let entry = match outcome {
+                WriteOutcome::Written(e) => e,
+                WriteOutcome::Skipped { duplicate_of } => {
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "skipped": true,
+                                "duplicate_of": duplicate_of,
+                                "status": "already_persisted",
+                                "note": "identical entry exists this session; no write needed",
+                            }))?
+                        );
+                    } else {
+                        println!(
+                            "Already saved as {} (identical entry this session — nothing to do).",
+                            duplicate_of
+                        );
+                    }
+                    return Ok(());
+                }
+            };
+
+            // W447 rulings #6: session_id=None bypasses dedup entirely with no
+            // candidate query. Surface that bypass rather than let a silent
+            // "the store dedups now" assumption creep in for session-less
+            // writes. Stderr only -- never pollutes --json stdout.
+            if entry.session_id.is_none() {
+                eprintln!("  (dedup bypassed: no --session-id provided)");
+            }
 
             let id = entry.id.clone();
 
             if json {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&serde_json::json!({
-                        "id": id,
-                        "category": category,
-                        "title": title,
-                        "visibility": entry_visibility,
-                        "owner": entry_owner,
-                        "resonance": entry.resonance,
-                        "resonance_type": entry.resonance_type,
-                        "tags": entry.tags,
-                        "applicability": entry.applicability,
-                        "anchors": entry.anchors,
-                        "wake_phrase": entry.wake_phrase,
-                        "wake_phrases": entry.wake_phrases,
-                        "triggers": entry.triggers,
-                    }))?
-                );
+                let mut payload = serde_json::json!({
+                    "id": id,
+                    "category": category,
+                    "title": title,
+                    "visibility": entry_visibility,
+                    "owner": entry_owner,
+                    "resonance": entry.resonance,
+                    "resonance_type": entry.resonance_type,
+                    "tags": entry.tags,
+                    "applicability": entry.applicability,
+                    "anchors": entry.anchors,
+                    "wake_phrase": entry.wake_phrase,
+                    "wake_phrases": entry.wake_phrases,
+                    "triggers": entry.triggers,
+                });
+                if entry.session_id.is_none() {
+                    payload["dedup"] = serde_json::json!("bypassed_no_session");
+                }
+                println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
                 println!("Added entry: {}", id);
                 println!("  Category: {}", category);
@@ -2237,6 +2443,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             let mut added_ids: Vec<String> = Vec::new();
             let mut entry_errors: Vec<(usize, String)> = Vec::new();
+            let mut skipped_count: usize = 0;
+            // Write-boundary dedup (W447), threaded across the whole batch so
+            // later lines dedup against earlier ones. See `DedupIndex` --
+            // fetches lazily, one query per distinct (session, owner) group.
+            let mut dedup = DedupIndex::default();
 
             for (line_idx, raw) in lines.iter().enumerate() {
                 let raw = raw.trim();
@@ -2384,6 +2595,37 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         effective_resonance: None,
                     };
 
+                    // Write-boundary dedup gate (W447). This inline fact-type
+                    // path is the funnel round-1 missed: it never touches
+                    // add_one, so it needs its OWN gate, immediately before
+                    // the upsert, with the SAME shared DedupIndex.
+                    let allow_duplicate = bool_field("allow_duplicate");
+                    if !allow_duplicate {
+                        if let Err(e) = dedup.ensure_group(
+                            db.as_ref(),
+                            session.as_deref(),
+                            entry.owner.as_deref(),
+                        ) {
+                            entry_errors.push((line_idx + 1, format!("dedup lookup error: {}", e)));
+                            continue;
+                        }
+                        if let DedupDecision::Duplicate { existing_id } = dedup.check(
+                            session.as_deref(),
+                            entry.owner.as_deref(),
+                            &entry.title,
+                            entry.body.as_deref().unwrap_or(""),
+                        ) {
+                            println!(
+                                "  [{}] Already saved: {} ({}) — identical this session, no action",
+                                line_idx + 1,
+                                existing_id,
+                                entry.title
+                            );
+                            skipped_count += 1;
+                            continue;
+                        }
+                    }
+
                     match db.upsert_knowledge(&entry) {
                         Ok(_) => {}
                         Err(e) => {
@@ -2407,6 +2649,17 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                             entry_errors.push((line_idx + 1, format!("read-back error: {}", e)));
                             continue;
                         }
+                    }
+
+                    // Record AFTER the write is durable and verified.
+                    if !allow_duplicate {
+                        dedup.record(
+                            session.as_deref(),
+                            entry.owner.as_deref(),
+                            &entry.title,
+                            entry.body.as_deref().unwrap_or(""),
+                            id.clone(),
+                        );
                     }
 
                     // EXTRACTED_FROM edge if session provided
@@ -2620,12 +2873,23 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         db.as_ref(),
                         false, // embed=false — hoisted pass below embeds all at once
                         true,  // no_auto_anchor=true — batch anchoring via nightly run
+                        &mut dedup,
+                        bool_field("allow_duplicate"),
                     );
 
                     match entry_result {
-                        Ok(entry) => {
+                        Ok(WriteOutcome::Written(entry)) => {
                             println!("  [{}] Added entry: {} ({})", line_idx + 1, entry.id, title);
                             added_ids.push(entry.id);
+                        }
+                        Ok(WriteOutcome::Skipped { duplicate_of }) => {
+                            println!(
+                                "  [{}] Already saved: {} ({}) — identical this session, no action",
+                                line_idx + 1,
+                                duplicate_of,
+                                title
+                            );
+                            skipped_count += 1;
                         }
                         Err(e) => {
                             entry_errors.push((line_idx + 1, format!("write error: {}", e)));
@@ -2676,10 +2940,13 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 );
             }
 
-            // Summary
+            // Summary. Skips get their OWN reassuring category, never folded
+            // into "failed" -- a duplicate-skip is a successful no-op, not
+            // an error (W447).
             println!(
-                "\nBatch complete: {} added, {} failed.",
+                "\nBatch complete: {} added, {} already saved (no action needed), {} failed.",
                 added_ids.len(),
+                skipped_count,
                 entry_errors.len()
             );
 
@@ -3903,6 +4170,642 @@ mod write_verification_tests {
         assert!(
             db.get("kn-never-written", &ctx).unwrap().is_none(),
             "an absent entry must read back None so the handler bails loudly"
+        );
+    }
+}
+
+#[cfg(test)]
+mod dedup_gate_tests {
+    use super::*;
+    use crate::store::{AgentContext, DedupCandidate, KnowledgeStore};
+    use crate::surreal_db::SurrealDatabase;
+    use std::cell::Cell;
+
+    /// Wraps a real in-memory SurrealDB store and counts
+    /// `get_entries_for_session` calls. Every OTHER method is a straight
+    /// pass-through to the real store -- this is real-store correctness plus
+    /// one counter, not a mock of the logic under test. Proves the batch
+    /// dedup gate issues ONE query per distinct `(session, owner)` group,
+    /// not one per entry (W447 acceptance gate).
+    struct CountingStore {
+        inner: Box<dyn KnowledgeStore>,
+        calls: Cell<usize>,
+    }
+
+    impl CountingStore {
+        fn new() -> Self {
+            Self {
+                inner: Box::new(SurrealDatabase::open_in_memory().unwrap()),
+                calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl KnowledgeStore for CountingStore {
+        fn upsert_knowledge(&self, entry: &knowledge::KnowledgeEntry) -> Result<()> {
+            self.inner.upsert_knowledge(entry)
+        }
+        fn get(&self, id: &str, ctx: &AgentContext) -> Result<Option<knowledge::KnowledgeEntry>> {
+            self.inner.get(id, ctx)
+        }
+        fn delete(&self, id: &str, ctx: &AgentContext) -> Result<bool> {
+            self.inner.delete(id, ctx)
+        }
+        fn search(
+            &self,
+            query: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.search(query, ctx, filter)
+        }
+        fn semantic_search(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+            limit: usize,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner
+                .semantic_search(query_embedding, ctx, filter, limit)
+        }
+        fn semantic_search_scored(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+            limit: usize,
+        ) -> Result<Vec<(knowledge::KnowledgeEntry, f32)>> {
+            self.inner
+                .semantic_search_scored(query_embedding, ctx, filter, limit)
+        }
+        fn semantic_search_entries_scored(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            limit: usize,
+        ) -> Result<Vec<(knowledge::KnowledgeEntry, f32)>> {
+            self.inner
+                .semantic_search_entries_scored(query_embedding, ctx, limit)
+        }
+        fn list_by_category(
+            &self,
+            category: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.list_by_category(category, ctx, filter)
+        }
+        fn count_by_category(
+            &self,
+            category: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<usize> {
+            self.inner.count_by_category(category, ctx, filter)
+        }
+        fn list_all(&self, ctx: &AgentContext) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.list_all(ctx)
+        }
+        fn list_with_triggers(&self, ctx: &AgentContext) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.list_with_triggers(ctx)
+        }
+        fn count(&self) -> Result<usize> {
+            self.inner.count()
+        }
+        fn wake_cascade(
+            &self,
+            ctx: &AgentContext,
+            limit: usize,
+            min_resonance: Option<i32>,
+            days: i64,
+        ) -> Result<store::WakeCascade> {
+            self.inner.wake_cascade(ctx, limit, min_resonance, days)
+        }
+        fn update_activations(&self, ids: &[String]) -> Result<()> {
+            self.inner.update_activations(ids)
+        }
+        fn update_summary(&self, id: &str, summary: &str, ctx: &AgentContext) -> Result<bool> {
+            self.inner.update_summary(id, summary, ctx)
+        }
+        fn apply_update(
+            &self,
+            id: &str,
+            spec: &crate::store_update::UpdateSpec,
+            ctx: &AgentContext,
+        ) -> Result<crate::store_update::UpdateOutcome> {
+            self.inner.apply_update(id, spec, ctx)
+        }
+        fn increment_activation_count(&self, ids: &[String]) -> Result<()> {
+            self.inner.increment_activation_count(ids)
+        }
+        fn query_recent_facts(&self, days: i32) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.query_recent_facts(days)
+        }
+        fn query_recent_facts_all_types(
+            &self,
+            days: i32,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.query_recent_facts_all_types(days)
+        }
+        fn reinforce(
+            &self,
+            id: &str,
+            amount: i32,
+            cap: Option<i32>,
+            ctx: &AgentContext,
+        ) -> Result<Option<store::ReinforcementResult>> {
+            self.inner.reinforce(id, amount, cap, ctx)
+        }
+        fn delete_embedding_chunks(&self, entry_id: &str) -> Result<()> {
+            self.inner.delete_embedding_chunks(entry_id)
+        }
+        fn insert_embedding_chunk(
+            &self,
+            entry_id: &str,
+            chunk_index: usize,
+            chunk_text: &str,
+            token_offset: usize,
+            token_count: usize,
+            embedding: &[f32],
+            model_id: &str,
+        ) -> Result<()> {
+            self.inner.insert_embedding_chunk(
+                entry_id,
+                chunk_index,
+                chunk_text,
+                token_offset,
+                token_count,
+                embedding,
+                model_id,
+            )
+        }
+        fn semantic_search_chunks(
+            &self,
+            query_embedding: &[f32],
+            limit: usize,
+        ) -> Result<Vec<(String, f32)>> {
+            self.inner.semantic_search_chunks(query_embedding, limit)
+        }
+        fn edit_content(
+            &self,
+            id: &str,
+            ctx: &AgentContext,
+            old_text: &str,
+            new_text: &str,
+            replace_all: bool,
+            nth: Option<usize>,
+        ) -> Result<store::EditResult> {
+            self.inner
+                .edit_content(id, ctx, old_text, new_text, replace_all, nth)
+        }
+        fn append_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()> {
+            self.inner.append_content(id, ctx, content)
+        }
+        fn prepend_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()> {
+            self.inner.prepend_content(id, ctx, content)
+        }
+        fn backup_content(
+            &self,
+            entry: &knowledge::KnowledgeEntry,
+            operation: &str,
+            agent: Option<&str>,
+        ) -> Result<String> {
+            self.inner.backup_content(entry, operation, agent)
+        }
+        fn list_backups(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
+            self.inner.list_backups(entry_id)
+        }
+        fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>> {
+            self.inner.latest_backup(entry_id)
+        }
+        fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<()> {
+            self.inner.purge_backups(entry_id, keep)
+        }
+        fn get_tags_for_entry(&self, entry_id: &str) -> Result<Vec<String>> {
+            self.inner.get_tags_for_entry(entry_id)
+        }
+        fn set_tags_for_entry(&self, entry_id: &str, tags: &[String]) -> Result<()> {
+            self.inner.set_tags_for_entry(entry_id, tags)
+        }
+        fn list_all_tags(&self, category: Option<&str>) -> Result<Vec<String>> {
+            self.inner.list_all_tags(category)
+        }
+        fn get_applicability_for_entry(&self, entry_id: &str) -> Result<Vec<String>> {
+            self.inner.get_applicability_for_entry(entry_id)
+        }
+        fn set_applicability_for_entry(&self, entry_id: &str, ids: &[String]) -> Result<()> {
+            self.inner.set_applicability_for_entry(entry_id, ids)
+        }
+        fn list_applicability_types(&self) -> Result<Vec<crate::types::ApplicabilityType>> {
+            self.inner.list_applicability_types()
+        }
+        fn upsert_applicability_type(&self, atype: &crate::types::ApplicabilityType) -> Result<()> {
+            self.inner.upsert_applicability_type(atype)
+        }
+        fn list_categories(&self) -> Result<Vec<crate::types::Category>> {
+            self.inner.list_categories()
+        }
+        fn get_category(&self, id: &str) -> Result<Option<crate::types::Category>> {
+            self.inner.get_category(id)
+        }
+        fn upsert_category(&self, category: &crate::types::Category) -> Result<()> {
+            self.inner.upsert_category(category)
+        }
+        fn delete_category(&self, id: &str) -> Result<bool> {
+            self.inner.delete_category(id)
+        }
+        fn list_projects(&self, active_only: bool) -> Result<Vec<crate::types::Project>> {
+            self.inner.list_projects(active_only)
+        }
+        fn get_project(&self, id: &str) -> Result<Option<crate::types::Project>> {
+            self.inner.get_project(id)
+        }
+        fn upsert_project(&self, project: &crate::types::Project) -> Result<()> {
+            self.inner.upsert_project(project)
+        }
+        fn get_tags_for_project(&self, project_id: &str) -> Result<Vec<String>> {
+            self.inner.get_tags_for_project(project_id)
+        }
+        fn set_tags_for_project(&self, project_id: &str, tags: &[String]) -> Result<()> {
+            self.inner.set_tags_for_project(project_id, tags)
+        }
+        fn get_applicability_for_project(&self, project_id: &str) -> Result<Vec<String>> {
+            self.inner.get_applicability_for_project(project_id)
+        }
+        fn set_applicability_for_project(&self, project_id: &str, ids: &[String]) -> Result<()> {
+            self.inner.set_applicability_for_project(project_id, ids)
+        }
+        fn list_agents(&self) -> Result<Vec<crate::types::Agent>> {
+            self.inner.list_agents()
+        }
+        fn get_agent(&self, id: &str) -> Result<Option<crate::types::Agent>> {
+            self.inner.get_agent(id)
+        }
+        fn upsert_agent(&self, agent: &crate::types::Agent) -> Result<()> {
+            self.inner.upsert_agent(agent)
+        }
+        fn list_relationships_for_entry(
+            &self,
+            entry_id: &str,
+        ) -> Result<Vec<crate::types::Relationship>> {
+            self.inner.list_relationships_for_entry(entry_id)
+        }
+        fn add_relationship(&self, from: &str, to: &str, rel_type: &str) -> Result<String> {
+            self.inner.add_relationship(from, to, rel_type)
+        }
+        fn delete_relationship(&self, id: &str) -> Result<bool> {
+            self.inner.delete_relationship(id)
+        }
+        fn get_facts_for_session(&self, session_id: &str) -> Result<Vec<String>> {
+            self.inner.get_facts_for_session(session_id)
+        }
+        fn get_entries_for_session(
+            &self,
+            session_id: &str,
+            owner: Option<&str>,
+            ctx: &AgentContext,
+        ) -> Result<Vec<DedupCandidate>> {
+            self.calls.set(self.calls.get() + 1);
+            self.inner.get_entries_for_session(session_id, owner, ctx)
+        }
+        fn get_session_for_fact(&self, fact_id: &str) -> Result<Option<String>> {
+            self.inner.get_session_for_fact(fact_id)
+        }
+        fn list_sessions(&self, project_id: Option<&str>) -> Result<Vec<crate::types::Session>> {
+            self.inner.list_sessions(project_id)
+        }
+        fn get_session(&self, id: &str) -> Result<Option<crate::types::Session>> {
+            self.inner.get_session(id)
+        }
+        fn upsert_session(&self, session: &crate::types::Session) -> Result<()> {
+            self.inner.upsert_session(session)
+        }
+        fn list_source_types(&self) -> Result<Vec<crate::types::SourceType>> {
+            self.inner.list_source_types()
+        }
+        fn list_entry_types(&self) -> Result<Vec<crate::types::EntryType>> {
+            self.inner.list_entry_types()
+        }
+        fn list_content_types(&self) -> Result<Vec<crate::types::ContentType>> {
+            self.inner.list_content_types()
+        }
+        fn list_session_types(&self) -> Result<Vec<crate::types::SessionType>> {
+            self.inner.list_session_types()
+        }
+        fn list_relationship_types(&self) -> Result<Vec<crate::types::RelationshipType>> {
+            self.inner.list_relationship_types()
+        }
+        fn create_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<String> {
+            self.inner.create_wake_session(session)
+        }
+        fn get_wake_session(
+            &self,
+            session_id: &str,
+        ) -> Result<Option<crate::wake_token::WakeSession>> {
+            self.inner.get_wake_session(session_id)
+        }
+        fn update_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<()> {
+            self.inner.update_wake_session(session)
+        }
+        fn delete_wake_session(&self, session_id: &str) -> Result<()> {
+            self.inner.delete_wake_session(session_id)
+        }
+        fn sweep_ghost_anchors(&self, dry_run: bool) -> Result<store::GhostSweepResult> {
+            self.inner.sweep_ghost_anchors(dry_run)
+        }
+        fn list_tables(&self) -> Result<Vec<String>> {
+            self.inner.list_tables()
+        }
+    }
+
+    fn one_line_args(
+        agent: &str,
+        owner: Option<&str>,
+        category: &str,
+        title: &str,
+        body: &str,
+        session_id: Option<&str>,
+    ) -> AddOneArgs {
+        AddOneArgs {
+            agent_id: agent.to_string(),
+            category: category.to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            tag_list: vec![],
+            applicability_list: vec![],
+            anchor_list: vec![],
+            trigger_list: vec![],
+            wake_phrase_list: vec![],
+            wake_phrase: None,
+            wake_order: None,
+            entry_visibility: "public".to_string(),
+            entry_owner: owner.map(String::from),
+            session_id: session_id.map(String::from),
+            ephemeral: false,
+            source_type: "manual".to_string(),
+            entry_type: "primary".to_string(),
+            content_type: "text".to_string(),
+            domain: None,
+            resonance: 0,
+            resonance_type: None,
+            project: None,
+        }
+    }
+
+    #[test]
+    fn standard_path_recased_duplicate_is_skipped_with_duplicate_of() {
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        let first = add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "test",
+                "The External Plan",
+                "Ship it.",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        let first_id = match first {
+            WriteOutcome::Written(e) => e.id,
+            WriteOutcome::Skipped { .. } => panic!("first write must not be a duplicate"),
+        };
+
+        let second = add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "test",
+                "the external plan",
+                "ship it.",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+
+        match second {
+            WriteOutcome::Written(_) => panic!("recased re-add must be skipped, not written"),
+            WriteOutcome::Skipped { duplicate_of } => assert_eq!(duplicate_of, first_id),
+        }
+    }
+
+    #[test]
+    fn allow_duplicate_forces_the_write_through() {
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "test",
+                "Title",
+                "Body text.",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+
+        let forced = add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "test",
+                "Title Two",
+                "Body text.",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            true, // allow_duplicate
+        )
+        .unwrap();
+
+        assert!(
+            matches!(forced, WriteOutcome::Written(_)),
+            "--allow-duplicate must force the write through even for identical body text"
+        );
+    }
+
+    #[test]
+    fn session_id_none_bypasses_dedup_with_no_candidate_query() {
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        add_one(
+            one_line_args("agent-a", None, "test", "Title", "Body.", None),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        add_one(
+            // recased, still no session_id
+            one_line_args("agent-a", None, "test", "title", "body.", None),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            db.calls.get(),
+            0,
+            "session_id=None must never issue a get_entries_for_session query"
+        );
+    }
+
+    #[test]
+    fn one_query_per_distinct_session_owner_group_not_per_entry() {
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        // Three entries, same (session, owner) group -- one query total.
+        for i in 0..3 {
+            add_one(
+                one_line_args(
+                    "agent-a",
+                    None,
+                    "test",
+                    &format!("Title {i}"),
+                    &format!("Body {i}"),
+                    Some("sess-1"),
+                ),
+                &db,
+                false,
+                true,
+                &mut dedup,
+                false,
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            db.calls.get(),
+            1,
+            "a single-session single-owner batch must issue exactly one get_entries_for_session call"
+        );
+
+        // A second, distinct owner in the SAME session: one MORE query for
+        // the new group (not zero -- which would silently skip owner-B's
+        // candidates -- and not one-per-entry).
+        add_one(
+            one_line_args(
+                "agent-b",
+                Some("agent-b"),
+                "test",
+                "Owner B Title",
+                "Owner B body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            db.calls.get(),
+            2,
+            "a second distinct owner in the same session must trigger exactly one more query"
+        );
+
+        // A recased duplicate for owner B must be caught by owner B's OWN
+        // fetched group, without re-querying for owner A's group and
+        // without cross-owner shadowing.
+        let dup_b = add_one(
+            one_line_args(
+                "agent-b",
+                Some("agent-b"),
+                "test",
+                "owner b title",
+                "owner b body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(matches!(dup_b, WriteOutcome::Skipped { .. }));
+        assert_eq!(
+            db.calls.get(),
+            2,
+            "a cached group must not trigger a repeat query"
+        );
+    }
+
+    #[test]
+    fn cross_owner_public_entry_is_not_a_dedup_candidate() {
+        // RIFT: two owners writing normalized-identical content in the same
+        // session must both land -- a same-hash PUBLIC row from a different
+        // owner must never cause a false-positive skip or leak its id.
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        let a = add_one(
+            one_line_args(
+                "agent-a",
+                Some("agent-a"),
+                "test",
+                "Shared Title",
+                "Shared body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(matches!(a, WriteOutcome::Written(_)));
+
+        let b = add_one(
+            one_line_args(
+                "agent-b",
+                Some("agent-b"),
+                "test",
+                "Shared Title",
+                "Shared body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(
+            matches!(b, WriteOutcome::Written(_)),
+            "agent-b's identical-text entry must land, not be skipped against agent-a's row"
         );
     }
 }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -352,13 +352,13 @@ enum DedupDecision {
 /// Candidates are fetched from the store LAZILY, one query per distinct
 /// `(session_id, owner)` group actually encountered -- not one per entry.
 /// For the common case (a whole batch sharing one session and one owner,
-/// which is how the pocket writes it) this is exactly one query, satisfying
+/// which is how batch callers write it) this is exactly one query, satisfying
 /// the "single query per batch" perf goal. For a batch that legitimately
 /// spans multiple sessions and/or owners (add-batch resolves both per line),
 /// this issues one query per distinct group instead of either (a) a single
 /// query that silently mis-scopes every other group, or (b) one query per
-/// entry -- resolving the tension the round-2 panel (Wren/Vale) flagged
-/// between "exactly one query" and correct per-line owner/session scoping.
+/// entry -- resolving the tension flagged in review between "exactly one
+/// query" and correct per-line owner/session scoping.
 ///
 /// Keyed by `(session_id, owner, dedup_hash)`: owner is part of the key so a
 /// hash collision under one owner never shadows a distinct write by another
@@ -369,6 +369,14 @@ enum DedupDecision {
 /// backing it. Two concurrent `mx` invocations can still both write the same
 /// normalized content. Accepted (W447 rulings #8): prevention, not a
 /// store-level uniqueness guarantee.
+///
+/// `seen` is a `HashMap`, so if the DB already holds MULTIPLE pre-existing
+/// rows sharing one normalized hash under the same group (only reachable
+/// from data written before this gate existed, or from legacy
+/// pre-`dedup_hash` duplicates), only the last one iterated in
+/// `ensure_group` survives and is reported as `duplicate_of` -- whichever
+/// one that is is incidental to query order, not the earliest or a
+/// canonical row.
 #[derive(Default)]
 struct DedupIndex {
     seen: std::collections::HashMap<(String, Option<String>, String), String>,
@@ -401,6 +409,16 @@ impl DedupIndex {
         // to public-only. A `None`-owner row is always public in this
         // codebase (private writes always set an owner), so public_only()
         // is correct and honest there -- never a fabricated agent id.
+        //
+        // Honest disclosure (PR #402, extended fix-round): this queries the
+        // store AS the caller-supplied `owner`, so a `Duplicate` hit is a
+        // content-existence oracle under a claimed owner -- bounded to the
+        // pre-existing owner-claim authz (a caller can already assert their
+        // own owner scope; this exposes no more than that), but it's a new
+        // confirmation surface. `add-batch`'s per-line `source_agent` makes
+        // this sharper in practice, not different in kind: one batch
+        // invocation can probe many owner+content combinations at once,
+        // where a single add only probes one.
         let ctx = match owner {
             Some(o) => store::AgentContext::for_agent(o.to_string()),
             None => store::AgentContext::public_only(),
@@ -459,12 +477,84 @@ impl DedupIndex {
     }
 }
 
+/// Why [`dedup_gate`] let a write proceed, so callers can surface the right
+/// signal (bypass note / lookup warning) without re-deriving it from raw
+/// args. `Fresh` and `AllowDuplicate` need no signal; `NoSession` and
+/// `LookupFailed` do.
+#[derive(Debug)]
+enum DedupProceedReason {
+    /// No matching hash found in the candidate group.
+    Fresh,
+    /// `--allow-duplicate` bypassed the gate entirely -- no check, no query.
+    AllowDuplicate,
+    /// `session_id` is `None`: dedup is bypassed by design, no candidate
+    /// query issued (W447 rulings #6). Callers surface this so a
+    /// session-less write is never silently assumed to have been deduped.
+    NoSession,
+    /// `ensure_group`'s candidate lookup failed and the gate failed OPEN
+    /// (fix-round review, finding 2): a transient read blip must not cost a
+    /// write that would otherwise succeed, since the gate already tolerates
+    /// a TOCTOU race between two concurrent writers -- a dedup mechanism
+    /// that tolerates a race can tolerate a read blip too. The write
+    /// proceeds uncontested; `msg` is the stringified lookup error so
+    /// callers can surface it (stderr always -- `dedup_gate` itself already
+    /// warns -- and a json field where the output is json).
+    LookupFailed { msg: String },
+}
+
+/// Outcome of the write-boundary dedup gate (W447 + fix-round).
+enum DedupGate {
+    Proceed(DedupProceedReason),
+    Skip { duplicate_of: String },
+}
+
+/// Run the write-boundary dedup gate: ensure the `(session, owner)`
+/// candidate group is loaded, then check title+body against it. This is the
+/// ONE place all three new-entry write funnels -- `add_one`'s standard path,
+/// the single-add `--type` fact path, and the batch inline fact path --
+/// make the dedup decision (fix-round review, structural finding: the gate
+/// was hand-rolled at three call sites with drifting bypass-signal and
+/// fail-open/fail-closed behavior between them). A fourth funnel now has to
+/// edit this function to diverge, not just forget to copy a change.
+///
+/// Fails OPEN on a lookup error (finding 2): logs a warning to stderr and
+/// returns `Proceed`, never aborts the write via `?`.
+fn dedup_gate(
+    dedup: &mut DedupIndex,
+    db: &dyn store::KnowledgeStore,
+    session_id: Option<&str>,
+    owner: Option<&str>,
+    title: &str,
+    body: &str,
+    allow_duplicate: bool,
+) -> DedupGate {
+    if allow_duplicate {
+        return DedupGate::Proceed(DedupProceedReason::AllowDuplicate);
+    }
+    if session_id.is_none() {
+        return DedupGate::Proceed(DedupProceedReason::NoSession);
+    }
+    if let Err(e) = dedup.ensure_group(db, session_id, owner) {
+        let msg = e.to_string();
+        eprintln!(
+            "Warning: dedup candidate lookup failed ({msg}) -- proceeding with the write (fail-open)"
+        );
+        return DedupGate::Proceed(DedupProceedReason::LookupFailed { msg });
+    }
+    match dedup.check(session_id, owner, title, body) {
+        DedupDecision::Duplicate { existing_id } => DedupGate::Skip {
+            duplicate_of: existing_id,
+        },
+        DedupDecision::Fresh => DedupGate::Proceed(DedupProceedReason::Fresh),
+    }
+}
+
 /// Result of [`add_one`]: either the entry was written, or the write-boundary
 /// dedup gate (W447) found a same-owner, same-session match and skipped the
 /// write. `Skipped` is an `Ok` variant, never `Err` -- an `Err` would abort
 /// the whole batch via `?` for what is, by design, a successful no-op.
 enum WriteOutcome {
-    Written(Box<knowledge::KnowledgeEntry>),
+    Written(Box<knowledge::KnowledgeEntry>, DedupProceedReason),
     Skipped { duplicate_of: String },
 }
 
@@ -573,19 +663,20 @@ fn add_one(
 
     // Write-boundary dedup gate (W447). Runs BEFORE any side effect (upsert,
     // edge, embed, anchor) so a skip is a true no-op -- not a partial write.
-    if !allow_duplicate {
-        dedup.ensure_group(db, args.session_id.as_deref(), args.entry_owner.as_deref())?;
-        if let DedupDecision::Duplicate { existing_id } = dedup.check(
-            args.session_id.as_deref(),
-            args.entry_owner.as_deref(),
-            &args.title,
-            &args.body,
-        ) {
-            return Ok(WriteOutcome::Skipped {
-                duplicate_of: existing_id,
-            });
+    let proceed_reason = match dedup_gate(
+        dedup,
+        db,
+        args.session_id.as_deref(),
+        args.entry_owner.as_deref(),
+        &args.title,
+        &args.body,
+        allow_duplicate,
+    ) {
+        DedupGate::Skip { duplicate_of } => {
+            return Ok(WriteOutcome::Skipped { duplicate_of });
         }
-    }
+        DedupGate::Proceed(reason) => reason,
+    };
 
     // Insert into database.
     db.upsert_knowledge(&entry)?;
@@ -649,7 +740,7 @@ fn add_one(
         );
     }
 
-    Ok(WriteOutcome::Written(Box::new(entry)))
+    Ok(WriteOutcome::Written(Box::new(entry), proceed_reason))
 }
 
 pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
@@ -1248,29 +1339,43 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 };
 
                 // Write-boundary dedup gate (W447). This single-add `--type`
-                // fact-routing path is a THIRD new-entry write funnel the
-                // round-1/round-2 census missed: it never touches add_one and
-                // never consulted the shared DedupIndex before this fix. Mirror
-                // the batch fact-type gate (below, near :2587) exactly: bind
+                // fact-routing path is a THIRD new-entry write funnel earlier
+                // review passes missed: it never touches add_one and
+                // never consulted the shared DedupIndex before this fix.
+                // Routed through the shared `dedup_gate` (fix-round
+                // structural finding) rather than hand-rolled here: bind
                 // `entry.owner.as_deref()` (= `agent:{agent_id}`), never the
                 // bare `agent_id`, or the candidate query's owner predicate
                 // returns empty and dedup silently no-ops. Bind `session`
                 // RAW, never the `kn-`-prefixed `session_ref` built below for
                 // the EXTRACTED_FROM edge.
-                if !allow_duplicate {
-                    let mut dedup = DedupIndex::default();
-                    dedup.ensure_group(db.as_ref(), session.as_deref(), entry.owner.as_deref())?;
-                    if let DedupDecision::Duplicate { existing_id } = dedup.check(
-                        session.as_deref(),
-                        entry.owner.as_deref(),
-                        &entry.title,
-                        entry.body.as_deref().unwrap_or(""),
-                    ) {
+                let mut dedup = DedupIndex::default();
+                match dedup_gate(
+                    &mut dedup,
+                    db.as_ref(),
+                    session.as_deref(),
+                    entry.owner.as_deref(),
+                    &entry.title,
+                    entry.body.as_deref().unwrap_or(""),
+                    allow_duplicate,
+                ) {
+                    DedupGate::Skip { duplicate_of } => {
                         println!(
                             "Already saved: {} ({}) — identical this session, no action",
-                            existing_id, entry.title
+                            duplicate_of, entry.title
                         );
                         return Ok(());
+                    }
+                    DedupGate::Proceed(reason) => {
+                        // No --json support on this path -- stderr is the
+                        // only signal surface (mirrors the standard path's
+                        // bypass note; fix-round finding: this funnel was
+                        // one of the three that emitted nothing on a
+                        // session-less write). The LookupFailed warning is
+                        // already printed once by `dedup_gate` itself.
+                        if matches!(reason, DedupProceedReason::NoSession) {
+                            eprintln!("  (dedup bypassed: no --session provided)");
+                        }
                     }
                 }
 
@@ -1461,13 +1566,18 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Skip = success, not failure: an identical entry already exists
             // this session, so there is nothing to write and nothing wrong.
-            let entry = match outcome {
-                WriteOutcome::Written(e) => e,
+            let (entry, dedup_reason) = match outcome {
+                WriteOutcome::Written(e, reason) => (e, reason),
                 WriteOutcome::Skipped { duplicate_of } => {
                     if json {
                         println!(
                             "{}",
                             serde_json::to_string_pretty(&serde_json::json!({
+                                // `id` mirrors every success payload's `id`
+                                // key (fix-round review, minor finding: a
+                                // skip payload with no `id` key means
+                                // `jq -r .id` silently reads null on a skip).
+                                "id": duplicate_of,
                                 "skipped": true,
                                 "duplicate_of": duplicate_of,
                                 "status": "already_persisted",
@@ -1475,6 +1585,12 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                             }))?
                         );
                     } else {
+                        // Deliberately NOT "Added entry: {id}" -- this is a
+                        // skip, not a write, and the two phrases must stay
+                        // visibly distinct in plain mode (documented in
+                        // docs/src/memory.typ: a caller regexing on "Added
+                        // entry: (kn-\S+)" should switch to --json rather
+                        // than assume this line matches that pattern).
                         println!(
                             "Already saved as {} (identical entry this session — nothing to do).",
                             duplicate_of
@@ -1484,11 +1600,17 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
             };
 
-            // W447 rulings #6: session_id=None bypasses dedup entirely with no
-            // candidate query. Surface that bypass rather than let a silent
-            // "the store dedups now" assumption creep in for session-less
-            // writes. Stderr only -- never pollutes --json stdout.
-            if entry.session_id.is_none() {
+            // W447 rulings #6 + fix-round finding 2/tail: surface the two
+            // non-fresh proceed reasons so neither is silent. Stderr note is
+            // unconditional (mirrors dedup_gate's own fail-open warning);
+            // json mode ALSO gets a payload field below. Guarding the stderr
+            // note on `!json` here (fix-round review, json-mode nuance: the
+            // pre-fix code printed this unconditionally, so --json got both
+            // the stderr note AND the json field, contradicting the docs'
+            // mode-exclusive phrasing) -- the LookupFailed warning is
+            // intentionally NOT re-gated here since dedup_gate already
+            // printed it once, unconditionally, before this point.
+            if matches!(dedup_reason, DedupProceedReason::NoSession) && !json {
                 eprintln!("  (dedup bypassed: no --session-id provided)");
             }
 
@@ -1510,8 +1632,11 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     "wake_phrases": entry.wake_phrases,
                     "triggers": entry.triggers,
                 });
-                if entry.session_id.is_none() {
+                if matches!(dedup_reason, DedupProceedReason::NoSession) {
                     payload["dedup"] = serde_json::json!("bypassed_no_session");
+                }
+                if let DedupProceedReason::LookupFailed { msg } = &dedup_reason {
+                    payload["dedup_lookup_warning"] = serde_json::json!(msg);
                 }
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
@@ -2623,33 +2748,45 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     };
 
                     // Write-boundary dedup gate (W447). This inline fact-type
-                    // path is the funnel round-1 missed: it never touches
-                    // add_one, so it needs its OWN gate, immediately before
-                    // the upsert, with the SAME shared DedupIndex.
+                    // path is the funnel earlier review missed: it never
+                    // touches add_one, so it routes through the shared `dedup_gate`
+                    // (fix-round structural finding) with the SAME shared
+                    // DedupIndex threaded across the whole batch.
+                    //
+                    // Fail-open (fix-round finding 2): a lookup error used to
+                    // `continue` here, which DROPPED this line's write on a
+                    // transient read blip -- the write always wins now, same
+                    // as the other two funnels.
                     let allow_duplicate = bool_field("allow_duplicate");
-                    if !allow_duplicate {
-                        if let Err(e) = dedup.ensure_group(
-                            db.as_ref(),
-                            session.as_deref(),
-                            entry.owner.as_deref(),
-                        ) {
-                            entry_errors.push((line_idx + 1, format!("dedup lookup error: {}", e)));
-                            continue;
-                        }
-                        if let DedupDecision::Duplicate { existing_id } = dedup.check(
-                            session.as_deref(),
-                            entry.owner.as_deref(),
-                            &entry.title,
-                            entry.body.as_deref().unwrap_or(""),
-                        ) {
+                    match dedup_gate(
+                        &mut dedup,
+                        db.as_ref(),
+                        session.as_deref(),
+                        entry.owner.as_deref(),
+                        &entry.title,
+                        entry.body.as_deref().unwrap_or(""),
+                        allow_duplicate,
+                    ) {
+                        DedupGate::Skip { duplicate_of } => {
                             println!(
                                 "  [{}] Already saved: {} ({}) — identical this session, no action",
                                 line_idx + 1,
-                                existing_id,
+                                duplicate_of,
                                 entry.title
                             );
                             skipped_count += 1;
                             continue;
+                        }
+                        DedupGate::Proceed(reason) => {
+                            // No --json support on this path -- stderr only.
+                            // The LookupFailed warning is already printed
+                            // once by `dedup_gate` itself.
+                            if matches!(reason, DedupProceedReason::NoSession) {
+                                eprintln!(
+                                    "  line {}: (dedup bypassed: no session provided)",
+                                    line_idx + 1
+                                );
+                            }
                         }
                     }
 
@@ -2905,8 +3042,19 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     );
 
                     match entry_result {
-                        Ok(WriteOutcome::Written(entry)) => {
+                        Ok(WriteOutcome::Written(entry, reason)) => {
                             println!("  [{}] Added entry: {} ({})", line_idx + 1, entry.id, title);
+                            // Batch has no --json mode -- stderr is the only
+                            // signal surface here. Mirrors the standard
+                            // single-add path's bypass note (fix-round
+                            // finding: this funnel was one of the three that
+                            // emitted nothing on a session-less write).
+                            if matches!(reason, DedupProceedReason::NoSession) {
+                                eprintln!(
+                                    "  line {}: (dedup bypassed: no session_id provided)",
+                                    line_idx + 1
+                                );
+                            }
                             added_ids.push(entry.id);
                         }
                         Ok(WriteOutcome::Skipped { duplicate_of }) => {
@@ -4546,6 +4694,340 @@ mod dedup_gate_tests {
         }
     }
 
+    /// Wraps a real in-memory SurrealDB store and forces
+    /// `get_entries_for_session` to return `Err` -- simulating the transient
+    /// read blip finding 2 (fix-round review) covers: a lookup failure must
+    /// fail the GATE open, not the write. Every other method is a real
+    /// pass-through, same shape as `CountingStore`.
+    struct FailingStore {
+        inner: Box<dyn KnowledgeStore>,
+    }
+
+    impl FailingStore {
+        fn new() -> Self {
+            Self {
+                inner: Box::new(SurrealDatabase::open_in_memory().unwrap()),
+            }
+        }
+    }
+
+    impl KnowledgeStore for FailingStore {
+        fn upsert_knowledge(&self, entry: &knowledge::KnowledgeEntry) -> Result<()> {
+            self.inner.upsert_knowledge(entry)
+        }
+        fn get(&self, id: &str, ctx: &AgentContext) -> Result<Option<knowledge::KnowledgeEntry>> {
+            self.inner.get(id, ctx)
+        }
+        fn delete(&self, id: &str, ctx: &AgentContext) -> Result<bool> {
+            self.inner.delete(id, ctx)
+        }
+        fn search(
+            &self,
+            query: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.search(query, ctx, filter)
+        }
+        fn semantic_search(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+            limit: usize,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner
+                .semantic_search(query_embedding, ctx, filter, limit)
+        }
+        fn semantic_search_scored(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+            limit: usize,
+        ) -> Result<Vec<(knowledge::KnowledgeEntry, f32)>> {
+            self.inner
+                .semantic_search_scored(query_embedding, ctx, filter, limit)
+        }
+        fn semantic_search_entries_scored(
+            &self,
+            query_embedding: &[f32],
+            ctx: &AgentContext,
+            limit: usize,
+        ) -> Result<Vec<(knowledge::KnowledgeEntry, f32)>> {
+            self.inner
+                .semantic_search_entries_scored(query_embedding, ctx, limit)
+        }
+        fn list_by_category(
+            &self,
+            category: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.list_by_category(category, ctx, filter)
+        }
+        fn count_by_category(
+            &self,
+            category: &str,
+            ctx: &AgentContext,
+            filter: &store::KnowledgeFilter,
+        ) -> Result<usize> {
+            self.inner.count_by_category(category, ctx, filter)
+        }
+        fn list_all(&self, ctx: &AgentContext) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.list_all(ctx)
+        }
+        fn list_with_triggers(&self, ctx: &AgentContext) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.list_with_triggers(ctx)
+        }
+        fn count(&self) -> Result<usize> {
+            self.inner.count()
+        }
+        fn wake_cascade(
+            &self,
+            ctx: &AgentContext,
+            limit: usize,
+            min_resonance: Option<i32>,
+            days: i64,
+        ) -> Result<store::WakeCascade> {
+            self.inner.wake_cascade(ctx, limit, min_resonance, days)
+        }
+        fn update_activations(&self, ids: &[String]) -> Result<()> {
+            self.inner.update_activations(ids)
+        }
+        fn update_summary(&self, id: &str, summary: &str, ctx: &AgentContext) -> Result<bool> {
+            self.inner.update_summary(id, summary, ctx)
+        }
+        fn apply_update(
+            &self,
+            id: &str,
+            spec: &crate::store_update::UpdateSpec,
+            ctx: &AgentContext,
+        ) -> Result<crate::store_update::UpdateOutcome> {
+            self.inner.apply_update(id, spec, ctx)
+        }
+        fn increment_activation_count(&self, ids: &[String]) -> Result<()> {
+            self.inner.increment_activation_count(ids)
+        }
+        fn query_recent_facts(&self, days: i32) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.query_recent_facts(days)
+        }
+        fn query_recent_facts_all_types(
+            &self,
+            days: i32,
+        ) -> Result<Vec<knowledge::KnowledgeEntry>> {
+            self.inner.query_recent_facts_all_types(days)
+        }
+        fn reinforce(
+            &self,
+            id: &str,
+            amount: i32,
+            cap: Option<i32>,
+            ctx: &AgentContext,
+        ) -> Result<Option<store::ReinforcementResult>> {
+            self.inner.reinforce(id, amount, cap, ctx)
+        }
+        fn delete_embedding_chunks(&self, entry_id: &str) -> Result<()> {
+            self.inner.delete_embedding_chunks(entry_id)
+        }
+        fn insert_embedding_chunk(
+            &self,
+            entry_id: &str,
+            chunk_index: usize,
+            chunk_text: &str,
+            token_offset: usize,
+            token_count: usize,
+            embedding: &[f32],
+            model_id: &str,
+        ) -> Result<()> {
+            self.inner.insert_embedding_chunk(
+                entry_id,
+                chunk_index,
+                chunk_text,
+                token_offset,
+                token_count,
+                embedding,
+                model_id,
+            )
+        }
+        fn semantic_search_chunks(
+            &self,
+            query_embedding: &[f32],
+            limit: usize,
+        ) -> Result<Vec<(String, f32)>> {
+            self.inner.semantic_search_chunks(query_embedding, limit)
+        }
+        fn edit_content(
+            &self,
+            id: &str,
+            ctx: &AgentContext,
+            old_text: &str,
+            new_text: &str,
+            replace_all: bool,
+            nth: Option<usize>,
+        ) -> Result<store::EditResult> {
+            self.inner
+                .edit_content(id, ctx, old_text, new_text, replace_all, nth)
+        }
+        fn append_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()> {
+            self.inner.append_content(id, ctx, content)
+        }
+        fn prepend_content(&self, id: &str, ctx: &AgentContext, content: &str) -> Result<()> {
+            self.inner.prepend_content(id, ctx, content)
+        }
+        fn backup_content(
+            &self,
+            entry: &knowledge::KnowledgeEntry,
+            operation: &str,
+            agent: Option<&str>,
+        ) -> Result<String> {
+            self.inner.backup_content(entry, operation, agent)
+        }
+        fn list_backups(&self, entry_id: &str) -> Result<Vec<crate::types::MemoryBackup>> {
+            self.inner.list_backups(entry_id)
+        }
+        fn latest_backup(&self, entry_id: &str) -> Result<Option<crate::types::MemoryBackup>> {
+            self.inner.latest_backup(entry_id)
+        }
+        fn purge_backups(&self, entry_id: &str, keep: usize) -> Result<()> {
+            self.inner.purge_backups(entry_id, keep)
+        }
+        fn get_tags_for_entry(&self, entry_id: &str) -> Result<Vec<String>> {
+            self.inner.get_tags_for_entry(entry_id)
+        }
+        fn set_tags_for_entry(&self, entry_id: &str, tags: &[String]) -> Result<()> {
+            self.inner.set_tags_for_entry(entry_id, tags)
+        }
+        fn list_all_tags(&self, category: Option<&str>) -> Result<Vec<String>> {
+            self.inner.list_all_tags(category)
+        }
+        fn get_applicability_for_entry(&self, entry_id: &str) -> Result<Vec<String>> {
+            self.inner.get_applicability_for_entry(entry_id)
+        }
+        fn set_applicability_for_entry(&self, entry_id: &str, ids: &[String]) -> Result<()> {
+            self.inner.set_applicability_for_entry(entry_id, ids)
+        }
+        fn list_applicability_types(&self) -> Result<Vec<crate::types::ApplicabilityType>> {
+            self.inner.list_applicability_types()
+        }
+        fn upsert_applicability_type(&self, atype: &crate::types::ApplicabilityType) -> Result<()> {
+            self.inner.upsert_applicability_type(atype)
+        }
+        fn list_categories(&self) -> Result<Vec<crate::types::Category>> {
+            self.inner.list_categories()
+        }
+        fn get_category(&self, id: &str) -> Result<Option<crate::types::Category>> {
+            self.inner.get_category(id)
+        }
+        fn upsert_category(&self, category: &crate::types::Category) -> Result<()> {
+            self.inner.upsert_category(category)
+        }
+        fn delete_category(&self, id: &str) -> Result<bool> {
+            self.inner.delete_category(id)
+        }
+        fn list_projects(&self, active_only: bool) -> Result<Vec<crate::types::Project>> {
+            self.inner.list_projects(active_only)
+        }
+        fn get_project(&self, id: &str) -> Result<Option<crate::types::Project>> {
+            self.inner.get_project(id)
+        }
+        fn upsert_project(&self, project: &crate::types::Project) -> Result<()> {
+            self.inner.upsert_project(project)
+        }
+        fn get_tags_for_project(&self, project_id: &str) -> Result<Vec<String>> {
+            self.inner.get_tags_for_project(project_id)
+        }
+        fn set_tags_for_project(&self, project_id: &str, tags: &[String]) -> Result<()> {
+            self.inner.set_tags_for_project(project_id, tags)
+        }
+        fn get_applicability_for_project(&self, project_id: &str) -> Result<Vec<String>> {
+            self.inner.get_applicability_for_project(project_id)
+        }
+        fn set_applicability_for_project(&self, project_id: &str, ids: &[String]) -> Result<()> {
+            self.inner.set_applicability_for_project(project_id, ids)
+        }
+        fn list_agents(&self) -> Result<Vec<crate::types::Agent>> {
+            self.inner.list_agents()
+        }
+        fn get_agent(&self, id: &str) -> Result<Option<crate::types::Agent>> {
+            self.inner.get_agent(id)
+        }
+        fn upsert_agent(&self, agent: &crate::types::Agent) -> Result<()> {
+            self.inner.upsert_agent(agent)
+        }
+        fn list_relationships_for_entry(
+            &self,
+            entry_id: &str,
+        ) -> Result<Vec<crate::types::Relationship>> {
+            self.inner.list_relationships_for_entry(entry_id)
+        }
+        fn add_relationship(&self, from: &str, to: &str, rel_type: &str) -> Result<String> {
+            self.inner.add_relationship(from, to, rel_type)
+        }
+        fn delete_relationship(&self, id: &str) -> Result<bool> {
+            self.inner.delete_relationship(id)
+        }
+        fn get_facts_for_session(&self, session_id: &str) -> Result<Vec<String>> {
+            self.inner.get_facts_for_session(session_id)
+        }
+        fn get_entries_for_session(
+            &self,
+            _session_id: &str,
+            _owner: Option<&str>,
+            _ctx: &AgentContext,
+        ) -> Result<Vec<DedupCandidate>> {
+            anyhow::bail!("simulated transient read blip")
+        }
+        fn get_session_for_fact(&self, fact_id: &str) -> Result<Option<String>> {
+            self.inner.get_session_for_fact(fact_id)
+        }
+        fn list_sessions(&self, project_id: Option<&str>) -> Result<Vec<crate::types::Session>> {
+            self.inner.list_sessions(project_id)
+        }
+        fn get_session(&self, id: &str) -> Result<Option<crate::types::Session>> {
+            self.inner.get_session(id)
+        }
+        fn upsert_session(&self, session: &crate::types::Session) -> Result<()> {
+            self.inner.upsert_session(session)
+        }
+        fn list_source_types(&self) -> Result<Vec<crate::types::SourceType>> {
+            self.inner.list_source_types()
+        }
+        fn list_entry_types(&self) -> Result<Vec<crate::types::EntryType>> {
+            self.inner.list_entry_types()
+        }
+        fn list_content_types(&self) -> Result<Vec<crate::types::ContentType>> {
+            self.inner.list_content_types()
+        }
+        fn list_session_types(&self) -> Result<Vec<crate::types::SessionType>> {
+            self.inner.list_session_types()
+        }
+        fn list_relationship_types(&self) -> Result<Vec<crate::types::RelationshipType>> {
+            self.inner.list_relationship_types()
+        }
+        fn create_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<String> {
+            self.inner.create_wake_session(session)
+        }
+        fn get_wake_session(
+            &self,
+            session_id: &str,
+        ) -> Result<Option<crate::wake_token::WakeSession>> {
+            self.inner.get_wake_session(session_id)
+        }
+        fn update_wake_session(&self, session: &crate::wake_token::WakeSession) -> Result<()> {
+            self.inner.update_wake_session(session)
+        }
+        fn delete_wake_session(&self, session_id: &str) -> Result<()> {
+            self.inner.delete_wake_session(session_id)
+        }
+        fn sweep_ghost_anchors(&self, dry_run: bool) -> Result<store::GhostSweepResult> {
+            self.inner.sweep_ghost_anchors(dry_run)
+        }
+        fn list_tables(&self) -> Result<Vec<String>> {
+            self.inner.list_tables()
+        }
+    }
+
     fn one_line_args(
         agent: &str,
         owner: Option<&str>,
@@ -4602,7 +5084,7 @@ mod dedup_gate_tests {
         )
         .unwrap();
         let first_id = match first {
-            WriteOutcome::Written(e) => e.id,
+            WriteOutcome::Written(e, _) => e.id,
             WriteOutcome::Skipped { .. } => panic!("first write must not be a duplicate"),
         };
 
@@ -4624,7 +5106,7 @@ mod dedup_gate_tests {
         .unwrap();
 
         match second {
-            WriteOutcome::Written(_) => panic!("recased re-add must be skipped, not written"),
+            WriteOutcome::Written(..) => panic!("recased re-add must be skipped, not written"),
             WriteOutcome::Skipped { duplicate_of } => assert_eq!(duplicate_of, first_id),
         }
     }
@@ -4669,7 +5151,7 @@ mod dedup_gate_tests {
         .unwrap();
 
         assert!(
-            matches!(forced, WriteOutcome::Written(_)),
+            matches!(forced, WriteOutcome::Written(..)),
             "--allow-duplicate must force the write through even for identical body text"
         );
     }
@@ -4812,7 +5294,7 @@ mod dedup_gate_tests {
             false,
         )
         .unwrap();
-        assert!(matches!(a, WriteOutcome::Written(_)));
+        assert!(matches!(a, WriteOutcome::Written(..)));
 
         let b = add_one(
             one_line_args(
@@ -4831,8 +5313,109 @@ mod dedup_gate_tests {
         )
         .unwrap();
         assert!(
-            matches!(b, WriteOutcome::Written(_)),
+            matches!(b, WriteOutcome::Written(..)),
             "agent-b's identical-text entry must land, not be skipped against agent-a's row"
         );
+    }
+
+    #[test]
+    fn public_owned_and_public_unowned_identical_content_do_not_dedup() {
+        // Fix-round review, minor finding (garbaggio): `owner` is a hard
+        // AND-conjoined predicate, so a PUBLIC+owned entry and a later
+        // PUBLIC+unowned entry with identical normalized content -- both
+        // visible to every reader, the exact case this gate targets -- never
+        // dedup against each other. This is a known, documented false
+        // negative (misses a dupe, never merges distinct content), accepted
+        // rather than fixed this round (documented in docs/src/memory.typ's
+        // coverage-boundary note). This test PINS the current behavior so a
+        // future change to the owner predicate can't silently alter it.
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        let owned = add_one(
+            one_line_args(
+                "agent-a",
+                Some("agent-a"), // public + owned
+                "test",
+                "Shared Public Title",
+                "Shared public body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(matches!(owned, WriteOutcome::Written(..)));
+
+        let unowned = add_one(
+            one_line_args(
+                "agent-a",
+                None, // public + unowned, identical normalized content
+                "test",
+                "shared public title",
+                "shared public body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(
+            matches!(unowned, WriteOutcome::Written(..)),
+            "public+unowned must NOT be deduped against public+owned identical content -- \
+             a known accepted gap (owner is a hard predicate), not a bug this test regresses"
+        );
+    }
+
+    #[test]
+    fn lookup_failure_fails_open_and_the_write_still_lands() {
+        // Fix-round review, finding 2: a transient `ensure_group` lookup
+        // failure must NOT abort the write via `?` -- pre-fix this test
+        // would have returned `Err` here instead of a landed write.
+        let db = FailingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        let outcome = add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "test",
+                "Title",
+                "Body text.",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .expect("a dedup lookup failure must fail OPEN, not abort the write with Err");
+
+        match outcome {
+            WriteOutcome::Written(entry, reason) => {
+                assert!(
+                    matches!(reason, DedupProceedReason::LookupFailed { .. }),
+                    "the proceed reason must record that the gate failed open on a lookup error"
+                );
+                // Confirm the write actually landed in the store, not just
+                // that add_one returned Ok -- the whole point of failing
+                // open is that the write is real.
+                let ctx = AgentContext::for_agent("agent-a");
+                assert!(
+                    db.inner.get(&entry.id, &ctx).unwrap().is_some(),
+                    "the write must be persisted even though the dedup lookup failed"
+                );
+            }
+            WriteOutcome::Skipped { .. } => {
+                panic!("a lookup failure must proceed with the write, never skip it")
+            }
+        }
     }
 }

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -360,10 +360,29 @@ enum DedupDecision {
 /// entry -- resolving the tension flagged in review between "exactly one
 /// query" and correct per-line owner/session scoping.
 ///
-/// Keyed by `(session_id, owner, dedup_hash)`: owner is part of the key so a
-/// hash collision under one owner never shadows a distinct write by another
-/// owner (W447 rulings #2); session is part of the key so the same hash in a
-/// DIFFERENT session is never treated as a duplicate.
+/// Keyed by `(session_id, owner, category, dedup_hash)`: owner is part of
+/// the key so a hash collision under one owner never shadows a distinct
+/// write by another owner (W447 rulings #2); session is part of the key so
+/// the same hash in a DIFFERENT session is never treated as a duplicate;
+/// `category` is part of the key (PR #402 finding 1) so the same hash filed
+/// under a DIFFERENT category is never treated as a duplicate either --
+/// identical title+body re-filed under a new category is a distinct fact,
+/// not a re-add of the same one. `category` must live in this key even
+/// though the candidate query is ALSO scoped by category: the query scoping
+/// keeps a wrong-category row out of `seen` in the first place, and the key
+/// keeps a `check()` for one category from ever reading a `seen` entry
+/// populated by a different category's `ensure_group` call -- either one
+/// alone would still let a cross-category collision through the other path.
+///
+/// `tags` are deliberately NOT part of this key, anywhere. Tags are
+/// edge-modeled (a relationship table), not a scalar field on the
+/// `knowledge` row, so scoping the candidate query by tags (or folding them
+/// into `dedup_hash`) would cost an extra query per candidate to fetch
+/// them. Identical title+body filed with different tags is treated as the
+/// same fact re-tagged, and dedupes -- an accepted, documented
+/// false-negative (see `dedup_hash`'s IDENTITY CONTRACT doc-comment in
+/// `knowledge.rs`, and `identical_content_different_tags_still_dedups`
+/// below, which pins this behavior).
 ///
 /// TOCTOU: read-then-write, per-process, with no DB-level unique constraint
 /// backing it. Two concurrent `mx` invocations can still both write the same
@@ -379,26 +398,34 @@ enum DedupDecision {
 /// canonical row.
 #[derive(Default)]
 struct DedupIndex {
-    seen: std::collections::HashMap<(String, Option<String>, String), String>,
-    fetched_groups: std::collections::HashSet<(String, Option<String>)>,
+    seen: std::collections::HashMap<(String, Option<String>, String, String), String>,
+    fetched_groups: std::collections::HashSet<(String, Option<String>, String)>,
 }
 
 impl DedupIndex {
-    /// Ensure the `(session_id, owner)` group's DB candidates are loaded.
-    /// No query at all when `session_id` is `None` -- dedup is bypassed
-    /// entirely for session-less writes (settled, W447 rulings #6) -- and no
-    /// REPEAT query when the group was already fetched by an earlier line in
-    /// this run.
+    /// Ensure the `(session_id, owner, category)` group's DB candidates are
+    /// loaded. No query at all when `session_id` is `None` -- dedup is
+    /// bypassed entirely for session-less writes (settled, W447 rulings
+    /// #6) -- and no REPEAT query when the group was already fetched by an
+    /// earlier line in this run. A write under a NEW category in an
+    /// already-fetched `(session, owner)` pair still triggers its own query
+    /// (PR #402 finding 1): category is part of the group key, so it is a
+    /// distinct group, not a cache hit against the wrong category's rows.
     fn ensure_group(
         &mut self,
         db: &dyn store::KnowledgeStore,
         session_id: Option<&str>,
         owner: Option<&str>,
+        category: &str,
     ) -> Result<()> {
         let Some(sid) = session_id else {
             return Ok(());
         };
-        let group = (sid.to_string(), owner.map(String::from));
+        let group = (
+            sid.to_string(),
+            owner.map(String::from),
+            category.to_string(),
+        );
         if self.fetched_groups.contains(&group) {
             return Ok(());
         }
@@ -423,23 +450,31 @@ impl DedupIndex {
             Some(o) => store::AgentContext::for_agent(o.to_string()),
             None => store::AgentContext::public_only(),
         };
-        let candidates = db.get_entries_for_session(sid, owner, &ctx)?;
+        let candidates = db.get_entries_for_session(sid, owner, category, &ctx)?;
         for c in candidates {
             let hash = knowledge::dedup_hash(&c.title, &c.body);
-            self.seen
-                .insert((sid.to_string(), owner.map(String::from), hash), c.id);
+            self.seen.insert(
+                (
+                    sid.to_string(),
+                    owner.map(String::from),
+                    category.to_string(),
+                    hash,
+                ),
+                c.id,
+            );
         }
         self.fetched_groups.insert(group);
         Ok(())
     }
 
-    /// Check whether `(session_id, owner)` already has an entry whose
-    /// title+body normalizes to the same hash. Always `Fresh` when
+    /// Check whether `(session_id, owner, category)` already has an entry
+    /// whose title+body normalizes to the same hash. Always `Fresh` when
     /// `session_id` is `None` (dedup bypassed by design).
     fn check(
         &self,
         session_id: Option<&str>,
         owner: Option<&str>,
+        category: &str,
         title: &str,
         body: &str,
     ) -> DedupDecision {
@@ -447,7 +482,12 @@ impl DedupIndex {
             return DedupDecision::Fresh;
         };
         let hash = knowledge::dedup_hash(title, body);
-        let key = (sid.to_string(), owner.map(String::from), hash);
+        let key = (
+            sid.to_string(),
+            owner.map(String::from),
+            category.to_string(),
+            hash,
+        );
         match self.seen.get(&key) {
             Some(existing_id) => DedupDecision::Duplicate {
                 existing_id: existing_id.clone(),
@@ -465,14 +505,22 @@ impl DedupIndex {
         &mut self,
         session_id: Option<&str>,
         owner: Option<&str>,
+        category: &str,
         title: &str,
         body: &str,
         id: String,
     ) {
         if let Some(sid) = session_id {
             let hash = knowledge::dedup_hash(title, body);
-            self.seen
-                .insert((sid.to_string(), owner.map(String::from), hash), id);
+            self.seen.insert(
+                (
+                    sid.to_string(),
+                    owner.map(String::from),
+                    category.to_string(),
+                    hash,
+                ),
+                id,
+            );
         }
     }
 }
@@ -508,22 +556,30 @@ enum DedupGate {
     Skip { duplicate_of: String },
 }
 
-/// Run the write-boundary dedup gate: ensure the `(session, owner)`
-/// candidate group is loaded, then check title+body against it. This is the
-/// ONE place all three new-entry write funnels -- `add_one`'s standard path,
-/// the single-add `--type` fact path, and the batch inline fact path --
-/// make the dedup decision (fix-round review, structural finding: the gate
-/// was hand-rolled at three call sites with drifting bypass-signal and
-/// fail-open/fail-closed behavior between them). A fourth funnel now has to
-/// edit this function to diverge, not just forget to copy a change.
+/// Run the write-boundary dedup gate: ensure the `(session, owner,
+/// category)` candidate group is loaded, then check title+body against it.
+/// This is the ONE place all three new-entry write funnels -- `add_one`'s
+/// standard path, the single-add `--type` fact path, and the batch inline
+/// fact path -- make the dedup decision (fix-round review, structural
+/// finding: the gate was hand-rolled at three call sites with drifting
+/// bypass-signal and fail-open/fail-closed behavior between them). A fourth
+/// funnel now has to edit this function to diverge, not just forget to
+/// copy a change.
+///
+/// `category` scopes the candidate group (PR #402 finding 1): identical
+/// title+body filed under a different category is a distinct fact, never a
+/// dedup candidate. See `DedupIndex`'s doc-comment for why category is a
+/// query-scope decision rather than a hash field.
 ///
 /// Fails OPEN on a lookup error (finding 2): logs a warning to stderr and
 /// returns `Proceed`, never aborts the write via `?`.
+#[allow(clippy::too_many_arguments)] // one gate, one signature -- see doc-comment above.
 fn dedup_gate(
     dedup: &mut DedupIndex,
     db: &dyn store::KnowledgeStore,
     session_id: Option<&str>,
     owner: Option<&str>,
+    category: &str,
     title: &str,
     body: &str,
     allow_duplicate: bool,
@@ -534,14 +590,14 @@ fn dedup_gate(
     if session_id.is_none() {
         return DedupGate::Proceed(DedupProceedReason::NoSession);
     }
-    if let Err(e) = dedup.ensure_group(db, session_id, owner) {
+    if let Err(e) = dedup.ensure_group(db, session_id, owner, category) {
         let msg = e.to_string();
         eprintln!(
             "Warning: dedup candidate lookup failed ({msg}) -- proceeding with the write (fail-open)"
         );
         return DedupGate::Proceed(DedupProceedReason::LookupFailed { msg });
     }
-    match dedup.check(session_id, owner, title, body) {
+    match dedup.check(session_id, owner, category, title, body) {
         DedupDecision::Duplicate { existing_id } => DedupGate::Skip {
             duplicate_of: existing_id,
         },
@@ -668,6 +724,7 @@ fn add_one(
         db,
         args.session_id.as_deref(),
         args.entry_owner.as_deref(),
+        &args.category,
         &args.title,
         &args.body,
         allow_duplicate,
@@ -734,6 +791,7 @@ fn add_one(
         dedup.record(
             args.session_id.as_deref(),
             args.entry_owner.as_deref(),
+            &args.category,
             &args.title,
             &args.body,
             id.clone(),
@@ -1355,6 +1413,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     db.as_ref(),
                     session.as_deref(),
                     entry.owner.as_deref(),
+                    &entry.category_id,
                     &entry.title,
                     entry.body.as_deref().unwrap_or(""),
                     allow_duplicate,
@@ -2763,6 +2822,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         db.as_ref(),
                         session.as_deref(),
                         entry.owner.as_deref(),
+                        &entry.category_id,
                         &entry.title,
                         entry.body.as_deref().unwrap_or(""),
                         allow_duplicate,
@@ -2820,6 +2880,7 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                         dedup.record(
                             session.as_deref(),
                             entry.owner.as_deref(),
+                            &entry.category_id,
                             &entry.title,
                             entry.body.as_deref().unwrap_or(""),
                             id.clone(),
@@ -4639,10 +4700,12 @@ mod dedup_gate_tests {
             &self,
             session_id: &str,
             owner: Option<&str>,
+            category: &str,
             ctx: &AgentContext,
         ) -> Result<Vec<DedupCandidate>> {
             self.calls.set(self.calls.get() + 1);
-            self.inner.get_entries_for_session(session_id, owner, ctx)
+            self.inner
+                .get_entries_for_session(session_id, owner, category, ctx)
         }
         fn get_session_for_fact(&self, fact_id: &str) -> Result<Option<String>> {
             self.inner.get_session_for_fact(fact_id)
@@ -4974,6 +5037,7 @@ mod dedup_gate_tests {
             &self,
             _session_id: &str,
             _owner: Option<&str>,
+            _category: &str,
             _ctx: &AgentContext,
         ) -> Result<Vec<DedupCandidate>> {
             anyhow::bail!("simulated transient read blip")
@@ -5417,5 +5481,133 @@ mod dedup_gate_tests {
                 panic!("a lookup failure must proceed with the write, never skip it")
             }
         }
+    }
+
+    #[test]
+    fn identical_content_different_category_does_not_dedup() {
+        // PR #402 finding 1 (BLOCKER): identical title+body re-filed under a
+        // DIFFERENT category in the same session+owner must land as a
+        // distinct entry, never be skipped as "already saved" under the
+        // other category's row. Pre-fix, `dedup_hash` alone (title+body,
+        // no category) meant this exact case silently dropped the second
+        // write.
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        let recipe = add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "recipe",
+                "Shared Title",
+                "Shared body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(matches!(recipe, WriteOutcome::Written(..)));
+
+        let discovery = add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "discovery", // different category, byte-identical title+body
+                "Shared Title",
+                "Shared body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(
+            matches!(discovery, WriteOutcome::Written(..)),
+            "identical title+body under a different category must land as a distinct \
+             entry, not be skipped against the other category's row"
+        );
+
+        // The different-category write is a NEW group -- its own query, not
+        // a cache hit reusing the "recipe" group's candidates.
+        assert_eq!(
+            db.calls.get(),
+            2,
+            "a different category in the same (session, owner) must trigger its own \
+             candidate query, not reuse the other category's cached group"
+        );
+
+        // A true recased re-add WITHIN the same category is still caught.
+        let recipe_dup = add_one(
+            one_line_args(
+                "agent-a",
+                None,
+                "recipe",
+                "shared title", // recased, same category as the first write
+                "shared body",
+                Some("sess-1"),
+            ),
+            &db,
+            false,
+            true,
+            &mut dedup,
+            false,
+        )
+        .unwrap();
+        assert!(
+            matches!(recipe_dup, WriteOutcome::Skipped { .. }),
+            "within the SAME category, a recased duplicate must still be caught -- the \
+             category fix must not weaken same-category dedup"
+        );
+    }
+
+    #[test]
+    fn identical_content_different_tags_still_dedups() {
+        // Documented, accepted gap (PR #402 finding 1 follow-up decision,
+        // see `DedupIndex`'s doc-comment and `dedup_hash`'s IDENTITY
+        // CONTRACT note in knowledge.rs): tags are edge-modeled, not a
+        // scalar field on the row, and are deliberately NOT part of the
+        // dedup identity. Identical title+body filed with different tags is
+        // treated as the same fact re-tagged, and the second write is
+        // skipped -- this test PINS that behavior so a future change can't
+        // silently start folding tags into the identity (or stop dedupeing
+        // across tags) without this test forcing the decision to be visible.
+        let db = CountingStore::new();
+        let mut dedup = DedupIndex::default();
+
+        let mut first_args = one_line_args(
+            "agent-a",
+            None,
+            "test",
+            "Shared Title",
+            "Shared body",
+            Some("sess-1"),
+        );
+        first_args.tag_list = vec!["alpha".to_string()];
+        let first = add_one(first_args, &db, false, true, &mut dedup, false).unwrap();
+        assert!(matches!(first, WriteOutcome::Written(..)));
+
+        let mut second_args = one_line_args(
+            "agent-a",
+            None,
+            "test",
+            "Shared Title",
+            "Shared body",
+            Some("sess-1"),
+        );
+        second_args.tag_list = vec!["beta".to_string(), "gamma".to_string()];
+        let second = add_one(second_args, &db, false, true, &mut dedup, false).unwrap();
+
+        assert!(
+            matches!(second, WriteOutcome::Skipped { .. }),
+            "identical title+body with DIFFERENT tags must still dedup -- tags are \
+             excluded from the identity by design, not a bug this test regresses"
+        );
     }
 }

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -233,6 +233,24 @@ pub fn normalize_for_dedup(content: &str) -> String {
 /// `ensure_group` call and from the incoming entry on every `check`), so
 /// changing this algorithm has no migration concern -- there is no stored
 /// value anywhere that this invalidates.
+///
+/// IDENTITY CONTRACT (PR #402 finding 1): this hash keys on title+body ONLY.
+/// "Same identity" for dedup purposes is enforced by two things working
+/// together, not this function alone:
+///   - `category` is scoped at the CANDIDATE QUERY, not the hash (see
+///     `get_entries_for_session` / `DedupIndex` in `handlers/memory.rs`).
+///     Identical title+body filed under a different category is a distinct
+///     fact, never a candidate, so it can never collide here.
+///   - `tags` are deliberately EXCLUDED from the identity entirely, not
+///     scoped anywhere. Tags are edge-modeled (a relationship table), not a
+///     scalar field on the row, so folding them in would cost an extra
+///     query per candidate; identical title+body with different tags is
+///     treated as the same fact filed with more/fewer labels, and dedupes.
+///     This is a documented, accepted false-negative surface (a
+///     tag-only-differing duplicate is skipped, same as the intended
+///     behavior) -- pinned by
+///     `identical_content_different_tags_still_dedups` in
+///     `handlers/memory.rs`.
 pub fn dedup_hash(title: &str, body: &str) -> String {
     let norm_title = normalize_for_dedup(title);
     let norm_body = normalize_for_dedup(body);

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -158,6 +158,45 @@ where
     out
 }
 
+/// Normalize content for write-boundary DEDUPLICATION (W447). Lowercases,
+/// strips ASCII punctuation, and collapses whitespace, so a
+/// recased/repunctuated regenerated duplicate ("The plan!" vs "the plan")
+/// normalizes identically to its original.
+///
+/// Distinct from [`KnowledgeEntry::normalize_content`], which stops at
+/// case/whitespace folding and is depended on by thread-matching -- that
+/// function is deliberately left unchanged. This is a separate, stricter
+/// normalization used only by [`dedup_hash`].
+pub fn normalize_for_dedup(content: &str) -> String {
+    let no_punct: String = content
+        .chars()
+        .filter(|c| !c.is_ascii_punctuation())
+        .collect();
+    no_punct
+        .trim()
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Compute the write-boundary dedup hash for an entry's title+body (W447).
+/// Two entries whose title+body normalize identically -- same text modulo
+/// case, punctuation, and whitespace -- hash equal, so a
+/// regenerated/recased near-duplicate is caught at the write boundary before
+/// it lands as a second row.
+///
+/// Distinct from the legacy title-only `content_hash`
+/// ([`KnowledgeEntry::compute_hash`], import-time change detection, computed
+/// but never enforced) -- that field is untouched by this. `dedup_hash` keys
+/// on title+body and is the write-boundary gate's identity key.
+pub fn dedup_hash(title: &str, body: &str) -> String {
+    // `blake3_hex` has no `pub` but is visible here: Rust privacy is
+    // module-scoped, and this free function lives in the same module
+    // (knowledge.rs) as `impl KnowledgeEntry`.
+    KnowledgeEntry::blake3_hex(normalize_for_dedup(&format!("{title}\n{body}")).as_bytes())
+}
+
 fn default_format() -> String {
     "markdown".to_string()
 }
@@ -207,8 +246,12 @@ impl KnowledgeEntry {
 
     /// Normalize content for comparison (thread matching, etc.)
     ///
-    /// Strips whitespace, lowercases, and removes punctuation variations
-    /// to enable fuzzy content matching.
+    /// Trims, lowercases, and collapses internal whitespace runs to a single
+    /// space. Does NOT strip punctuation -- "hello, world!" stays
+    /// "hello, world!" (lowercased/collapsed). Thread-matching (helpers.rs)
+    /// depends on this exact behavior, so this function is intentionally
+    /// left unchanged; see `normalize_for_dedup` below for the punctuation-
+    /// stripping variant used by write-boundary dedup (W447).
     pub fn normalize_content(content: &str) -> String {
         content
             .trim()
@@ -344,6 +387,45 @@ mod tests {
                 "glucose".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn test_normalize_for_dedup_strips_punctuation_case_and_whitespace() {
+        assert_eq!(
+            normalize_for_dedup("The EXTERNAL, numberless plan."),
+            normalize_for_dedup("the external numberless plan")
+        );
+        assert_eq!(
+            normalize_for_dedup("The EXTERNAL, numberless plan."),
+            "the external numberless plan"
+        );
+    }
+
+    #[test]
+    fn test_normalize_content_not_mutated_by_dedup_work() {
+        // normalize_content must still lowercase/collapse WITHOUT stripping
+        // punctuation -- thread-matching (helpers.rs) depends on the exact
+        // pre-W447 behavior.
+        assert_eq!(
+            KnowledgeEntry::normalize_content("hello, world!"),
+            "hello, world!"
+        );
+    }
+
+    #[test]
+    fn test_dedup_hash_recased_repunctuated_pair_equal() {
+        // W447 evidence class: regenerated duplicates differ only by case,
+        // punctuation, or whitespace -- dedup_hash must collapse them.
+        let a = dedup_hash("The External Plan", "Ship it, and move on.");
+        let b = dedup_hash("the external plan", "ship it and move on");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_dedup_hash_different_bodies_unequal() {
+        let a = dedup_hash("The External Plan", "Ship it and move on.");
+        let b = dedup_hash("The External Plan", "Ship it and hold off.");
+        assert_ne!(a, b);
     }
 
     #[test]

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -158,10 +158,24 @@ where
     out
 }
 
+/// Common LLM-regenerated Unicode punctuation glyphs that stand in for their
+/// ASCII counterparts: smart quotes, en/em dash, and horizontal ellipsis
+/// (fix-round review, minor finding: `is_ascii_punctuation` alone leaves
+/// these untouched, so "don't" vs "don't" -- straight vs smart apostrophe --
+/// fails to dedup even though it's the exact recase/repunctuate class this
+/// gate targets). A false negative here only means a real duplicate slips
+/// through uncaught, never a false-positive merge of distinct content, so
+/// extending this list is one-directional safe.
+const DEDUP_UNICODE_PUNCTUATION: [char; 7] = [
+    '\u{2018}', '\u{2019}', '\u{201C}', '\u{201D}', '\u{2013}', '\u{2014}', '\u{2026}',
+];
+
 /// Normalize content for write-boundary DEDUPLICATION (W447). Lowercases,
-/// strips ASCII punctuation, and collapses whitespace, so a
-/// recased/repunctuated regenerated duplicate ("The plan!" vs "the plan")
-/// normalizes identically to its original.
+/// strips ASCII punctuation plus the common Unicode punctuation glyphs LLM
+/// regeneration substitutes for them (see [`DEDUP_UNICODE_PUNCTUATION`]), and
+/// collapses whitespace, so a recased/repunctuated regenerated duplicate
+/// ("The plan!" vs "the plan", or "don't" vs "don't") normalizes identically
+/// to its original.
 ///
 /// Distinct from [`KnowledgeEntry::normalize_content`], which stops at
 /// case/whitespace folding and is depended on by thread-matching -- that
@@ -170,7 +184,7 @@ where
 pub fn normalize_for_dedup(content: &str) -> String {
     let no_punct: String = content
         .chars()
-        .filter(|c| !c.is_ascii_punctuation())
+        .filter(|c| !c.is_ascii_punctuation() && !DEDUP_UNICODE_PUNCTUATION.contains(c))
         .collect();
     no_punct
         .trim()
@@ -190,11 +204,46 @@ pub fn normalize_for_dedup(content: &str) -> String {
 /// ([`KnowledgeEntry::compute_hash`], import-time change detection, computed
 /// but never enforced) -- that field is untouched by this. `dedup_hash` keys
 /// on title+body and is the write-boundary gate's identity key.
+///
+/// Hashes title and body as a length-prefixed PAIR, never a joined string
+/// (fix-round review, finding 1): `normalize_for_dedup` collapses ALL
+/// whitespace -- including any separator character we might pick, since
+/// separators are themselves whitespace or get stripped as punctuation -- so
+/// `dedup_hash("Ship it", "now.")` and `dedup_hash("Ship it now", "")`
+/// previously collapsed to the identical normalized string "ship it now" and
+/// hashed equal. That's exactly the variance an LLM regenerating the same
+/// fact produces (folding a sentence into the title one turn, splitting it
+/// title+body the next) -- a false-positive skip that silently drops the
+/// second write. The length prefix on the normalized title makes the byte
+/// stream fed to blake3 unambiguous: given the prefix, the title/body
+/// boundary can always be recovered, so two different splits of the same
+/// concatenated text can only hash equal if the title itself is
+/// byte-identical too.
+///
+/// LANDMINE FOR THE NEXT EDITOR: this scheme is sound for exactly the two
+/// fields hashed here -- the first field's length prefix pins the one
+/// boundary that exists between two fields. If a third content field ever
+/// gets folded into this hash (e.g. a summary or a tags string), it needs
+/// its OWN length prefix too -- one prefix only disambiguates one boundary,
+/// and an unprefixed third field reopens the exact ambiguity class this fix
+/// closed (two different three-way splits of the same concatenated bytes
+/// hashing equal).
+///
+/// `dedup_hash` is never persisted (recomputed from candidate rows on every
+/// `ensure_group` call and from the incoming entry on every `check`), so
+/// changing this algorithm has no migration concern -- there is no stored
+/// value anywhere that this invalidates.
 pub fn dedup_hash(title: &str, body: &str) -> String {
+    let norm_title = normalize_for_dedup(title);
+    let norm_body = normalize_for_dedup(body);
+    let mut buf = Vec::with_capacity(norm_title.len() + norm_body.len() + 8);
+    buf.extend_from_slice(&(norm_title.len() as u64).to_le_bytes());
+    buf.extend_from_slice(norm_title.as_bytes());
+    buf.extend_from_slice(norm_body.as_bytes());
     // `blake3_hex` has no `pub` but is visible here: Rust privacy is
     // module-scoped, and this free function lives in the same module
     // (knowledge.rs) as `impl KnowledgeEntry`.
-    KnowledgeEntry::blake3_hex(normalize_for_dedup(&format!("{title}\n{body}")).as_bytes())
+    KnowledgeEntry::blake3_hex(&buf)
 }
 
 fn default_format() -> String {
@@ -402,6 +451,29 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_for_dedup_strips_common_unicode_punctuation() {
+        // Fix-round review, minor finding: smart quotes / em-dash / ellipsis
+        // are the exact glyphs LLM regeneration swaps in for their ASCII
+        // counterparts -- must fold to the same normalized form.
+        assert_eq!(
+            normalize_for_dedup("don't"),
+            normalize_for_dedup("don\u{2019}t")
+        );
+        assert_eq!(
+            normalize_for_dedup("\u{201C}quoted\u{201D}"),
+            normalize_for_dedup("\"quoted\"")
+        );
+        assert_eq!(
+            normalize_for_dedup("wait\u{2014}really"),
+            normalize_for_dedup("wait-really")
+        );
+        assert_eq!(
+            normalize_for_dedup("hold on\u{2026}"),
+            normalize_for_dedup("hold on...")
+        );
+    }
+
+    #[test]
     fn test_normalize_content_not_mutated_by_dedup_work() {
         // normalize_content must still lowercase/collapse WITHOUT stripping
         // punctuation -- thread-matching (helpers.rs) depends on the exact
@@ -426,6 +498,23 @@ mod tests {
         let a = dedup_hash("The External Plan", "Ship it and move on.");
         let b = dedup_hash("The External Plan", "Ship it and hold off.");
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_dedup_hash_does_not_collapse_title_body_boundary() {
+        // Fix-round review, finding 1: pre-fix, both sides normalized to the
+        // identical string "ship it now" (the `\n` joiner is whitespace, so
+        // `normalize_for_dedup`'s split_whitespace/join collapses it exactly
+        // like any other space) and hashed equal -- a false-positive skip
+        // that silently drops a distinct entry. They must now differ.
+        assert_ne!(dedup_hash("Ship it", "now."), dedup_hash("Ship it now", ""));
+
+        // A second instance of the same class: the split point moves by one
+        // word, and the total token stream still matches.
+        assert_ne!(
+            dedup_hash("Ship it now", "and move on"),
+            dedup_hash("Ship it", "now and move on")
+        );
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -493,8 +493,9 @@ pub trait KnowledgeStore {
 
     /// Write-boundary dedup candidates (W447): entries whose `session`
     /// record-link FIELD equals `session_id` (indexed: `knowledge_session`),
-    /// scoped by `owner` (indexed: `knowledge_owner`). Field-scoped, NOT the
-    /// `EXTRACTED_FROM` edge that [`get_facts_for_session`](Self::get_facts_for_session)
+    /// scoped by `owner` (indexed: `knowledge_owner`) AND by `category`
+    /// (review PR #402 finding 1). Field-scoped, NOT the `EXTRACTED_FROM`
+    /// edge that [`get_facts_for_session`](Self::get_facts_for_session)
     /// uses -- that edge is frequently absent (session-not-found is a
     /// warn-and-skip elsewhere in the write path), which would under-fetch
     /// exactly the entries most prone to duplication.
@@ -506,12 +507,30 @@ pub trait KnowledgeStore {
     /// backstop to do the scoping (it admits every owner's public rows and
     /// provides no owner isolation on its own).
     ///
+    /// `category` is likewise a hard AND-conjoined predicate, never "any
+    /// category": identical title+body re-filed under a different category
+    /// in the same session is a distinct fact (a different shelf, not a
+    /// duplicate), so it must never surface as a dedup candidate. This is
+    /// the fix for PR #402 finding 1 (dedup identity previously excluded
+    /// category, so a same-session/same-owner write under a new category
+    /// was silently skipped as "already saved" under someone else's
+    /// category). Scoping the candidate query -- rather than folding
+    /// `category` into `dedup_hash` itself -- was the chosen fix: it avoids
+    /// adding a third length-prefixed field to the hash (see the LANDMINE
+    /// doc-comment on `dedup_hash` in `knowledge.rs`) and keeps the hash's
+    /// contract exactly "same title+body", with "same category" enforced
+    /// at the query boundary instead. Tags are deliberately NOT part of
+    /// this scope (see `DedupIndex` doc-comment in `handlers/memory.rs`):
+    /// they are edge-modeled, not a scalar field on the row, and folding
+    /// them in would require an extra query per candidate.
+    ///
     /// Projects only `id, title, body` -- never the full `KnowledgeEntry`
     /// with its 768-dim embedding.
     fn get_entries_for_session(
         &self,
         session_id: &str,
         owner: Option<&str>,
+        category: &str,
         ctx: &AgentContext,
     ) -> Result<Vec<DedupCandidate>>;
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -82,6 +82,17 @@ pub struct EditResult {
     pub new_content: String,
 }
 
+/// Lightweight candidate row for write-boundary dedup (W447): id/title/body
+/// only, NEVER the full `KnowledgeEntry` (which carries a 768-dim
+/// embedding). Used to compute `dedup_hash` for each candidate without
+/// paying for the embedding on every dedup check.
+#[derive(Debug, Clone)]
+pub struct DedupCandidate {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+}
+
 /// Result of a reinforce operation
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ReinforcementResult {
@@ -479,6 +490,30 @@ pub trait KnowledgeStore {
 
     /// Get facts extracted from a specific session
     fn get_facts_for_session(&self, session_id: &str) -> Result<Vec<String>>;
+
+    /// Write-boundary dedup candidates (W447): entries whose `session`
+    /// record-link FIELD equals `session_id` (indexed: `knowledge_session`),
+    /// scoped by `owner` (indexed: `knowledge_owner`). Field-scoped, NOT the
+    /// `EXTRACTED_FROM` edge that [`get_facts_for_session`](Self::get_facts_for_session)
+    /// uses -- that edge is frequently absent (session-not-found is a
+    /// warn-and-skip elsewhere in the write path), which would under-fetch
+    /// exactly the entries most prone to duplication.
+    ///
+    /// `owner = None` matches rows where `owner` is unset (public unowned
+    /// adds) -- it does NOT mean "any owner". Cross-owner rows are never
+    /// candidates: this is a hard AND-conjoined predicate in application
+    /// SQL, not a request for `build_visibility_filter`'s public-permissive
+    /// backstop to do the scoping (it admits every owner's public rows and
+    /// provides no owner isolation on its own).
+    ///
+    /// Projects only `id, title, body` -- never the full `KnowledgeEntry`
+    /// with its 768-dim embedding.
+    fn get_entries_for_session(
+        &self,
+        session_id: &str,
+        owner: Option<&str>,
+        ctx: &AgentContext,
+    ) -> Result<Vec<DedupCandidate>>;
 
     /// Get the session a fact was extracted from
     fn get_session_for_fact(&self, fact_id: &str) -> Result<Option<String>>;

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -727,21 +727,27 @@ impl SurrealDatabase {
     /// relationships.rs, which is edge-scoped and frequently under-fetches).
     /// `owner` is a hard AND-conjoined predicate (`knowledge_owner` index):
     /// `Some(o)` binds `owner = $owner`; `None` matches `owner IS NONE`
-    /// (unowned public rows) -- never "any owner". `build_visibility_filter`
-    /// is appended only as a redundant backstop, never the primary scope.
+    /// (unowned public rows) -- never "any owner". `category` is likewise a
+    /// hard AND-conjoined predicate (PR #402 finding 1): bound as a query
+    /// parameter, same as `session_id`/`owner`, so no string interpolation
+    /// / injection surface. `build_visibility_filter` is appended only as a
+    /// redundant backstop, never the primary scope.
     pub fn get_entries_for_session(
         &self,
         session_id: &str,
         owner: Option<&str>,
+        category: &str,
         ctx: &crate::store::AgentContext,
     ) -> Result<Vec<crate::store::DedupCandidate>> {
-        Self::runtime().block_on(self.get_entries_for_session_async(session_id, owner, ctx))
+        Self::runtime()
+            .block_on(self.get_entries_for_session_async(session_id, owner, category, ctx))
     }
 
     async fn get_entries_for_session_async(
         &self,
         session_id: &str,
         owner: Option<&str>,
+        category: &str,
         ctx: &crate::store::AgentContext,
     ) -> Result<Vec<crate::store::DedupCandidate>> {
         let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
@@ -757,12 +763,16 @@ impl SurrealDatabase {
         let sql = format!(
             "SELECT meta::id(id) AS id, title, (body ?? '') AS body
              FROM knowledge
-             WHERE session = type::thing('session', $session_id) {} {}",
+             WHERE session = type::thing('session', $session_id)
+               AND category = type::thing('category', $category) {} {}",
             owner_clause, visibility_clause
         );
 
         let mut response = with_db!(self, db, {
-            let mut q = db.query(&sql).bind(("session_id", session_id.to_string()));
+            let mut q = db
+                .query(&sql)
+                .bind(("session_id", session_id.to_string()))
+                .bind(("category", category.to_string()));
             if let Some(o) = owner {
                 q = q.bind(("owner", o.to_string()));
             }

--- a/src/surreal_db/knowledge.rs
+++ b/src/surreal_db/knowledge.rs
@@ -718,6 +718,78 @@ impl SurrealDatabase {
         Ok(Some(record.into_knowledge_entry(tags, applicability)))
     }
 
+    /// Write-boundary dedup candidates (W447). See
+    /// `KnowledgeStore::get_entries_for_session` for the full contract.
+    ///
+    /// Queries the indexed `session` record-link FIELD directly (matches on
+    /// the `knowledge_session` index, NOT the `EXTRACTED_FROM` edge --
+    /// deliberately NOT modeled on `get_facts_for_session` in
+    /// relationships.rs, which is edge-scoped and frequently under-fetches).
+    /// `owner` is a hard AND-conjoined predicate (`knowledge_owner` index):
+    /// `Some(o)` binds `owner = $owner`; `None` matches `owner IS NONE`
+    /// (unowned public rows) -- never "any owner". `build_visibility_filter`
+    /// is appended only as a redundant backstop, never the primary scope.
+    pub fn get_entries_for_session(
+        &self,
+        session_id: &str,
+        owner: Option<&str>,
+        ctx: &crate::store::AgentContext,
+    ) -> Result<Vec<crate::store::DedupCandidate>> {
+        Self::runtime().block_on(self.get_entries_for_session_async(session_id, owner, ctx))
+    }
+
+    async fn get_entries_for_session_async(
+        &self,
+        session_id: &str,
+        owner: Option<&str>,
+        ctx: &crate::store::AgentContext,
+    ) -> Result<Vec<crate::store::DedupCandidate>> {
+        let (visibility_clause, current_agent) = Self::build_visibility_filter(ctx);
+        let owner_clause = if owner.is_some() {
+            "AND owner = $owner"
+        } else {
+            "AND owner IS NONE"
+        };
+
+        // `body ?? ''` coalesces a NULL body (option<string>, schema:95) so a
+        // None body and an empty-string body hash identically on both sides
+        // of the dedup check (dedup_hash also treats a missing body as "").
+        let sql = format!(
+            "SELECT meta::id(id) AS id, title, (body ?? '') AS body
+             FROM knowledge
+             WHERE session = type::thing('session', $session_id) {} {}",
+            owner_clause, visibility_clause
+        );
+
+        let mut response = with_db!(self, db, {
+            let mut q = db.query(&sql).bind(("session_id", session_id.to_string()));
+            if let Some(o) = owner {
+                q = q.bind(("owner", o.to_string()));
+            }
+            if let Some(agent) = current_agent {
+                q = q.bind(("current_agent", agent));
+            }
+            q.await.context("Failed to query dedup candidates")
+        })?;
+
+        #[derive(Deserialize)]
+        struct DedupRow {
+            id: String,
+            title: String,
+            body: String,
+        }
+        let rows: Vec<DedupRow> = response.take(0)?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| crate::store::DedupCandidate {
+                id: format!("kn-{}", r.id),
+                title: r.title,
+                body: r.body,
+            })
+            .collect())
+    }
+
     /// Delete a knowledge entry (edges cascade automatically).
     /// Respects visibility: agents can only delete entries they can see.
     /// Returns Ok(false) for entries that don't exist OR that the agent can't see

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -3300,3 +3300,185 @@ fn off_dim_row_does_not_abort_cosine_scan() {
         "entry-level scored search must skip the off-dim row; got {scored_ids:?}"
     );
 }
+
+// =========================================================================
+// get_entries_for_session -- write-boundary dedup candidate fetch (W447)
+//
+// Real-store tests (open_in_memory, never a mock) proving the query's
+// field-scoping, hard owner isolation, and None-owner semantics -- the exact
+// seams the W447 round-1/round-2 panels flagged as false-confidence traps.
+// =========================================================================
+
+/// Build an entry for dedup-candidate tests: same shape as `make_test_entry`
+/// but with session/owner/visibility/title/body under test control.
+fn dedup_candidate_entry(
+    id: &str,
+    session_id: &str,
+    owner: Option<&str>,
+    visibility: &str,
+    title: &str,
+    body: &str,
+) -> crate::knowledge::KnowledgeEntry {
+    crate::knowledge::KnowledgeEntry {
+        session_id: Some(session_id.to_string()),
+        owner: owner.map(String::from),
+        visibility: visibility.to_string(),
+        title: title.to_string(),
+        body: Some(body.to_string()),
+        ..make_test_entry(id, 3, 0.0)
+    }
+}
+
+#[test]
+fn test_get_entries_for_session_field_scoped_not_edge_scoped() {
+    // No EXTRACTED_FROM edge is ever created here -- only the `session`
+    // FIELD is set. If the query were edge-scoped (like
+    // get_facts_for_session), this candidate would never be found.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let entry = dedup_candidate_entry(
+        "kn-field-scoped",
+        "sess-1",
+        Some("soren"),
+        "public",
+        "A Title",
+        "Some body",
+    );
+    db.upsert_knowledge(&entry).unwrap();
+
+    let ctx = crate::store::AgentContext::for_agent("soren");
+    let candidates = db
+        .get_entries_for_session("sess-1", Some("soren"), &ctx)
+        .unwrap();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].id, "kn-field-scoped");
+    assert_eq!(candidates[0].title, "A Title");
+    assert_eq!(candidates[0].body, "Some body");
+}
+
+#[test]
+fn test_get_entries_for_session_owner_scope_excludes_other_owners_public_entry() {
+    // RIFT: a same-session PUBLIC entry from a DIFFERENT owner must never be
+    // a dedup candidate -- the owner predicate is a hard AND, not delegated
+    // to the public-permissive visibility backstop.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let entry_b = dedup_candidate_entry(
+        "kn-owner-b-public",
+        "sess-1",
+        Some("agent-b"),
+        "public",
+        "Shared Title",
+        "Shared body",
+    );
+    db.upsert_knowledge(&entry_b).unwrap();
+
+    let ctx = crate::store::AgentContext::for_agent("agent-a");
+    let candidates = db
+        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .unwrap();
+    assert!(
+        candidates.is_empty(),
+        "agent-a's candidate set must never include agent-b's public entry; got {candidates:?}"
+    );
+}
+
+#[test]
+fn test_get_entries_for_session_same_owner_private_entry_is_included() {
+    // Same-owner private regenerations are exactly what W447 targets --
+    // must be visible to the owner's own dedup check.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let entry = dedup_candidate_entry(
+        "kn-owner-a-private",
+        "sess-1",
+        Some("agent-a"),
+        "private",
+        "Private Title",
+        "Private body",
+    );
+    db.upsert_knowledge(&entry).unwrap();
+
+    let ctx = crate::store::AgentContext::for_agent("agent-a");
+    let candidates = db
+        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .unwrap();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].id, "kn-owner-a-private");
+}
+
+#[test]
+fn test_get_entries_for_session_none_owner_matches_only_unowned_rows() {
+    // owner=None must match ownerless rows (`owner IS NONE`) -- NOT "any
+    // owner". An owned row must never appear in the None-owner candidate set.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let unowned = dedup_candidate_entry(
+        "kn-unowned",
+        "sess-1",
+        None,
+        "public",
+        "Unowned Title",
+        "Unowned body",
+    );
+    let owned = dedup_candidate_entry(
+        "kn-owned",
+        "sess-1",
+        Some("agent-a"),
+        "public",
+        "Owned Title",
+        "Owned body",
+    );
+    db.upsert_knowledge(&unowned).unwrap();
+    db.upsert_knowledge(&owned).unwrap();
+
+    let ctx = crate::store::AgentContext::public_only();
+    let candidates = db.get_entries_for_session("sess-1", None, &ctx).unwrap();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].id, "kn-unowned");
+}
+
+#[test]
+fn test_get_entries_for_session_scoped_to_session_field_only() {
+    // A same-owner entry in a DIFFERENT session must not appear.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let entry = dedup_candidate_entry(
+        "kn-other-session",
+        "sess-2",
+        Some("agent-a"),
+        "public",
+        "Title",
+        "Body",
+    );
+    db.upsert_knowledge(&entry).unwrap();
+
+    let ctx = crate::store::AgentContext::for_agent("agent-a");
+    let candidates = db
+        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .unwrap();
+    assert!(candidates.is_empty());
+}
+
+#[test]
+fn test_get_entries_for_session_projection_has_no_embedding_field() {
+    // DedupCandidate structurally carries no embedding field -- this test
+    // documents/pins that the projection is title/body/id only, matching
+    // the perf requirement (never a full KnowledgeEntry with a 768-dim
+    // vector).
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let mut entry = dedup_candidate_entry(
+        "kn-no-embed-leak",
+        "sess-1",
+        Some("agent-a"),
+        "public",
+        "Title",
+        "Body",
+    );
+    entry.embedding = Some(vec![0.1; 768]);
+    db.upsert_knowledge(&entry).unwrap();
+
+    let ctx = crate::store::AgentContext::for_agent("agent-a");
+    let candidates = db
+        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .unwrap();
+    assert_eq!(candidates.len(), 1);
+    // DedupCandidate has no `.embedding` field at all -- if this compiles
+    // and returns id/title/body, the projection never carried the vector.
+    assert_eq!(candidates[0].id, "kn-no-embed-leak");
+}

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -3306,7 +3306,7 @@ fn off_dim_row_does_not_abort_cosine_scan() {
 //
 // Real-store tests (open_in_memory, never a mock) proving the query's
 // field-scoping, hard owner isolation, and None-owner semantics -- the exact
-// seams the W447 round-1/round-2 panels flagged as false-confidence traps.
+// seams flagged in review as false-confidence traps.
 // =========================================================================
 
 /// Build an entry for dedup-candidate tests: same shape as `make_test_entry`

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -3305,12 +3305,14 @@ fn off_dim_row_does_not_abort_cosine_scan() {
 // get_entries_for_session -- write-boundary dedup candidate fetch (W447)
 //
 // Real-store tests (open_in_memory, never a mock) proving the query's
-// field-scoping, hard owner isolation, and None-owner semantics -- the exact
-// seams flagged in review as false-confidence traps.
+// field-scoping, hard owner isolation, category isolation, and None-owner
+// semantics -- the exact seams flagged in review as false-confidence traps.
 // =========================================================================
 
 /// Build an entry for dedup-candidate tests: same shape as `make_test_entry`
 /// but with session/owner/visibility/title/body under test control.
+/// `category_id` defaults to `make_test_entry`'s `"test"` -- use
+/// `dedup_candidate_entry_with_category` when the test needs a different one.
 fn dedup_candidate_entry(
     id: &str,
     session_id: &str,
@@ -3326,6 +3328,23 @@ fn dedup_candidate_entry(
         title: title.to_string(),
         body: Some(body.to_string()),
         ..make_test_entry(id, 3, 0.0)
+    }
+}
+
+/// Same as `dedup_candidate_entry`, with an explicit `category_id` (PR #402
+/// finding 1 category-scoping tests).
+fn dedup_candidate_entry_with_category(
+    id: &str,
+    session_id: &str,
+    owner: Option<&str>,
+    category_id: &str,
+    visibility: &str,
+    title: &str,
+    body: &str,
+) -> crate::knowledge::KnowledgeEntry {
+    crate::knowledge::KnowledgeEntry {
+        category_id: category_id.to_string(),
+        ..dedup_candidate_entry(id, session_id, owner, visibility, title, body)
     }
 }
 
@@ -3347,7 +3366,7 @@ fn test_get_entries_for_session_field_scoped_not_edge_scoped() {
 
     let ctx = crate::store::AgentContext::for_agent("soren");
     let candidates = db
-        .get_entries_for_session("sess-1", Some("soren"), &ctx)
+        .get_entries_for_session("sess-1", Some("soren"), "test", &ctx)
         .unwrap();
     assert_eq!(candidates.len(), 1);
     assert_eq!(candidates[0].id, "kn-field-scoped");
@@ -3373,7 +3392,7 @@ fn test_get_entries_for_session_owner_scope_excludes_other_owners_public_entry()
 
     let ctx = crate::store::AgentContext::for_agent("agent-a");
     let candidates = db
-        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .get_entries_for_session("sess-1", Some("agent-a"), "test", &ctx)
         .unwrap();
     assert!(
         candidates.is_empty(),
@@ -3398,7 +3417,7 @@ fn test_get_entries_for_session_same_owner_private_entry_is_included() {
 
     let ctx = crate::store::AgentContext::for_agent("agent-a");
     let candidates = db
-        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .get_entries_for_session("sess-1", Some("agent-a"), "test", &ctx)
         .unwrap();
     assert_eq!(candidates.len(), 1);
     assert_eq!(candidates[0].id, "kn-owner-a-private");
@@ -3429,7 +3448,9 @@ fn test_get_entries_for_session_none_owner_matches_only_unowned_rows() {
     db.upsert_knowledge(&owned).unwrap();
 
     let ctx = crate::store::AgentContext::public_only();
-    let candidates = db.get_entries_for_session("sess-1", None, &ctx).unwrap();
+    let candidates = db
+        .get_entries_for_session("sess-1", None, "test", &ctx)
+        .unwrap();
     assert_eq!(candidates.len(), 1);
     assert_eq!(candidates[0].id, "kn-unowned");
 }
@@ -3450,9 +3471,47 @@ fn test_get_entries_for_session_scoped_to_session_field_only() {
 
     let ctx = crate::store::AgentContext::for_agent("agent-a");
     let candidates = db
-        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .get_entries_for_session("sess-1", Some("agent-a"), "test", &ctx)
         .unwrap();
     assert!(candidates.is_empty());
+}
+
+#[test]
+fn test_get_entries_for_session_category_scope_excludes_other_categories() {
+    // PR #402 finding 1 (BLOCKER): a same-session, same-owner entry filed
+    // under a DIFFERENT category must never be a dedup candidate. Before
+    // this fix, `get_entries_for_session` scoped only by session+owner, so
+    // identical title+body re-filed under a new category silently
+    // collided -- the second write was skipped as "already saved" under the
+    // WRONG category's row.
+    let db = SurrealDatabase::open_in_memory().unwrap();
+    let other_category = dedup_candidate_entry_with_category(
+        "kn-other-category",
+        "sess-1",
+        Some("agent-a"),
+        "discovery",
+        "public",
+        "Shared Title",
+        "Shared body",
+    );
+    db.upsert_knowledge(&other_category).unwrap();
+
+    let ctx = crate::store::AgentContext::for_agent("agent-a");
+    let candidates = db
+        .get_entries_for_session("sess-1", Some("agent-a"), "recipe", &ctx)
+        .unwrap();
+    assert!(
+        candidates.is_empty(),
+        "a 'recipe'-category query must never surface a 'discovery'-category row \
+         with identical title+body; got {candidates:?}"
+    );
+
+    // The SAME category must still find it.
+    let same_category = db
+        .get_entries_for_session("sess-1", Some("agent-a"), "discovery", &ctx)
+        .unwrap();
+    assert_eq!(same_category.len(), 1);
+    assert_eq!(same_category[0].id, "kn-other-category");
 }
 
 #[test]
@@ -3475,7 +3534,7 @@ fn test_get_entries_for_session_projection_has_no_embedding_field() {
 
     let ctx = crate::store::AgentContext::for_agent("agent-a");
     let candidates = db
-        .get_entries_for_session("sess-1", Some("agent-a"), &ctx)
+        .get_entries_for_session("sess-1", Some("agent-a"), "test", &ctx)
         .unwrap();
     assert_eq!(candidates.len(), 1);
     // DedupCandidate has no `.embedding` field at all -- if this compiles

--- a/src/surreal_db/trait_impl.rs
+++ b/src/surreal_db/trait_impl.rs
@@ -262,6 +262,15 @@ impl KnowledgeStore for SurrealDatabase {
         self.get_facts_for_session(session_id)
     }
 
+    fn get_entries_for_session(
+        &self,
+        session_id: &str,
+        owner: Option<&str>,
+        ctx: &crate::store::AgentContext,
+    ) -> Result<Vec<crate::store::DedupCandidate>> {
+        self.get_entries_for_session(session_id, owner, ctx)
+    }
+
     fn get_session_for_fact(&self, fact_id: &str) -> Result<Option<String>> {
         self.get_session_for_fact(fact_id)
     }

--- a/src/surreal_db/trait_impl.rs
+++ b/src/surreal_db/trait_impl.rs
@@ -266,9 +266,10 @@ impl KnowledgeStore for SurrealDatabase {
         &self,
         session_id: &str,
         owner: Option<&str>,
+        category: &str,
         ctx: &crate::store::AgentContext,
     ) -> Result<Vec<crate::store::DedupCandidate>> {
-        self.get_entries_for_session(session_id, owner, ctx)
+        self.get_entries_for_session(session_id, owner, category, ctx)
     }
 
     fn get_session_for_fact(&self, fact_id: &str) -> Result<Option<String>> {

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1568,6 +1568,7 @@ mod tests {
                 &self,
                 _id: &str,
                 _owner: Option<&str>,
+                _category: &str,
                 _ctx: &AgentContext,
             ) -> Result<Vec<crate::store::DedupCandidate>> {
                 unreachable!()

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1564,6 +1564,14 @@ mod tests {
             fn get_facts_for_session(&self, _id: &str) -> Result<Vec<String>> {
                 unreachable!()
             }
+            fn get_entries_for_session(
+                &self,
+                _id: &str,
+                _owner: Option<&str>,
+                _ctx: &AgentContext,
+            ) -> Result<Vec<crate::store::DedupCandidate>> {
+                unreachable!()
+            }
             fn get_session_for_fact(&self, _id: &str) -> Result<Option<String>> {
                 unreachable!()
             }

--- a/tests/dedup_write_boundary.rs
+++ b/tests/dedup_write_boundary.rs
@@ -108,6 +108,17 @@ fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).to_string()
 }
 
+/// Parse `mx memory list --json` stdout (a bare JSON array of entries) into
+/// its elements, so a test can assert on the actual row count in the store
+/// rather than trusting only the CLI's human-readable summary line.
+fn extract_json_array(text: &str) -> Vec<serde_json::Value> {
+    serde_json::from_str::<serde_json::Value>(text.trim())
+        .unwrap_or_else(|e| panic!("failed to parse JSON array ({e}): {text:?}"))
+        .as_array()
+        .unwrap_or_else(|| panic!("expected a JSON array: {text:?}"))
+        .clone()
+}
+
 // =========================================================================
 // Standard path (add_one), single add
 // =========================================================================
@@ -416,4 +427,123 @@ fn standard_batch_path_also_dedups_via_add_one() {
         "expected exactly one skip: {text}"
     );
     assert!(text.contains("0 failed"), "expected zero failures: {text}");
+}
+
+// =========================================================================
+// Fact-type single-add path (`mx memory add --type <fact_type>`) -- a THIRD
+// new-entry write funnel the round-1/round-2 census never enumerated. It
+// builds a KnowledgeEntry inline and calls `db.upsert_knowledge` directly,
+// never touching `add_one` and never (until this fix) consulting the shared
+// DedupIndex. Requires `--session`: `ensure_group`/`check` both bypass on a
+// `None` session by design (W447 rulings #6), so this suite must always pass
+// `--session` or it would green-pass without ever exercising the gate.
+// =========================================================================
+
+#[test]
+fn single_add_fact_type_path_recased_duplicate_is_skipped_exactly_one_entry() {
+    let env = setup();
+
+    let first = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--type",
+            "insight",
+            "--content",
+            "Ship it, and move on.",
+            "--session",
+            "sess-1",
+            "--no-embed",
+        ],
+    );
+    assert!(first.status.success());
+    assert!(
+        stdout(&first).contains("Added fact:"),
+        "first add must write through: {}",
+        stdout(&first)
+    );
+
+    // Recased/repunctuated re-add of the same content, same session -> must
+    // be skipped, not written as a second entry.
+    let second = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--type",
+            "insight",
+            "--content",
+            "ship it and move on",
+            "--session",
+            "sess-1",
+            "--no-embed",
+        ],
+    );
+    assert!(
+        second.status.success(),
+        "a duplicate-skip must exit 0: {}",
+        stderr(&second)
+    );
+    let second_out = stdout(&second);
+    assert!(
+        second_out.contains("Already saved:"),
+        "recased duplicate must be reported as an affirmative skip, not a second write: {second_out}"
+    );
+    assert!(
+        !second_out.contains("Added fact:"),
+        "recased duplicate must NOT write a second entry: {second_out}"
+    );
+
+    // Confirm exactly one entry actually landed in the store: list the
+    // session's facts and count.
+    let list = mx(&env, &["memory", "list", "--category", "insight", "--json"]);
+    assert!(list.status.success(), "list failed: {}", stderr(&list));
+    let entries = extract_json_array(&stdout(&list));
+    assert_eq!(
+        entries.len(),
+        1,
+        "exactly one entry should exist after a recased re-add via the single-add fact-type path: {:?}",
+        entries
+    );
+}
+
+#[test]
+fn single_add_fact_type_path_allow_duplicate_forces_the_write_through() {
+    let env = setup();
+
+    // Note: same body -> same `fact_title` -> same `generate_id` output for
+    // this fact-routing path, so a same-content re-add overwrites to one row
+    // via `generate_id` regardless of the dedup gate (documented W447 caveat,
+    // mirrors `allow_duplicate_forces_the_second_write_through` above for the
+    // standard path) -- this test asserts `--allow-duplicate` bypasses the
+    // skip (both writes go through, neither says "Already saved"), not a
+    // phantom second row.
+    for _ in 0..2 {
+        let out = mx(
+            &env,
+            &[
+                "memory",
+                "add",
+                "--type",
+                "insight",
+                "--content",
+                "Ship it, and move on.",
+                "--session",
+                "sess-1",
+                "--no-embed",
+                "--allow-duplicate",
+            ],
+        );
+        assert!(out.status.success());
+        let text = stdout(&out);
+        assert!(
+            text.contains("Added fact:"),
+            "--allow-duplicate must force every write through: {text}"
+        );
+        assert!(
+            !text.contains("Already saved:"),
+            "--allow-duplicate must bypass the dedup skip entirely: {text}"
+        );
+    }
 }

--- a/tests/dedup_write_boundary.rs
+++ b/tests/dedup_write_boundary.rs
@@ -1,0 +1,419 @@
+//! CLI-level integration tests for write-boundary dedup (W447).
+//!
+//! Root cause: mx stores `content_hash` but never enforced it, so
+//! regenerated/recased duplicates (same meaning, different case/punctuation)
+//! landed as separate rows. These tests drive the REAL `mx` binary against an
+//! isolated, real SurrealDB (`MX_HOME` per test), covering the two write
+//! funnels the round-1/round-2 panels flagged: `add_one` (single add +
+//! batch-standard) and the add-batch fact-type inline path -- proving BOTH
+//! are gated, not just the one that's easy to test.
+//!
+//! `--no-embed --no-auto-anchor` on every write: entry creation must never
+//! touch the embedding model cache (network-dependent, flaky in CI). The
+//! write-boundary dedup gate runs before either side effect, so this doesn't
+//! change what's under test.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use tempfile::TempDir;
+
+const MX: &str = env!("CARGO_BIN_EXE_mx");
+
+/// Serialize the heavyweight binary invocations (mirrors
+/// `write_side_effect_nonfatal.rs`'s harness style).
+fn test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct Env {
+    dir: TempDir,
+    _guard: MutexGuard<'static, ()>,
+}
+
+fn setup() -> Env {
+    let guard = test_lock().lock().unwrap_or_else(|e| e.into_inner());
+    Env {
+        dir: TempDir::new().unwrap(),
+        _guard: guard,
+    }
+}
+
+/// Isolate the child from any ambient `MX_SURREAL_*` network config in the
+/// invoking shell (this dev sandbox exports `MX_SURREAL_MODE=network` +
+/// live-DB credentials for the Soren hearth) -- force embedded/file-backed
+/// mode under the per-test `MX_HOME` so these tests never touch a shared
+/// live database.
+fn isolate(cmd: &mut Command, home: &std::path::Path) {
+    cmd.env("MX_HOME", home)
+        .env("MX_CURRENT_AGENT", "test-agent")
+        .env("MX_SURREAL_MODE", "embedded")
+        .env_remove("MX_SURREAL_URL")
+        .env_remove("MX_SURREAL_NS")
+        .env_remove("MX_SURREAL_DB")
+        .env_remove("MX_SURREAL_USER")
+        .env_remove("MX_SURREAL_AUTH_LEVEL")
+        .env_remove("MX_SURREAL_ROOT");
+}
+
+fn mx(env: &Env, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(MX);
+    cmd.args(args);
+    isolate(&mut cmd, env.dir.path());
+    cmd.output().expect("failed to run mx")
+}
+
+fn mx_stdin(env: &Env, args: &[&str], stdin: &str) -> std::process::Output {
+    let mut cmd = Command::new(MX);
+    cmd.args(args);
+    isolate(&mut cmd, env.dir.path());
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn mx");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    drop(child.stdin.take());
+    child.wait_with_output().expect("failed to wait on mx")
+}
+
+fn stdout(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// Extract the pretty-printed JSON object from a WRITE-path `--json`
+/// response. Pre-existing, out-of-scope bug (flagged separately, inherited
+/// from the #399 fix): on the WRITE path, `add_one`'s `(embed skipped)` /
+/// `(auto-anchor skipped)` notices print to stdout BEFORE the caller's JSON
+/// payload when `--no-embed`/`--no-auto-anchor` are set, so write-path
+/// `--json` stdout is not pure JSON. The dedup SKIP path is unaffected (it
+/// returns before those notices) -- see `standard_path_recased_duplicate_is_skipped_exactly_one_entry`,
+/// which asserts the skip path's stdout parses as JSON with no slicing.
+fn extract_json(text: &str) -> serde_json::Value {
+    let start = text
+        .find("{\n")
+        .unwrap_or_else(|| panic!("no JSON object found in stdout: {text:?}"));
+    serde_json::from_str(text[start..].trim())
+        .unwrap_or_else(|e| panic!("failed to parse extracted JSON ({e}): {:?}", &text[start..]))
+}
+
+fn stderr(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+// =========================================================================
+// Standard path (add_one), single add
+// =========================================================================
+
+#[test]
+fn standard_path_recased_duplicate_is_skipped_exactly_one_entry() {
+    let env = setup();
+
+    let first = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "The External Plan",
+            "--content",
+            "Ship it, and move on.",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(
+        first.status.success(),
+        "first add must succeed: {}",
+        stderr(&first)
+    );
+    let first_json = extract_json(&stdout(&first));
+    let first_id = first_json["id"].as_str().unwrap().to_string();
+
+    // Recased + repunctuated variant, same session, same (implicit) owner.
+    let second = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "the external plan",
+            "--content",
+            "ship it and move on",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(
+        second.status.success(),
+        "a duplicate-skip must still exit 0: {}",
+        stderr(&second)
+    );
+    let second_json: serde_json::Value = serde_json::from_str(&stdout(&second)).unwrap();
+    assert_eq!(second_json["skipped"], serde_json::json!(true));
+    assert_eq!(
+        second_json["status"],
+        serde_json::json!("already_persisted")
+    );
+    assert_eq!(second_json["duplicate_of"], serde_json::json!(first_id));
+
+    // No non-JSON text on stdout in json mode for the skip path.
+    assert!(
+        serde_json::from_str::<serde_json::Value>(stdout(&second).trim()).is_ok(),
+        "skip --json stdout must be pure JSON, got: {:?}",
+        stdout(&second)
+    );
+}
+
+#[test]
+fn evolved_re_add_different_title_and_body_produces_two_entries() {
+    let env = setup();
+
+    let first = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Plan A",
+            "--content",
+            "Ship it and move on.",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(first.status.success());
+
+    // Genuinely different title AND body -- must NOT be treated as a
+    // duplicate (different generate_id, different dedup_hash).
+    let second = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Plan B",
+            "--content",
+            "Hold off and reassess next week.",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(second.status.success());
+    let second_json = extract_json(&stdout(&second));
+    assert!(
+        second_json.get("skipped").is_none(),
+        "a genuinely different entry must not be skipped: {:?}",
+        second_json
+    );
+}
+
+#[test]
+fn allow_duplicate_forces_the_second_write_through() {
+    let env = setup();
+
+    let first = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Repeated Note",
+            "--content",
+            "Same content twice, on purpose.",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(first.status.success());
+
+    let second = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Repeated Note",
+            "--content",
+            "Same content twice, on purpose.",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+            "--allow-duplicate",
+        ],
+    );
+    assert!(second.status.success());
+    let second_json = extract_json(&stdout(&second));
+    assert!(
+        second_json.get("skipped").is_none(),
+        "--allow-duplicate must force the write through: {:?}",
+        second_json
+    );
+}
+
+#[test]
+fn session_id_none_writes_through_with_no_dedup() {
+    let env = setup();
+
+    for _ in 0..2 {
+        let out = mx(
+            &env,
+            &[
+                "memory",
+                "add",
+                "--category",
+                "insight",
+                "--title",
+                "No Session Note",
+                "--content",
+                "Written without a session id.",
+                "--json",
+                "--no-embed",
+                "--no-auto-anchor",
+            ],
+        );
+        assert!(out.status.success());
+        let json = extract_json(&stdout(&out));
+        assert!(
+            json.get("skipped").is_none(),
+            "session_id=None must bypass dedup entirely (write through): {:?}",
+            json
+        );
+        assert_eq!(
+            json["dedup"],
+            serde_json::json!("bypassed_no_session"),
+            "json payload must surface the bypass signal"
+        );
+    }
+}
+
+// =========================================================================
+// Fact-type add-batch inline path (the funnel round-1 missed entirely --
+// never touches add_one)
+// =========================================================================
+
+#[test]
+fn fact_type_batch_path_idempotent_across_reruns() {
+    let env = setup();
+
+    let batch = "{\"type\": \"insight\", \"content\": \"Ship it, and move on.\", \"session\": \"sess-1\"}\n\
+                 {\"type\": \"insight\", \"content\": \"ship it and move on\", \"session\": \"sess-1\"}\n";
+
+    // First run: two lines, one recased duplicate of the other -> lands 1.
+    let first = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
+    assert!(
+        first.status.success(),
+        "batch with only a duplicate-skip (no hard failures) must still exit 0: {}",
+        stderr(&first)
+    );
+    let first_out = stdout(&first);
+    assert!(
+        first_out.contains("1 added"),
+        "first run must add exactly one entry: {first_out}"
+    );
+    assert!(
+        first_out.contains("1 already saved"),
+        "first run must report exactly one skip: {first_out}"
+    );
+
+    // Re-running the SAME batch: both lines now dedup against the DB ->
+    // zero new entries, proving the fact-type funnel is gated (not just
+    // add_one).
+    let second = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
+    assert!(second.status.success());
+    let second_out = stdout(&second);
+    assert!(
+        second_out.contains("0 added"),
+        "re-running the identical batch must add zero new entries: {second_out}"
+    );
+    assert!(
+        second_out.contains("2 already saved"),
+        "re-running the identical batch must skip both lines: {second_out}"
+    );
+}
+
+#[test]
+fn batch_skip_line_is_positional_and_carries_duplicate_of_id() {
+    let env = setup();
+
+    let batch = "{\"type\": \"insight\", \"content\": \"Ship it, and move on.\", \"session\": \"sess-1\"}\n\
+                 {\"type\": \"insight\", \"content\": \"ship it and move on\", \"session\": \"sess-1\"}\n";
+    mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
+    let out = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
+    let text = stdout(&out);
+
+    // Positional [1] / [2] lines must both read as affirmative "Already
+    // saved" -- never the bare words "skipped" or "duplicate" -- and must
+    // carry a kn- id so positional mark-back can tag the right capture line.
+    assert!(
+        text.contains("[1] Already saved: kn-"),
+        "line 1 must be a positional 'Already saved' line with a kn- id: {text}"
+    );
+    assert!(
+        text.contains("[2] Already saved: kn-"),
+        "line 2 must be a positional 'Already saved' line with a kn- id: {text}"
+    );
+    assert!(
+        !text.to_lowercase().contains("skipped:") && !text.to_lowercase().contains("duplicate:"),
+        "per-entry skip lines must never use bare 'skipped'/'duplicate' framing: {text}"
+    );
+}
+
+#[test]
+fn standard_batch_path_also_dedups_via_add_one() {
+    let env = setup();
+
+    // Title case differs ("Batch Note" vs "batch note") so `generate_id`
+    // (title+path keyed, case-sensitive) would produce TWO DIFFERENT ids --
+    // i.e. without the dedup gate this lands as two separate rows, which is
+    // exactly the W447 evidence class (regenerated duplicates differ only by
+    // case/punctuation). `dedup_hash` normalizes case, so the gate must
+    // still catch it.
+    let batch = "{\"category\": \"insight\", \"title\": \"Batch Note\", \"content\": \"Same body twice.\", \"session_id\": \"sess-1\"}\n\
+                 {\"category\": \"insight\", \"title\": \"batch note\", \"content\": \"same body twice.\", \"session_id\": \"sess-1\"}\n";
+    let out = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
+    assert!(out.status.success());
+    let text = stdout(&out);
+    assert!(text.contains("1 added"), "expected exactly one add: {text}");
+    assert!(
+        text.contains("1 already saved"),
+        "expected exactly one skip: {text}"
+    );
+    assert!(text.contains("0 failed"), "expected zero failures: {text}");
+}

--- a/tests/dedup_write_boundary.rs
+++ b/tests/dedup_write_boundary.rs
@@ -4,7 +4,7 @@
 //! regenerated/recased duplicates (same meaning, different case/punctuation)
 //! landed as separate rows. These tests drive the REAL `mx` binary against an
 //! isolated, real SurrealDB (`MX_HOME` per test), covering the two write
-//! funnels the round-1/round-2 panels flagged: `add_one` (single add +
+//! funnels flagged in review: `add_one` (single add +
 //! batch-standard) and the add-batch fact-type inline path -- proving BOTH
 //! are gated, not just the one that's easy to test.
 //!
@@ -42,9 +42,9 @@ fn setup() -> Env {
 
 /// Isolate the child from any ambient `MX_SURREAL_*` network config in the
 /// invoking shell (this dev sandbox exports `MX_SURREAL_MODE=network` +
-/// live-DB credentials for the Soren hearth) -- force embedded/file-backed
-/// mode under the per-test `MX_HOME` so these tests never touch a shared
-/// live database.
+/// ambient live-DB credentials from the development environment) -- force
+/// embedded/file-backed mode under the per-test `MX_HOME` so these tests
+/// never touch a shared live database.
 fn isolate(cmd: &mut Command, home: &std::path::Path) {
     cmd.env("MX_HOME", home)
         .env("MX_CURRENT_AGENT", "test-agent")
@@ -191,6 +191,24 @@ fn standard_path_recased_duplicate_is_skipped_exactly_one_entry() {
         "skip --json stdout must be pure JSON, got: {:?}",
         stdout(&second)
     );
+
+    // Test-authority fix (fix-round review, finding 3): the CLI's
+    // self-reported `"skipped": true` is not proof nothing was written --
+    // ask the store directly. mystery-meat proved this gap live: a patched
+    // `add_one` that still fell through to a second `upsert_knowledge` after
+    // a detected duplicate kept every `dedup_gate_tests` unit test green and
+    // still printed a clean `"skipped": true`, while `mx memory list` showed
+    // two persisted rows. This assertion is the one thing in the suite that
+    // would have caught that.
+    let list = mx(&env, &["memory", "list", "--category", "insight", "--json"]);
+    assert!(list.status.success(), "list failed: {}", stderr(&list));
+    let entries = extract_json_array(&stdout(&list));
+    assert_eq!(
+        entries.len(),
+        1,
+        "exactly one entry should exist after a recased re-add via the standard path: {:?}",
+        entries
+    );
 }
 
 #[test]
@@ -331,11 +349,108 @@ fn session_id_none_writes_through_with_no_dedup() {
             serde_json::json!("bypassed_no_session"),
             "json payload must surface the bypass signal"
         );
+        // Fix-round review, json-mode double-signal nuance: pre-fix, the
+        // plain-mode stderr note fired UNCONDITIONALLY, so --json mode got
+        // both the stderr note and the json field, contradicting the docs'
+        // mode-exclusive phrasing ("a bypass signal ... in --json mode, and
+        // a stderr note in plain mode"). In --json mode only the json field
+        // should appear.
+        assert!(
+            !stderr(&out).contains("dedup bypassed"),
+            "--json mode must not ALSO print the plain-mode stderr bypass note: {}",
+            stderr(&out)
+        );
     }
 }
 
+#[test]
+fn session_id_none_plain_mode_prints_bypass_note_on_stderr() {
+    let env = setup();
+
+    let out = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "No Session Note Plain",
+            "--content",
+            "Written without a session id, plain mode.",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(out.status.success());
+    assert!(
+        stderr(&out).contains("dedup bypassed"),
+        "plain mode must still print the stderr bypass note: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn skip_json_payload_carries_the_duplicate_id_under_the_id_key() {
+    // Fix-round review, minor finding: every success payload has an `id`
+    // key; the skip payload had none, so `jq -r .id` silently read null on a
+    // skip. The skip payload's `id` must equal `duplicate_of`.
+    let env = setup();
+
+    let first = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Has An Id",
+            "--content",
+            "Content for the id-key regression test.",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(first.status.success());
+    let first_id = extract_json(&stdout(&first))["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let second = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "has an id",
+            "--content",
+            "content for the id-key regression test",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(second.status.success());
+    let second_json: serde_json::Value = serde_json::from_str(&stdout(&second)).unwrap();
+    assert_eq!(
+        second_json["id"],
+        serde_json::json!(first_id),
+        "skip payload's 'id' key must carry the duplicate's id, not be absent: {second_json:?}"
+    );
+    assert_eq!(second_json["duplicate_of"], serde_json::json!(first_id));
+}
+
 // =========================================================================
-// Fact-type add-batch inline path (the funnel round-1 missed entirely --
+// Fact-type add-batch inline path (the funnel earlier review missed entirely --
 // never touches add_one)
 // =========================================================================
 
@@ -354,13 +469,24 @@ fn fact_type_batch_path_idempotent_across_reruns() {
         stderr(&first)
     );
     let first_out = stdout(&first);
+    // Anchored to the full summary line, not a bare `contains("1 added")`
+    // (fix-round review, hygiene finding: that substring also matches "21
+    // added" at larger magnitudes -- harmless today, fragile if this suite
+    // is ever reused at scale).
     assert!(
-        first_out.contains("1 added"),
-        "first run must add exactly one entry: {first_out}"
+        first_out
+            .contains("Batch complete: 1 added, 1 already saved (no action needed), 0 failed."),
+        "first run must add exactly one entry and skip exactly one: {first_out}"
     );
-    assert!(
-        first_out.contains("1 already saved"),
-        "first run must report exactly one skip: {first_out}"
+
+    // Test-authority fix (fix-round review, finding 3): confirm the actual
+    // row count, not just the self-reported summary line.
+    let list = mx(&env, &["memory", "list", "--category", "insight", "--json"]);
+    assert!(list.status.success(), "list failed: {}", stderr(&list));
+    assert_eq!(
+        extract_json_array(&stdout(&list)).len(),
+        1,
+        "exactly one entry should exist after the first batch run"
     );
 
     // Re-running the SAME batch: both lines now dedup against the DB ->
@@ -370,12 +496,18 @@ fn fact_type_batch_path_idempotent_across_reruns() {
     assert!(second.status.success());
     let second_out = stdout(&second);
     assert!(
-        second_out.contains("0 added"),
-        "re-running the identical batch must add zero new entries: {second_out}"
+        second_out
+            .contains("Batch complete: 0 added, 2 already saved (no action needed), 0 failed."),
+        "re-running the identical batch must add zero new entries and skip both lines: {second_out}"
     );
-    assert!(
-        second_out.contains("2 already saved"),
-        "re-running the identical batch must skip both lines: {second_out}"
+
+    let list_again = mx(&env, &["memory", "list", "--category", "insight", "--json"]);
+    assert!(list_again.status.success());
+    assert_eq!(
+        extract_json_array(&stdout(&list_again)).len(),
+        1,
+        "row count must still be exactly one after the identical batch is re-run: {:?}",
+        stdout(&list_again)
     );
 }
 
@@ -421,17 +553,27 @@ fn standard_batch_path_also_dedups_via_add_one() {
     let out = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
     assert!(out.status.success());
     let text = stdout(&out);
-    assert!(text.contains("1 added"), "expected exactly one add: {text}");
+    // Anchored to the full summary line (fix-round review, hygiene finding),
+    // not loose `contains("1 added")` substrings.
     assert!(
-        text.contains("1 already saved"),
-        "expected exactly one skip: {text}"
+        text.contains("Batch complete: 1 added, 1 already saved (no action needed), 0 failed."),
+        "expected exactly one add and one skip: {text}"
     );
-    assert!(text.contains("0 failed"), "expected zero failures: {text}");
+
+    // Test-authority fix (fix-round review, finding 3): confirm the actual
+    // row count via the store, not just the self-reported summary line.
+    let list = mx(&env, &["memory", "list", "--category", "insight", "--json"]);
+    assert!(list.status.success(), "list failed: {}", stderr(&list));
+    assert_eq!(
+        extract_json_array(&stdout(&list)).len(),
+        1,
+        "exactly one entry should exist after a recased duplicate via the standard batch path"
+    );
 }
 
 // =========================================================================
 // Fact-type single-add path (`mx memory add --type <fact_type>`) -- a THIRD
-// new-entry write funnel the round-1/round-2 census never enumerated. It
+// new-entry write funnel earlier review passes never enumerated. It
 // builds a KnowledgeEntry inline and calls `db.upsert_knowledge` directly,
 // never touching `add_one` and never (until this fix) consulting the shared
 // DedupIndex. Requires `--session`: `ensure_group`/`check` both bypass on a
@@ -546,4 +688,125 @@ fn single_add_fact_type_path_allow_duplicate_forces_the_write_through() {
             "--allow-duplicate must bypass the dedup skip entirely: {text}"
         );
     }
+}
+
+// =========================================================================
+// Bypass-signal consistency across all four write funnels (fix-round review,
+// tail finding: "bypass is never silent" held on only the standard `add_one`
+// caller path before this fix -- the other three emitted nothing on a
+// session-less write, contrary to the documented guarantee).
+// =========================================================================
+
+#[test]
+fn single_add_fact_type_path_no_session_emits_bypass_note_on_stderr() {
+    let env = setup();
+
+    let out = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--type",
+            "insight",
+            "--content",
+            "No session here.",
+            "--no-embed",
+        ],
+    );
+    assert!(out.status.success());
+    assert!(
+        stderr(&out).contains("dedup bypassed"),
+        "the single-add fact-type path must surface the bypass note when --session is omitted: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn batch_fact_type_path_no_session_emits_bypass_note_on_stderr() {
+    let env = setup();
+
+    let batch = "{\"type\": \"insight\", \"content\": \"No session on this line.\"}\n";
+    let out = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
+    assert!(out.status.success());
+    assert!(
+        stderr(&out).contains("dedup bypassed"),
+        "the batch fact-type path must surface the bypass note when 'session' is absent: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn standard_batch_path_no_session_id_emits_bypass_note_on_stderr() {
+    let env = setup();
+
+    let batch = "{\"category\": \"insight\", \"title\": \"No Session\", \"content\": \"No session_id on this line.\"}\n";
+    let out = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], batch);
+    assert!(out.status.success());
+    assert!(
+        stderr(&out).contains("dedup bypassed"),
+        "the standard batch path must surface the bypass note when 'session_id' is absent: {}",
+        stderr(&out)
+    );
+}
+
+// =========================================================================
+// Claimed-owner existence oracle (fix-round review, minor finding,
+// author-disclosed and accepted): a `duplicate_of` hit confirms content
+// exists under a CLAIMED owner, before any authz that would reject a forged
+// write. This is accepted behavior, not a bug -- this test PINS it so a
+// future change can't silently alter it without a test failure forcing the
+// question back into view. Extended per the review to the batch per-line
+// owner vector, the sharper form (one batch call can probe many
+// owner+content combinations).
+// =========================================================================
+
+#[test]
+fn batch_per_line_owner_claim_confirms_existence_of_matching_private_content() {
+    let env = setup();
+
+    // "victim" writes a private entry. The schema's `owner` field carries no
+    // PERMISSIONS clause (confirmed: `schema/surrealdb-schema.surql` defines
+    // it as a plain `option<string>`), so this write is not itself gated on
+    // the acting agent matching the claimed owner -- the same is true of the
+    // probe below, which is the point of the disclosure.
+    let victim_write = mx(
+        &env,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "insight",
+            "--title",
+            "Victim Secret",
+            "--content",
+            "Victim's private content.",
+            "--owner",
+            "victim",
+            "--private",
+            "--session-id",
+            "sess-1",
+            "--json",
+            "--no-embed",
+            "--no-auto-anchor",
+        ],
+    );
+    assert!(victim_write.status.success());
+    let victim_id = extract_json(&stdout(&victim_write))["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // "attacker" (a different source_agent) probes the same owner+content
+    // via a single add-batch line -- never having written anything as
+    // "victim" themselves.
+    let probe = "{\"category\": \"insight\", \"title\": \"Victim Secret\", \"content\": \"Victim's private content.\", \"private\": true, \"owner\": \"victim\", \"session_id\": \"sess-1\", \"source_agent\": \"attacker\"}\n";
+    let out = mx_stdin(&env, &["memory", "add-batch", "--no-embed"], probe);
+    assert!(out.status.success());
+    let text = stdout(&out);
+    assert!(
+        text.contains(&format!("Already saved: {}", victim_id)),
+        "a batch line claiming owner=victim with matching content confirms the private \
+         entry's existence via the skip -- accepted per PR #402's Honest Disclosures, \
+         extended to the batch per-line owner vector: {text}"
+    );
 }

--- a/tests/trigger_check.rs
+++ b/tests/trigger_check.rs
@@ -22,12 +22,25 @@ use tempfile::TempDir;
 const MX: &str = env!("CARGO_BIN_EXE_mx");
 
 /// Run `mx` with isolated surreal root + fired-state path. `stdin` is optional.
+///
+/// Isolate the child from any ambient `MX_SURREAL_*` network config in the
+/// invoking shell (this dev sandbox exports `MX_SURREAL_MODE=network` +
+/// ambient live-DB credentials from the development environment) -- force
+/// embedded/file-backed mode under the per-test `MX_SURREAL_ROOT` so these
+/// tests never touch a shared live database. Mirrors the isolation pattern
+/// in `dedup_write_boundary.rs`.
 fn mx(dir: &TempDir, args: &[&str], stdin: Option<&str>) -> std::process::Output {
     let mut cmd = Command::new(MX);
     cmd.args(args)
         .env("MX_CURRENT_AGENT", "test-agent")
+        .env("MX_SURREAL_MODE", "embedded")
         .env("MX_SURREAL_ROOT", dir.path().join("surreal"))
         .env("MX_TRIGGER_FIRED_PATH", dir.path().join("fired.json"))
+        .env_remove("MX_SURREAL_URL")
+        .env_remove("MX_SURREAL_NS")
+        .env_remove("MX_SURREAL_DB")
+        .env_remove("MX_SURREAL_USER")
+        .env_remove("MX_SURREAL_AUTH_LEVEL")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());

--- a/tests/triggers_cli.rs
+++ b/tests/triggers_cli.rs
@@ -35,11 +35,25 @@ fn setup() -> Env {
     }
 }
 
+/// Isolate the child from any ambient `MX_SURREAL_*` network config in the
+/// invoking shell (this dev sandbox exports `MX_SURREAL_MODE=network` +
+/// ambient live-DB credentials from the development environment) -- force
+/// embedded/file-backed mode under the per-test `MX_HOME` so these tests
+/// never touch a shared live database. Same pre-existing leak as
+/// `trigger_check.rs`; mirrors the isolation pattern in
+/// `dedup_write_boundary.rs`.
 fn mx(env: &Env, args: &[&str]) -> std::process::Output {
     Command::new(MX)
         .args(args)
         .env("MX_HOME", env.dir.path())
         .env("MX_CURRENT_AGENT", "test")
+        .env("MX_SURREAL_MODE", "embedded")
+        .env("MX_SURREAL_ROOT", env.dir.path().join("surreal"))
+        .env_remove("MX_SURREAL_URL")
+        .env_remove("MX_SURREAL_NS")
+        .env_remove("MX_SURREAL_DB")
+        .env_remove("MX_SURREAL_USER")
+        .env_remove("MX_SURREAL_AUTH_LEVEL")
         .output()
         .expect("failed to run mx")
 }


### PR DESCRIPTION
## Summary

Store-boundary write dedup for memory. Every `mx memory add` — and every fact-type add — now hashes a **normalized `dedup_hash`** (title+body, lowercased, punctuation-stripped) and checks it against same-owner rows *before* the upsert. On a hit, the write skips and exits 0 with a `duplicate_of` pointer to the row that already holds the content. No new row, no edges, no embedding.

The enforcement lives in one shared pre-upsert helper wired into **both** write paths: the plain `add_one` path and the fact-type add-batch inline path. There was no single choke point before, so the two paths could disagree about what counted as a duplicate. Now they don't.

Candidate lookup is a same-owner fetch keyed on the `session_id` field — visibility-filtered, params bound. Hit -> skip and short-circuit. Miss -> the write proceeds exactly as it does today.

## Design notes

- **Owner scope is a hard AND predicate.** Owner is part of the match, not a filter layered on top. `None` matches null-owner rows, so a public unowned add dedups against *its own kind* rather than colliding with owned content.
- **`DedupIndex` is keyed `(owner, hash)`** so a mixed-owner batch dedups per-owner instead of smearing across owners inside a single add-batch.
- **Skips return `Ok` and short-circuit** ahead of edge-building and embedding. A duplicate costs nothing downstream.
- **`session_id = None` bypasses dedup** and emits an observable json note rather than silently doing nothing. The bounded fallback for the no-session case is deferred, not forgotten.
- **Fix round: one `dedup_gate()` helper.** All three new-entry write funnels (standard `add_one`, single-add `--type`, batch inline `--type`) now call one shared `dedup_gate()` — the check, the bypass-signal, and the fail-open lookup-error handling all live in one place instead of being hand-rolled per funnel.

## Honest disclosures

- The write boundary now **confirms content existence under a claimed owner** (that's what `duplicate_of` tells you). This is bounded to the pre-existing owner-claim authz — it exposes no more than a caller could already assert about their own owner scope, but it is a new confirmation surface and worth naming. **Extended per fix-round review:** `add-batch`'s per-line `source_agent`/`owner` makes this sharper in practice (one batch call can probe many owner+content combinations at once) — same bound, not a new hole. Pinned by `batch_per_line_owner_claim_confirms_existence_of_matching_private_content`.
- **TOCTOU:** the in-process `DedupIndex` is per-process best-effort. Two concurrent writers can still both land the same content — the check-then-write window is real. This matches the pre-existing concurrency posture; we did not make it worse, and we did not close it. **Fix round:** a candidate-*lookup* failure (transient read blip) now fails the gate OPEN rather than aborting the write — a mechanism that already tolerates a check-then-write race should tolerate a read blip the same way.
- **Legacy title-only `content_hash` is untouched.** `dedup_hash` (title+body, W447) is a distinct, additional mechanism. The old hash keeps doing its old job.

## Housekeeping

Motivated by ~20 double-write pairs traced across W342–W445 — regenerated duplicates that exact-match checks slid right past because a regenerated body differs by a comma. Normalization is what catches those.

**Session-scope coverage (raccoon review, garbaggio — RESOLVED):** the ~20 historical double-write pairs were traced (W447) to same-session dual generations (same `session_id`, same resonance, minutes apart); session-scoped dedup covers the observed failure class; cross-session near-duplicates are deliberately out of scope.

**Sibling context for the merger:** PR #401 (exclude-tags) is open on this repo. Both it and this PR touch `src/handlers/memory.rs` and `src/surreal_db/knowledge.rs`, and PR #399 touches the same add-path functions. Landing/merge order across the three is Cory's call — flagging the overlap so it's a decision, not a surprise.

## Fix round (raccoon review response, 8 raccoons + 3 Opus deep-divers)

Both blockers fixed, the structural finding implemented, the test-authority gap closed, and every tail finding fixed or documented. Full per-finding disposition table went to Lens for verification alongside this PR. Summary:

- **[Blocker] `dedup_hash` title/body boundary collapse** — fixed. Hashes the normalized title/body as a length-prefixed pair (not a joined string), so a duplicate that shifts the split point (title one turn, title+body the next) no longer collapses to the same hash. `dedup_hash` is recomputed on every call and never persisted, so there's no migration concern. Regression test added.
- **[Blocker] fail-CLOSED on candidate-lookup error** — fixed. All three funnels now fail OPEN on a lookup error (warn to stderr on all three funnels; the standard path's `--json` also carries a `dedup_lookup_warning` field; write proceeds) via the shared `dedup_gate()`. Unit test injects a lookup failure and asserts the write still lands.
- **[Major] test-authority gap** — fixed. The primary-path skip test (and every other skip test that only read self-reported CLI output) now also asserts the actual persisted row count via `mx memory list --json`.
- **[Structural] gate copy-pasted 3x** — implemented. One `dedup_gate()` helper; all three funnels call it. `garbaggio`'s UNIQUE-index redesign was NOT implemented (see design option below) — this fix is the DRY consolidation only, not a store-level constraint.
- **Tail findings (9):** bypass-signal now consistent across all four funnels (fixed structurally via the shared gate); `--allow-duplicate` silent-overwrite caveat documented on `cli.rs --help`, `docs/src/memory.typ`, and `mx-docs.md` (perturbing the id was considered and rejected — see disclosure above); json-mode double-signal nuance fixed (stderr note now gated on plain mode only); smart-quote/em-dash/ellipsis normalization extended (one-directional safe, false-negative-only); public+owned vs public+unowned dedup gap documented + pinned by a regression test (not fixed — would need an owner-predicate redesign); claimed-owner oracle disclosure extended to the batch per-line owner vector + regression test; unbounded candidate fetch documented as a follow-up (not fixed — see design option below); skip-payload `id` key added; `duplicate_of` last-seen-not-canonical documented; batch-summary test assertions anchored to full lines instead of loose substrings.

## Design option for a future PR (not implemented here)

`garbaggio`'s structural alternative, surfaced but deliberately not built this round: persist `dedup_hash` as a field on `knowledge` and back it with `DEFINE INDEX ... UNIQUE ON knowledge FIELDS session, owner, dedup_hash` (the schema already has the pattern — `tagged_with_unique`, `applies_to_unique`, `relates_to_unique`). That would make "store-boundary" literally true and close the acknowledged TOCTOU gap at the database level, at the cost of mapping a constraint-violation error to `WriteOutcome::Skipped` and a migration to backfill `dedup_hash` on existing rows. Cory's call whether this is worth a follow-up PR — flagging so it's a decision, not a surprise. Also unaddressed this round: `get_entries_for_session` has no result limit, so a very long-lived session pays a full rehash of its group on every write (bounded in practice; a follow-up if it stops being bounded).

## Test plan

- `cargo test` — 1,255 tests green (1,203 baseline + 10 new: 2 in `knowledge.rs`, 2 in `handlers::memory::dedup_gate_tests`, 6 in `tests/dedup_write_boundary.rs`; 3 existing skip-tests strengthened with store-level row-count assertions), 0 failed, 3 pre-existing ignored.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `docs/build.sh` regenerated (`docs/src/memory.typ` touched — dedup section rewritten to cover all four funnels, the fail-open behavior, the allow-duplicate caveat, and the coverage-boundary open questions).

No merge from me — Cory merges.
