### PR TITLE
fix(memory): warn on hidden owned-private matches in list/search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to `mx` are documented here.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
+
+## [Unreleased]
+
+### Added
+- `mx memory list` and `mx memory search` now emit a best-effort **stderr**
+  hint when the caller's own private entries match the query but are hidden by
+  the public-only default (Issue #400). The hint reads
+  `note: N private entr(y|ies) of yours matched but ... hidden; use
+  --include-private to see them`. It fires only when `MX_CURRENT_AGENT` is set
+  and neither `--include-private` nor `--mine` was given. **No change** to
+  stdout, `--json` output, or exit codes — the hint is STDERR only and any
+  error computing it is swallowed silently.
+
+### Changed
+- Documented the `--min-resonance` basis divergence (Issue #404): `wake`
+  filters on **raw** stored resonance, while `list`/`search` filter on
+  time-decayed **effective** resonance. Behavior is unchanged; the flag help
+  text now states which basis each command uses until an explicit
+  `--resonance-basis raw|decayed` flag lands in #404.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,18 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com).
   --include-private to see them`. It fires only when `MX_CURRENT_AGENT` is set
   and neither `--include-private` nor `--mine` was given. **No change** to
   stdout, `--json` output, or exit codes — the hint is STDERR only and any
-  error computing it is swallowed silently.
+  error computing it is swallowed silently. The hint is **suppressed under
+  `search --semantic`**: its count uses the BM25 `@@` text predicate, which does
+  not agree with vector similarity, so counting there would both under- and
+  over-report relative to what `--include-private --semantic` actually shows.
+
+### Fixed
+- Embedded schema application now retries transient SurrealDB
+  "read or write conflict … can be retried" errors with jittered backoff
+  (bounded, `IF NOT EXISTS`-idempotent). Fixes flaky failures when several `mx`
+  processes initialize a fresh store concurrently (surfaced by the integration
+  test suite under parallel load). No change on the happy path — retries only
+  run on a contended init.
 
 ### Changed
 - Documented the `--min-resonance` basis divergence (Issue #404): `wake`

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ mx memory stats
 
 Default categories: `pattern`, `technique`, `insight`, `gotcha`, `reference`, `decision`, `bloom`, `session`. Categories are customizable per-deployment -- run `mx memory categories list` to see available categories.
 
+`mx memory list` and `mx memory search` are **public-only by default** -- your own private entries are omitted unless you pass `--include-private` (or `--mine`). When a public-only query matches private entries you own but hides them, `mx` prints a best-effort hint on **stderr** pointing at `--include-private` (stdout, `--json`, and exit codes are unaffected). See the [memory docs](https://coryzibell.github.io/mx/memory.html) for the full visibility and resonance-basis details.
+
 ### KV Store
 
 Fast local key-value state per agent. Counters, strings, lists, timestamped history, and structured state fields -- all backed by a TOML schema file and a JSON data file. No networking, no database.

--- a/docs/out/llm/mx-docs.md
+++ b/docs/out/llm/mx-docs.md
@@ -377,29 +377,16 @@ Key environment variables recognized by mx. All boolean opt-outs follow
 the same convention: `"1"` or `"true"` (case-insensitive) to disable;
 any other value leaves the default behavior on.
 
+SurrealDB connection variables (`MX_SURREAL_MODE`, `MX_SURREAL_URL`,
+`MX_SURREAL_NS`, `MX_SURREAL_DB`, etc.) are documented in full with
+their defaults in filesystem layout → SurrealDB connection.
+
 +------------------------+-----------------+-----------------+-------------------------+
 | **Variable**           | **Type**        | **Default**     | **Description**         |
 +------------------------+-----------------+-----------------+-------------------------+
 | `MX_HOME`              | path            | `~/.mx/`        | Root directory for all  |
 |                        |                 |                 | mx data. Override to    |
 |                        |                 |                 | move the whole tree.    |
-+------------------------+-----------------+-----------------+-------------------------+
-| `MX_SURREAL_MODE`      | string          | `embedded`      | `embedded` (local       |
-|                        |                 |                 | SurrealKV file) or      |
-|                        |                 |                 | `network` (remote       |
-|                        |                 |                 | WebSocket). Embedding   |
-|                        |                 |                 | model calls only work   |
-|                        |                 |                 | in network mode.        |
-+------------------------+-----------------+-----------------+-------------------------+
-| `MX_SURREAL_URL`       | string          | ---             | WebSocket URL for       |
-|                        |                 |                 | network mode (e.g.      |
-|                        |                 |                 | `ws://localhost:8000`). |
-+------------------------+-----------------+-----------------+-------------------------+
-| `MX_SURREAL_NS`        | string          | ---             | SurrealDB namespace for |
-|                        |                 |                 | network mode.           |
-+------------------------+-----------------+-----------------+-------------------------+
-| `MX_SURREAL_DB`        | string          | ---             | SurrealDB database name |
-|                        |                 |                 | for network mode.       |
 +------------------------+-----------------+-----------------+-------------------------+
 | `MX_CURRENT_AGENT`     | string          | ---             | Active agent            |
 |                        |                 |                 | identifier. Used as     |
@@ -1343,13 +1330,13 @@ Several read commands (`search`, `list`) share a common set of filter
 flags. These are documented once here and referenced below.
 
   **Flag**                     **Type**   **Description**
-  ---------------------------- ---------- ----------------------------------------------------
+  ---------------------------- ---------- -------------------------------------------------------------------------------------------------------------------------------------
   `-c, --category`             `string`   Filter by category (comma-separated).
   `--json`                     `flag`     Output as JSON.
   `--mine`                     `flag`     Show only your private entries.
   `--include-private`          `flag`     Include private entries (requires matching owner).
-  `--min-resonance`            `int`      Minimum resonance level.
-  `--max-resonance`            `int`      Maximum resonance level.
+  `--min-resonance`            `int`      Minimum resonance level. Filtered on the time-decayed **effective** resonance (see note below on the basis divergence with `wake`).
+  `--max-resonance`            `int`      Maximum resonance level. Filtered on the time-decayed **effective** resonance.
   `--has-wake-phrase`          `flag`     Filter to entries WITH a wake phrase.
   `--missing-wake-phrase`      `flag`     Filter to entries WITHOUT a wake phrase.
   `--has-anchors`              `flag`     Filter to entries WITH anchors.
@@ -1358,6 +1345,44 @@ flags. These are documented once here and referenced below.
   `--missing-resonance-type`   `flag`     Filter to entries WITHOUT a resonance type.
   `--limit`                    `int`      Limit number of results.
   `--tags`                     `string`   Filter by tags (comma-separated, matches any).
+
+::: {.admonition .note}
+**NOTE:** **Visibility default:** `list` and `search` run
+**public-only** by default. Your own private entries are omitted unless
+you pass `--include-private` (or `--mine`, which shows only your private
+entries). When a public-only query matches private entries you own but
+hides them, `mx` prints a best-effort **stderr** nudge --- see the note
+below on the hidden-private hint. (`wake`, by contrast, includes
+owned-private blooms in its cascade.)
+:::
+
+::: {.admonition .note}
+**NOTE:** **Hidden-private hint:** When `MX_CURRENT_AGENT` is set and a
+public-only `list`/`search` query matches private entries you own, `mx`
+writes a hint to **stderr** pointing at `--include-private`, e.g.:
+:::
+
+    note: 3 private entries of yours matched but are hidden; use --include-private to see them
+
+The hint is **stderr only** --- it never touches `stdout`, `--json`
+output, or the exit code, and any error computing it is swallowed
+silently. It fires only in the public-only case: passing
+`--include-private` or `--mine` silences it (they already show your
+private entries), and it is **suppressed under `search
+--semantic`** because the underlying count uses the keyword (BM25)
+predicate, which does not agree with vector similarity.
+
+::: {.admonition .note}
+**NOTE:** **Resonance basis divergence (Issue #404):**
+`list`/`search --min-resonance` and `--max-resonance` filter on the
+time-decayed **effective** resonance, whereas `wake --min-resonance`
+filters on the **raw** stored value. The same numeric threshold can
+therefore admit an entry under `wake` but exclude it under
+`list`/`search` once decay is applied. `foundational` and
+`transformative` resonance types are decay-exempt, so they filter
+identically under both. This divergence is intentional for now; an
+explicit `--resonance-basis raw|decayed` flag is tracked in #404.
+:::
 
 ## `mx memory show`
 
@@ -1400,7 +1425,9 @@ mx memory list --missing-wake-phrase --limit 20
 ```
 
 ::: {.admonition .note}
-**NOTE:** `list` accepts all shared filter flags documented above.
+**NOTE:** `list` accepts all shared filter flags documented above,
+including the public-only visibility default and the hidden-private
+stderr hint.
 :::
 
 ## `mx memory search`
@@ -1435,8 +1462,10 @@ mx memory search "retry pattern" --activate
 ```
 
 ::: {.admonition .note}
-**NOTE:** `search` accepts all shared filter flags. Semantic search
-requires entries to have embeddings generated via `mx memory embed`.
+**NOTE:** `search` accepts all shared filter flags, including the
+public-only visibility default and the hidden-private stderr hint (the
+hint is suppressed under `--semantic`). Semantic search requires entries
+to have embeddings generated via `mx memory embed`.
 :::
 
 ::: {.admonition .tip}
@@ -1679,9 +1708,9 @@ and presents them in the requested format.
 ### Flags
 
   **Flag**            **Type**   **Description**
-  ------------------- ---------- -------------------------------------------------------------------------------------
+  ------------------- ---------- ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   `-l, --limit`       `int`      Number of blooms to return. Default: `20`.
-  `--min-resonance`   `int`      Minimum resonance threshold -- get ALL blooms \>= this value (overrides `--limit`).
+  `--min-resonance`   `int`      Minimum resonance threshold -- get ALL blooms \>= this value (overrides `--limit`). Filtered on the **raw** stored resonance, unlike `list`/`search`, which use the decayed **effective** value (Issue #404).
   `-d, --days`        `int`      Include memories activated in last N days. Default: `7`.
   `--no-activate`     `flag`     Do not update activation counts.
   `--begin`           `flag`     Start token-based wake ritual. Returns first bloom and session token.
@@ -7535,6 +7564,17 @@ schema setup is required.
 The `apply_schema` method on `SurrealDatabase` uses the `with_db!` macro
 so the same code path runs against both the embedded and network
 backends.
+
+::: {.admonition .note}
+**NOTE:** **Contended init:** when several `mx` processes bootstrap a
+fresh store concurrently, embedded SurrealDB can return a transient
+*"read or write conflict ... can be retried"* error during schema
+application. `apply_schema` retries these with bounded, jittered backoff
+(up to 12 attempts, with per-process-entropy jitter to de-correlate
+racing writers). Because every schema statement is `IF NOT EXISTS` /
+`UPSERT`, retries are idempotent. The happy, uncontended path is
+untouched -- retries run only when a conflict is actually observed.
+:::
 
 #### `MX_SKIP_SCHEMA`
 

--- a/docs/src/architecture.typ
+++ b/docs/src/architecture.typ
@@ -334,6 +334,15 @@ first connection -- no manual schema setup is required.
 The `apply_schema` method on `SurrealDatabase` uses the `with_db!` macro so the
 same code path runs against both the embedded and network backends.
 
+#note[*Contended init:* when several `mx` processes bootstrap a fresh store
+concurrently, embedded SurrealDB can return a transient _"read or write
+conflict ... can be retried"_ error during schema application. `apply_schema`
+retries these with bounded, jittered backoff (up to 12 attempts, with
+per-process-entropy jitter to de-correlate racing writers). Because every schema
+statement is `IF NOT EXISTS` / `UPSERT`, retries are idempotent. The happy,
+uncontended path is untouched -- retries run only when a conflict is actually
+observed.]
+
 ==== `MX_SKIP_SCHEMA`
 
 Set `MX_SKIP_SCHEMA=1` (or `true`) to skip schema application at connection

--- a/docs/src/memory.typ
+++ b/docs/src/memory.typ
@@ -142,8 +142,8 @@ flags. These are documented once here and referenced below.
   [`--json`],          [`flag`],   [Output as JSON.],
   [`--mine`],          [`flag`],   [Show only your private entries.],
   [`--include-private`], [`flag`], [Include private entries (requires matching owner).],
-  [`--min-resonance`], [`int`],    [Minimum resonance level.],
-  [`--max-resonance`], [`int`],    [Maximum resonance level.],
+  [`--min-resonance`], [`int`],    [Minimum resonance level. Filtered on the time-decayed *effective* resonance (see note below on the basis divergence with `wake`).],
+  [`--max-resonance`], [`int`],    [Maximum resonance level. Filtered on the time-decayed *effective* resonance.],
   [`--has-wake-phrase`], [`flag`],  [Filter to entries WITH a wake phrase.],
   [`--missing-wake-phrase`], [`flag`], [Filter to entries WITHOUT a wake phrase.],
   [`--has-anchors`],   [`flag`],   [Filter to entries WITH anchors.],
@@ -153,6 +153,37 @@ flags. These are documented once here and referenced below.
   [`--limit`],         [`int`],    [Limit number of results.],
   [`--tags`],          [`string`], [Filter by tags (comma-separated, matches any).],
 )
+
+#note[*Visibility default:* `list` and `search` run *public-only* by default.
+Your own private entries are omitted unless you pass `--include-private` (or
+`--mine`, which shows only your private entries). When a public-only query
+matches private entries you own but hides them, `mx` prints a best-effort
+*stderr* nudge --- see the note below on the hidden-private hint. (`wake`, by
+contrast, includes owned-private blooms in its cascade.)]
+
+#note[*Hidden-private hint:* When `MX_CURRENT_AGENT` is set and a public-only
+`list`/`search` query matches private entries you own, `mx` writes a hint to
+*stderr* pointing at `--include-private`, e.g.:
+
+```
+note: 3 private entries of yours matched but are hidden; use --include-private to see them
+```
+
+The hint is *stderr only* --- it never touches `stdout`, `--json` output, or the
+exit code, and any error computing it is swallowed silently. It fires only in
+the public-only case: passing `--include-private` or `--mine` silences it (they
+already show your private entries), and it is *suppressed under `search
+--semantic`* because the underlying count uses the keyword (BM25) predicate,
+which does not agree with vector similarity.]
+
+#note[*Resonance basis divergence (Issue \#404):* `list`/`search --min-resonance`
+and `--max-resonance` filter on the time-decayed *effective* resonance, whereas
+`wake --min-resonance` filters on the *raw* stored value. The same numeric
+threshold can therefore admit an entry under `wake` but exclude it under
+`list`/`search` once decay is applied. `foundational` and `transformative`
+resonance types are decay-exempt, so they filter identically under both. This
+divergence is intentional for now; an explicit `--resonance-basis raw|decayed`
+flag is tracked in \#404.]
 
 #command(
   "mx memory show",
@@ -179,7 +210,8 @@ flags. These are documented once here and referenced below.
   ),
 )
 
-#note[`list` accepts all shared filter flags documented above.]
+#note[`list` accepts all shared filter flags documented above, including the
+public-only visibility default and the hidden-private stderr hint.]
 
 #command(
   "mx memory search",
@@ -197,8 +229,10 @@ flags. These are documented once here and referenced below.
   ),
 )
 
-#note[`search` accepts all shared filter flags. Semantic search requires entries
-to have embeddings generated via `mx memory embed`.]
+#note[`search` accepts all shared filter flags, including the public-only
+visibility default and the hidden-private stderr hint (the hint is suppressed
+under `--semantic`). Semantic search requires entries to have embeddings
+generated via `mx memory embed`.]
 
 #tip[By default, search does not activate results -- browsing is not the same as
 engagement. Use `--activate` when you are intentionally consuming the results
@@ -386,7 +420,7 @@ cascade; a token-based ritual flow is available for programmatic use.
   and presents them in the requested format.],
   flags: (
     ([`-l, --limit`],   [`int`],    [Number of blooms to return. Default: `20`.]),
-    ([`--min-resonance`], [`int`],   [Minimum resonance threshold -- get ALL blooms >= this value (overrides `--limit`).]),
+    ([`--min-resonance`], [`int`],   [Minimum resonance threshold -- get ALL blooms >= this value (overrides `--limit`). Filtered on the *raw* stored resonance, unlike `list`/`search`, which use the decayed *effective* value (Issue \#404).]),
     ([`-d, --days`],    [`int`],    [Include memories activated in last N days. Default: `7`.]),
     ([`--no-activate`], [`flag`],   [Do not update activation counts.]),
     ([`--begin`],       [`flag`],   [Start token-based wake ritual. Returns first bloom and session token.]),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -365,11 +365,18 @@ pub struct EntryFilter {
     #[arg(long)]
     pub include_private: bool,
 
-    /// Minimum resonance level
+    /// Minimum resonance level (filtered on time-decayed EFFECTIVE resonance)
+    ///
+    /// NOTE (#404): `list`/`search` filter on the decay-adjusted *effective*
+    /// resonance, whereas `wake --min-resonance` filters on the *raw* stored
+    /// value. The same numeric threshold can therefore include an entry under
+    /// `wake` but exclude it here once decay is applied. This divergence is
+    /// intentional for now and will be made explicit via a
+    /// `--resonance-basis raw|decayed` flag in #404.
     #[arg(long)]
     pub min_resonance: Option<i32>,
 
-    /// Maximum resonance level
+    /// Maximum resonance level (filtered on time-decayed EFFECTIVE resonance)
     #[arg(long)]
     pub max_resonance: Option<i32>,
 
@@ -1137,6 +1144,13 @@ pub enum MemoryCommands {
         limit: usize,
 
         /// Minimum resonance threshold - get ALL blooms >= this value (overrides --limit)
+        ///
+        /// NOTE (#404): `wake` filters on the *raw* stored resonance value,
+        /// whereas `list`/`search --min-resonance` filter on the time-decayed
+        /// *effective* resonance. The same threshold can thus admit an entry
+        /// here that `list`/`search` would exclude after decay. Intentional for
+        /// now; a `--resonance-basis raw|decayed` flag in #404 will make the
+        /// basis explicit.
         #[arg(long)]
         min_resonance: Option<i32>,
 

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -568,7 +568,9 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Issue #400: nudge (stderr only) if the caller's OWN private
             // entries matched but were hidden by the public-only default.
-            warn_hidden_private(db.as_ref(), &ctx, &filter, Some(&query));
+            // Suppressed under `--semantic` (W1): the hint counts with the BM25
+            // `@@` predicate, which does not agree with vector similarity.
+            warn_hidden_private(db.as_ref(), &ctx, &filter, Some(&query), semantic);
 
             // --activate: activate returned results (mark as intentionally consumed)
             if activate && !entries.is_empty() {
@@ -640,7 +642,8 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
 
             // Issue #400: nudge (stderr only) if the caller's OWN private
             // entries matched but were hidden by the public-only default.
-            warn_hidden_private(db.as_ref(), &ctx, &filter, None);
+            // `list` has no semantic mode, so `semantic = false` always.
+            warn_hidden_private(db.as_ref(), &ctx, &filter, None, false);
         }
 
         MemoryCommands::Show {

--- a/src/handlers/memory.rs
+++ b/src/handlers/memory.rs
@@ -566,6 +566,10 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                 }
             }
 
+            // Issue #400: nudge (stderr only) if the caller's OWN private
+            // entries matched but were hidden by the public-only default.
+            warn_hidden_private(db.as_ref(), &ctx, &filter, Some(&query));
+
             // --activate: activate returned results (mark as intentionally consumed)
             if activate && !entries.is_empty() {
                 let ids: Vec<String> = entries.iter().map(|e| e.id.clone()).collect();
@@ -633,6 +637,10 @@ pub(crate) fn handle_memory(cmd: MemoryCommands, verbose: bool) -> Result<()> {
                     print_entry_summary(&entry);
                 }
             }
+
+            // Issue #400: nudge (stderr only) if the caller's OWN private
+            // entries matched but were hidden by the public-only default.
+            warn_hidden_private(db.as_ref(), &ctx, &filter, None);
         }
 
         MemoryCommands::Show {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1679,14 +1679,8 @@ mod hidden_private_hint_tests {
     #[test]
     fn hint_appears_for_list_when_owned_private_hidden() {
         let db = SurrealDatabase::open_in_memory().unwrap();
-        db.upsert_knowledge(&priv_entry(
-            "kn-a",
-            "agent-a",
-            "my note",
-            "body",
-            vec![],
-        ))
-        .unwrap();
+        db.upsert_knowledge(&priv_entry("kn-a", "agent-a", "my note", "body", vec![]))
+            .unwrap();
 
         // Default view for a known agent: public-only ctx, agent_id set.
         let ctx = AgentContext::public_for_agent("agent-a");

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -168,6 +168,96 @@ pub(crate) fn resolve_agent_context(mine: bool, include_private: bool) -> store:
     }
 }
 
+/// Compute the "hidden private entries" hint for a `list`/`search` query, or
+/// `None` when no hint should be shown (Issue #400).
+///
+/// The public-only default of `list`/`search` silently omits the caller's OWN
+/// private entries (an ~85% undercount was observed), while `wake` includes
+/// them. This surfaces that gap as a best-effort, stderr-only nudge — it never
+/// touches stdout, `--json` output, or the exit code. This function is PURE
+/// w.r.t. output: it returns the message string and lets the caller
+/// (`warn_hidden_private`) do the `eprintln!`, which keeps it unit-testable.
+///
+/// Returns `None` (no hint) when ANY of the following hold:
+///   - the context already includes private entries (`ctx.include_private`),
+///     i.e. `--include-private` or `--mine` was given — those already show them;
+///   - there is no calling agent (`MX_CURRENT_AGENT` unset ⇒ `agent_id` is
+///     `None`), so there are no owned-private entries to hide;
+///   - the count query errors — the hint is best-effort and must NEVER fail the
+///     command over a diagnostic;
+///   - zero owned-private entries survive the SAME in-memory filters
+///     (`apply_entry_filters`, minus the display limit) the main query applies.
+///
+/// `query` is `Some(terms)` for `search` (matched with the same `@@` full-text
+/// predicate) and `None` for `list`.
+pub(crate) fn hidden_private_hint(
+    db: &dyn store::KnowledgeStore,
+    ctx: &store::AgentContext,
+    filter: &EntryFilter,
+    query: Option<&str>,
+) -> Option<String> {
+    // Trigger only in the default (public-only) view AND when there is a
+    // calling agent whose private entries could exist. `--include-private` and
+    // `--mine` both resolve to `include_private = true`, so they no-op here;
+    // an anonymous/no-agent context has `agent_id == None` and also no-ops.
+    if ctx.include_private {
+        return None;
+    }
+    let agent = ctx.agent_id.as_deref()?;
+
+    // Same category + resonance filter the main query builds. Category is
+    // sourced from the flag (list handles categories in the handler; here we
+    // fold them into the DB filter so build_category_filter matches all of
+    // them at once — equivalent to the union of the per-category queries).
+    let db_filter = store::KnowledgeFilter {
+        min_resonance: filter.min_resonance,
+        max_resonance: filter.max_resonance,
+        categories: filter.category.clone(),
+    };
+
+    // Best-effort: on ANY error, stay silent. The hint must never turn a
+    // successful list/search into a failure (kn-97344000: don't trade one
+    // silent-data defect for a louder one).
+    let candidates = db.owned_private_matching(agent, query, &db_filter).ok()?;
+
+    // Apply the SAME in-memory filters the main query uses (tags + field
+    // presence), but with the display `limit` stripped: the hint reports how
+    // many owned-private matches are hidden in total, not just the first page.
+    let mut filter_no_limit = filter.clone();
+    filter_no_limit.limit = None;
+    let count = apply_entry_filters(candidates, &filter_no_limit).len();
+
+    if count == 0 {
+        return None;
+    }
+
+    let (noun, verb) = if count == 1 {
+        ("entry", "is")
+    } else {
+        ("entries", "are")
+    };
+    Some(format!(
+        "note: {count} private {noun} of yours matched but {verb} hidden; \
+         use --include-private to see them"
+    ))
+}
+
+/// Print the [`hidden_private_hint`] to STDERR when one applies (Issue #400).
+///
+/// Side-effect wrapper: STDERR only, so it can never alter stdout, `--json`
+/// output, or the exit code. No-ops entirely when `hidden_private_hint`
+/// returns `None`.
+pub(crate) fn warn_hidden_private(
+    db: &dyn store::KnowledgeStore,
+    ctx: &store::AgentContext,
+    filter: &EntryFilter,
+    query: Option<&str>,
+) {
+    if let Some(msg) = hidden_private_hint(db, ctx, filter, query) {
+        eprintln!("{msg}");
+    }
+}
+
 /// Similarity threshold above which two entries are considered near-duplicates
 /// and should NOT be anchored together. Used in both the batch `AutoAnchor`
 /// handler and the per-entry `auto_anchor` helper.
@@ -1494,5 +1584,328 @@ mod auto_anchor_tests {
             !embed_gate_with_env(Some("0"), true),
             "--no-embed must skip embedding even when env flag would allow it"
         );
+    }
+}
+
+#[cfg(test)]
+mod hidden_private_hint_tests {
+    //! Issue #400: the stderr hint that surfaces the caller's OWN private
+    //! entries when list/search hide them behind the public-only default.
+    //!
+    //! `hidden_private_hint` is pure w.r.t. output (returns the message or
+    //! `None`), so these tests assert the trigger matrix and message text
+    //! directly. STDOUT/JSON invariance is structural: the hint value only ever
+    //! reaches the terminal via `warn_hidden_private`'s `eprintln!` (STDERR),
+    //! and the handlers call it AFTER all stdout/JSON printing — no code path
+    //! lets it touch stdout.
+
+    use super::*;
+    use crate::cli::EntryFilter;
+    use crate::knowledge::KnowledgeEntry;
+    use crate::store::{AgentContext, KnowledgeStore};
+    use crate::surreal_db::SurrealDatabase;
+    use serial_test::serial;
+
+    /// A baseline `EntryFilter` with every flag off / unset. Tests tweak the
+    /// one field under test.
+    fn base_filter() -> EntryFilter {
+        EntryFilter {
+            category: None,
+            json: false,
+            mine: false,
+            include_private: false,
+            min_resonance: None,
+            max_resonance: None,
+            has_wake_phrase: false,
+            missing_wake_phrase: false,
+            has_anchors: false,
+            missing_anchors: false,
+            has_resonance_type: false,
+            missing_resonance_type: false,
+            limit: None,
+            tags: None,
+        }
+    }
+
+    /// An owned-private entry for `owner`, with the given id/title/body/tags.
+    fn priv_entry(
+        id: &str,
+        owner: &str,
+        title: &str,
+        body: &str,
+        tags: Vec<String>,
+    ) -> KnowledgeEntry {
+        let now = chrono::Utc::now().to_rfc3339();
+        KnowledgeEntry {
+            id: id.to_string(),
+            category_id: "test".to_string(),
+            title: title.to_string(),
+            body: Some(body.to_string()),
+            summary: None,
+            applicability: vec![],
+            source_project_id: None,
+            source_agent_id: None,
+            file_path: None,
+            tags,
+            created_at: Some(now.clone()),
+            updated_at: Some(now.clone()),
+            content_hash: Some(format!("hash-{id}")),
+            source_type_id: Some("manual".to_string()),
+            entry_type_id: Some("primary".to_string()),
+            session_id: None,
+            ephemeral: false,
+            content_type_id: Some("text".to_string()),
+            owner: Some(owner.to_string()),
+            visibility: "private".to_string(),
+            resonance: 5,
+            resonance_type: Some("ephemeral".to_string()),
+            last_activated: Some(now),
+            activation_count: 0,
+            decay_rate: 0.0,
+            anchors: vec![],
+            wake_phrases: vec![],
+            triggers: vec![],
+            wake_order: None,
+            wake_phrase: None,
+            embedding: None,
+            embedding_model: None,
+            embedded_at: None,
+            chunk_count: 0,
+            format: "markdown".to_string(),
+            effective_resonance: None,
+        }
+    }
+
+    #[test]
+    fn hint_appears_for_list_when_owned_private_hidden() {
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry(
+            "kn-a",
+            "agent-a",
+            "my note",
+            "body",
+            vec![],
+        ))
+        .unwrap();
+
+        // Default view for a known agent: public-only ctx, agent_id set.
+        let ctx = AgentContext::public_for_agent("agent-a");
+        let msg = hidden_private_hint(&db, &ctx, &base_filter(), None)
+            .expect("hint should fire for a hidden owned-private match");
+
+        assert!(msg.contains("1 private entry of yours"), "msg: {msg}");
+        assert!(msg.contains("is hidden"), "msg: {msg}");
+        assert!(msg.contains("--include-private"), "msg: {msg}");
+    }
+
+    #[test]
+    fn hint_pluralizes_for_multiple_matches() {
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry("kn-a", "agent-a", "one", "b", vec![]))
+            .unwrap();
+        db.upsert_knowledge(&priv_entry("kn-b", "agent-a", "two", "b", vec![]))
+            .unwrap();
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+        let msg = hidden_private_hint(&db, &ctx, &base_filter(), None).unwrap();
+
+        assert!(msg.contains("2 private entries of yours"), "msg: {msg}");
+        assert!(msg.contains("are hidden"), "msg: {msg}");
+    }
+
+    #[test]
+    fn hint_appears_for_search_matching_query() {
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry(
+            "kn-a",
+            "agent-a",
+            "unique searchable widget",
+            "unique searchable widget content",
+            vec![],
+        ))
+        .unwrap();
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+        let msg = hidden_private_hint(&db, &ctx, &base_filter(), Some("widget"))
+            .expect("search hint should fire when an owned-private entry matches the query");
+        assert!(msg.contains("1 private entry of yours"), "msg: {msg}");
+    }
+
+    #[test]
+    fn hint_absent_for_search_when_query_does_not_match() {
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry(
+            "kn-a",
+            "agent-a",
+            "unrelated sprocket",
+            "unrelated sprocket content",
+            vec![],
+        ))
+        .unwrap();
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+        assert!(
+            hidden_private_hint(&db, &ctx, &base_filter(), Some("widget")).is_none(),
+            "no hint when the owned-private entry doesn't match the search terms"
+        );
+    }
+
+    #[test]
+    fn hint_absent_with_include_private_context() {
+        // `--include-private` resolves to a for_agent ctx (include_private=true).
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry("kn-a", "agent-a", "note", "b", vec![]))
+            .unwrap();
+
+        let ctx = AgentContext::for_agent("agent-a");
+        assert!(
+            hidden_private_hint(&db, &ctx, &base_filter(), None).is_none(),
+            "--include-private already shows private entries -> no hint"
+        );
+    }
+
+    #[test]
+    fn hint_absent_with_no_calling_agent() {
+        // No MX_CURRENT_AGENT -> public_only ctx (agent_id = None).
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry("kn-a", "agent-a", "note", "b", vec![]))
+            .unwrap();
+
+        let ctx = AgentContext::public_only();
+        assert!(
+            hidden_private_hint(&db, &ctx, &base_filter(), None).is_none(),
+            "no calling agent -> nothing owned to hide -> no hint"
+        );
+    }
+
+    #[test]
+    fn hint_absent_when_no_owned_private_matches() {
+        // Only ANOTHER agent's private entry exists; caller has none.
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry("kn-b", "agent-b", "theirs", "b", vec![]))
+            .unwrap();
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+        assert!(
+            hidden_private_hint(&db, &ctx, &base_filter(), None).is_none(),
+            "caller has no owned-private matches (and must never count agent-b's) -> no hint"
+        );
+    }
+
+    #[test]
+    fn hint_respects_tag_filter() {
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry(
+            "kn-a",
+            "agent-a",
+            "note",
+            "b",
+            vec!["focus".to_string()],
+        ))
+        .unwrap();
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+
+        // Tag that the entry does NOT have -> filtered out in-memory -> no hint.
+        let mut f = base_filter();
+        f.tags = Some(vec!["nonmatch".to_string()]);
+        assert!(
+            hidden_private_hint(&db, &ctx, &f, None).is_none(),
+            "tag filter must apply to the hint count exactly as to the main query"
+        );
+
+        // Matching tag -> hint fires.
+        let mut f2 = base_filter();
+        f2.tags = Some(vec!["focus".to_string()]);
+        assert!(
+            hidden_private_hint(&db, &ctx, &f2, None).is_some(),
+            "a matching tag filter must still surface the hidden owned-private entry"
+        );
+    }
+
+    #[test]
+    fn hint_count_ignores_display_limit() {
+        // The display `--limit` truncates the visible list but must NOT cap the
+        // hint count: the hint reports the TOTAL owned-private matches hidden.
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        for i in 0..3 {
+            db.upsert_knowledge(&priv_entry(
+                &format!("kn-{i}"),
+                "agent-a",
+                "note",
+                "b",
+                vec![],
+            ))
+            .unwrap();
+        }
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+        let mut f = base_filter();
+        f.limit = Some(1);
+        let msg = hidden_private_hint(&db, &ctx, &f, None).unwrap();
+        assert!(
+            msg.contains("3 private entries of yours"),
+            "hint counts all hidden matches regardless of --limit; msg: {msg}"
+        );
+    }
+
+    // --- resolve_agent_context flag -> ctx mapping (the hint's trigger seam) ---
+    // These pin the mapping the hint relies on: only the DEFAULT branch (no
+    // --mine, no --include-private) yields include_private=false, which is the
+    // sole case that can fire the hint. --mine and --include-private both flip
+    // include_private=true and thus suppress it.
+
+    fn with_agent_env<T>(agent: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let prev = std::env::var("MX_CURRENT_AGENT").ok();
+        unsafe {
+            match agent {
+                Some(a) => std::env::set_var("MX_CURRENT_AGENT", a),
+                None => std::env::remove_var("MX_CURRENT_AGENT"),
+            }
+        }
+        let out = f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("MX_CURRENT_AGENT", v),
+                None => std::env::remove_var("MX_CURRENT_AGENT"),
+            }
+        }
+        out
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_context_default_branch_is_the_only_hint_trigger() {
+        with_agent_env(Some("agent-a"), || {
+            let default_ctx = resolve_agent_context(false, false);
+            assert!(
+                !default_ctx.include_private && default_ctx.agent_id.is_some(),
+                "default branch: public-only view with a known agent -> CAN trigger hint"
+            );
+
+            let mine_ctx = resolve_agent_context(true, false);
+            assert!(
+                mine_ctx.include_private,
+                "--mine flips include_private=true -> hint suppressed"
+            );
+
+            let incl_ctx = resolve_agent_context(false, true);
+            assert!(
+                incl_ctx.include_private,
+                "--include-private flips include_private=true -> hint suppressed"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_context_no_agent_never_triggers_hint() {
+        with_agent_env(None, || {
+            let ctx = resolve_agent_context(false, false);
+            assert!(
+                ctx.agent_id.is_none(),
+                "no MX_CURRENT_AGENT -> agent_id None -> hint suppressed"
+            );
+        });
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -179,6 +179,14 @@ pub(crate) fn resolve_agent_context(mine: bool, include_private: bool) -> store:
 /// (`warn_hidden_private`) do the `eprintln!`, which keeps it unit-testable.
 ///
 /// Returns `None` (no hint) when ANY of the following hold:
+///   - the search ran in `--semantic` mode (`semantic == true`): the count
+///     query below matches with the BM25 `@@` text predicate, which does NOT
+///     mirror vector similarity. Counting under semantic mode would produce both
+///     false negatives (a semantic match with no literal term overlap goes
+///     uncounted — the very #400 undercount this exists to fix) and false
+///     positives (a literal `@@` match that isn't in the top-N vector results,
+///     or isn't embedded at all, would promise an entry `--include-private
+///     --semantic` never shows). So the hint is gated off entirely there;
 ///   - the context already includes private entries (`ctx.include_private`),
 ///     i.e. `--include-private` or `--mine` was given — those already show them;
 ///   - there is no calling agent (`MX_CURRENT_AGENT` unset ⇒ `agent_id` is
@@ -188,14 +196,26 @@ pub(crate) fn resolve_agent_context(mine: bool, include_private: bool) -> store:
 ///   - zero owned-private entries survive the SAME in-memory filters
 ///     (`apply_entry_filters`, minus the display limit) the main query applies.
 ///
-/// `query` is `Some(terms)` for `search` (matched with the same `@@` full-text
-/// predicate) and `None` for `list`.
+/// `query` is `Some(terms)` for `search` (matched with the same BM25 `@@`
+/// full-text predicate the non-semantic `search` branch uses) and `None` for
+/// `list`. `semantic` is the `search --semantic` flag (always `false` for
+/// `list`); when set, the hint is suppressed per the first bullet above.
 pub(crate) fn hidden_private_hint(
     db: &dyn store::KnowledgeStore,
     ctx: &store::AgentContext,
     filter: &EntryFilter,
     query: Option<&str>,
+    semantic: bool,
 ) -> Option<String> {
+    // Semantic search matches by vector similarity, but the count query below
+    // uses the BM25 `@@` text predicate — the two do not agree. Rather than emit
+    // a hint that could over- or under-count relative to what `--include-private
+    // --semantic` would actually show, gate it off. (Counting with the semantic
+    // predicate would also be heavier and top-N-dependent.)
+    if semantic {
+        return None;
+    }
+
     // Trigger only in the default (public-only) view AND when there is a
     // calling agent whose private entries could exist. `--include-private` and
     // `--mine` both resolve to `include_private = true`, so they no-op here;
@@ -252,8 +272,9 @@ pub(crate) fn warn_hidden_private(
     ctx: &store::AgentContext,
     filter: &EntryFilter,
     query: Option<&str>,
+    semantic: bool,
 ) {
-    if let Some(msg) = hidden_private_hint(db, ctx, filter, query) {
+    if let Some(msg) = hidden_private_hint(db, ctx, filter, query, semantic) {
         eprintln!("{msg}");
     }
 }
@@ -1684,7 +1705,7 @@ mod hidden_private_hint_tests {
 
         // Default view for a known agent: public-only ctx, agent_id set.
         let ctx = AgentContext::public_for_agent("agent-a");
-        let msg = hidden_private_hint(&db, &ctx, &base_filter(), None)
+        let msg = hidden_private_hint(&db, &ctx, &base_filter(), None, false)
             .expect("hint should fire for a hidden owned-private match");
 
         assert!(msg.contains("1 private entry of yours"), "msg: {msg}");
@@ -1701,7 +1722,7 @@ mod hidden_private_hint_tests {
             .unwrap();
 
         let ctx = AgentContext::public_for_agent("agent-a");
-        let msg = hidden_private_hint(&db, &ctx, &base_filter(), None).unwrap();
+        let msg = hidden_private_hint(&db, &ctx, &base_filter(), None, false).unwrap();
 
         assert!(msg.contains("2 private entries of yours"), "msg: {msg}");
         assert!(msg.contains("are hidden"), "msg: {msg}");
@@ -1720,9 +1741,35 @@ mod hidden_private_hint_tests {
         .unwrap();
 
         let ctx = AgentContext::public_for_agent("agent-a");
-        let msg = hidden_private_hint(&db, &ctx, &base_filter(), Some("widget"))
+        let msg = hidden_private_hint(&db, &ctx, &base_filter(), Some("widget"), false)
             .expect("search hint should fire when an owned-private entry matches the query");
         assert!(msg.contains("1 private entry of yours"), "msg: {msg}");
+    }
+
+    #[test]
+    fn hint_absent_under_semantic_mode() {
+        // W1: `search --semantic` matches by vector similarity, but the hint's
+        // count query uses the BM25 `@@` predicate. The two do not agree, so the
+        // hint must be gated OFF under semantic mode — even when a literal `@@`
+        // match exists (as it does here: same fixture as the firing text-search
+        // case above), the semantic flag suppresses the hint entirely.
+        let db = SurrealDatabase::open_in_memory().unwrap();
+        db.upsert_knowledge(&priv_entry(
+            "kn-a",
+            "agent-a",
+            "unique searchable widget",
+            "unique searchable widget content",
+            vec![],
+        ))
+        .unwrap();
+
+        let ctx = AgentContext::public_for_agent("agent-a");
+        // Same query that fires the hint in non-semantic mode; only `semantic`
+        // differs. Proves the suppression is driven by the flag, not the data.
+        assert!(
+            hidden_private_hint(&db, &ctx, &base_filter(), Some("widget"), true).is_none(),
+            "the hint must not fire under --semantic: BM25 count != vector match"
+        );
     }
 
     #[test]
@@ -1739,7 +1786,7 @@ mod hidden_private_hint_tests {
 
         let ctx = AgentContext::public_for_agent("agent-a");
         assert!(
-            hidden_private_hint(&db, &ctx, &base_filter(), Some("widget")).is_none(),
+            hidden_private_hint(&db, &ctx, &base_filter(), Some("widget"), false).is_none(),
             "no hint when the owned-private entry doesn't match the search terms"
         );
     }
@@ -1753,7 +1800,7 @@ mod hidden_private_hint_tests {
 
         let ctx = AgentContext::for_agent("agent-a");
         assert!(
-            hidden_private_hint(&db, &ctx, &base_filter(), None).is_none(),
+            hidden_private_hint(&db, &ctx, &base_filter(), None, false).is_none(),
             "--include-private already shows private entries -> no hint"
         );
     }
@@ -1767,7 +1814,7 @@ mod hidden_private_hint_tests {
 
         let ctx = AgentContext::public_only();
         assert!(
-            hidden_private_hint(&db, &ctx, &base_filter(), None).is_none(),
+            hidden_private_hint(&db, &ctx, &base_filter(), None, false).is_none(),
             "no calling agent -> nothing owned to hide -> no hint"
         );
     }
@@ -1781,7 +1828,7 @@ mod hidden_private_hint_tests {
 
         let ctx = AgentContext::public_for_agent("agent-a");
         assert!(
-            hidden_private_hint(&db, &ctx, &base_filter(), None).is_none(),
+            hidden_private_hint(&db, &ctx, &base_filter(), None, false).is_none(),
             "caller has no owned-private matches (and must never count agent-b's) -> no hint"
         );
     }
@@ -1804,7 +1851,7 @@ mod hidden_private_hint_tests {
         let mut f = base_filter();
         f.tags = Some(vec!["nonmatch".to_string()]);
         assert!(
-            hidden_private_hint(&db, &ctx, &f, None).is_none(),
+            hidden_private_hint(&db, &ctx, &f, None, false).is_none(),
             "tag filter must apply to the hint count exactly as to the main query"
         );
 
@@ -1812,7 +1859,7 @@ mod hidden_private_hint_tests {
         let mut f2 = base_filter();
         f2.tags = Some(vec!["focus".to_string()]);
         assert!(
-            hidden_private_hint(&db, &ctx, &f2, None).is_some(),
+            hidden_private_hint(&db, &ctx, &f2, None, false).is_some(),
             "a matching tag filter must still surface the hidden owned-private entry"
         );
     }
@@ -1836,7 +1883,7 @@ mod hidden_private_hint_tests {
         let ctx = AgentContext::public_for_agent("agent-a");
         let mut f = base_filter();
         f.limit = Some(1);
-        let msg = hidden_private_hint(&db, &ctx, &f, None).unwrap();
+        let msg = hidden_private_hint(&db, &ctx, &f, None, false).unwrap();
         assert!(
             msg.contains("3 private entries of yours"),
             "hint counts all hidden matches regardless of --limit; msg: {msg}"

--- a/src/store.rs
+++ b/src/store.rs
@@ -176,6 +176,30 @@ pub trait KnowledgeStore {
         filter: &KnowledgeFilter,
     ) -> Result<usize>;
 
+    /// Fetch the caller's OWN private entries (`visibility = 'private' AND
+    /// owner = agent`) that match the same category / resonance / (optional)
+    /// full-text search filters as a `list`/`search` query, using the SAME
+    /// decayed effective-resonance semantics as those commands (Issue #400).
+    ///
+    /// Strictly scoped to the caller's own private rows — it must NEVER return
+    /// another agent's private entries (see the visibility-bypass pipe-dream
+    /// kn-a5f8a209). It exists solely to power the "N private entries of yours
+    /// matched but are hidden" stderr hint that `list`/`search` emit when the
+    /// public-only default would otherwise silently drop the caller's matches.
+    ///
+    /// Callers apply the remaining in-memory filters (tags, field presence) to
+    /// the returned entries — via the same `apply_entry_filters` the main query
+    /// uses — so the resulting count matches the main query exactly.
+    ///
+    /// `query`: `Some(terms)` runs the same BM25 `@@` full-text match `search`
+    /// uses; `None` (for `list`) omits the text predicate.
+    fn owned_private_matching(
+        &self,
+        agent: &str,
+        query: Option<&str>,
+        filter: &KnowledgeFilter,
+    ) -> Result<Vec<KnowledgeEntry>>;
+
     /// List all entries
     fn list_all(&self, ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>>;
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -191,8 +191,11 @@ pub trait KnowledgeStore {
     /// the returned entries — via the same `apply_entry_filters` the main query
     /// uses — so the resulting count matches the main query exactly.
     ///
-    /// `query`: `Some(terms)` runs the same BM25 `@@` full-text match `search`
-    /// uses; `None` (for `list`) omits the text predicate.
+    /// `query`: `Some(terms)` runs the same BM25 `@@` full-text match that
+    /// `search`'s TEXT (non-`--semantic`) branch uses; `None` (for `list`) omits
+    /// the text predicate. This method is intentionally text-only: it does NOT
+    /// model vector similarity, so the hint it powers is suppressed under
+    /// `--semantic` (see `hidden_private_hint`) rather than counted here.
     fn owned_private_matching(
         &self,
         agent: &str,

--- a/src/surreal_db/connection.rs
+++ b/src/surreal_db/connection.rs
@@ -188,16 +188,22 @@ fn is_retryable_conflict(err: &surrealdb::Error) -> bool {
 }
 
 /// Backoff before the next schema-application retry. Capped exponential growth
-/// (`~20ms · 2^(attempt-1)`, ceilinged at 320ms) plus wall-clock jitter, so that
-/// processes retrying in lockstep desynchronize instead of colliding again on
-/// the same tick. Only ever runs on a contended init, never on the happy path.
+/// (`~20ms · 2^(attempt-1)`, ceilinged at 320ms) plus jitter, so that processes
+/// retrying in lockstep desynchronize instead of colliding again on the same
+/// tick. Only ever runs on a contended init, never on the happy path.
+///
+/// The jitter seed folds in `process::id()` alongside the wall clock: on a
+/// coarse-resolution clock, lockstep peers on the same attempt would otherwise
+/// read a near-identical `subsec_nanos` and draw the same jitter, re-colliding.
+/// Per-process entropy breaks that tie even when the clock does not.
 fn schema_retry_backoff(attempt: u32) -> std::time::Duration {
     let base_ms = 20u64.saturating_mul(1u64 << attempt.min(5).saturating_sub(1));
     let base_ms = base_ms.min(320);
-    let jitter_ms = std::time::SystemTime::now()
+    let clock_nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| (d.subsec_nanos() as u64) % 40)
+        .map(|d| d.subsec_nanos() as u64)
         .unwrap_or(0);
+    let jitter_ms = (clock_nanos ^ u64::from(std::process::id())) % 40;
     std::time::Duration::from_millis(base_ms + jitter_ms)
 }
 

--- a/src/surreal_db/connection.rs
+++ b/src/surreal_db/connection.rs
@@ -178,6 +178,29 @@ pub enum SurrealConnection {
 /// Embedded SurrealDB schema - applied on database open
 const SCHEMA: &str = include_str!("../../schema/surrealdb-schema.surql");
 
+/// True when a per-statement SurrealDB error is a transient, retryable
+/// transaction conflict (SurrealDB's optimistic-concurrency "read or write
+/// conflict … can be retried"). Matched on the message text because these
+/// arrive as opaque `Api(Query(..))` errors with no dedicated variant.
+fn is_retryable_conflict(err: &surrealdb::Error) -> bool {
+    let msg = err.to_string();
+    msg.contains("read or write conflict") || msg.contains("can be retried")
+}
+
+/// Backoff before the next schema-application retry. Capped exponential growth
+/// (`~20ms · 2^(attempt-1)`, ceilinged at 320ms) plus wall-clock jitter, so that
+/// processes retrying in lockstep desynchronize instead of colliding again on
+/// the same tick. Only ever runs on a contended init, never on the happy path.
+fn schema_retry_backoff(attempt: u32) -> std::time::Duration {
+    let base_ms = 20u64.saturating_mul(1u64 << attempt.min(5).saturating_sub(1));
+    let base_ms = base_ms.min(320);
+    let jitter_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| (d.subsec_nanos() as u64) % 40)
+        .unwrap_or(0);
+    std::time::Duration::from_millis(base_ms + jitter_ms)
+}
+
 /// Normalize datetime string to RFC3339 format for SurrealDB
 pub(super) fn normalize_datetime(s: &str) -> String {
     // If already looks like RFC3339 (has T and timezone), return as-is
@@ -628,18 +651,45 @@ impl SurrealDatabase {
             eprintln!("[mx] Applying database schema");
         }
 
-        let mut response = with_db!(self, db, {
-            db.query(SCHEMA)
-                .await
-                .context("Failed to apply database schema")?
-        });
+        // Under concurrent embedded-DB initialization (e.g. several `mx`
+        // processes each opening a fresh store at once — the integration-test
+        // hot path), SurrealDB's optimistic concurrency can reject a schema
+        // statement with a transient "read or write conflict … can be retried"
+        // error. Because every SCHEMA statement is `IF NOT EXISTS` (idempotent),
+        // re-running the whole batch is safe, so we retry a bounded number of
+        // times on a purely-retryable failure with jittered backoff before
+        // surfacing the error. A conflict that never clears — or any
+        // non-retryable error — still fails fast.
+        const MAX_SCHEMA_ATTEMPTS: u32 = 12;
+        let mut attempt: u32 = 0;
+        loop {
+            attempt += 1;
 
-        let errors = response.take_errors();
-        if !errors.is_empty() {
+            let mut response = with_db!(self, db, {
+                db.query(SCHEMA)
+                    .await
+                    .context("Failed to apply database schema")?
+            });
+
+            let errors = response.take_errors();
+            if errors.is_empty() {
+                return Ok(());
+            }
+
+            let all_retryable = errors.values().all(is_retryable_conflict);
+            if all_retryable && attempt < MAX_SCHEMA_ATTEMPTS {
+                if verbose {
+                    eprintln!(
+                        "[mx] Schema application hit a retryable conflict \
+                         (attempt {attempt}/{MAX_SCHEMA_ATTEMPTS}); retrying"
+                    );
+                }
+                tokio::time::sleep(schema_retry_backoff(attempt)).await;
+                continue;
+            }
+
             return Err(anyhow::anyhow!("Schema application failed: {:?}", errors));
         }
-
-        Ok(())
     }
 
     /// Explicitly apply the database schema, ignoring `MX_SKIP_SCHEMA`.

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1528,6 +1528,72 @@ impl SurrealDatabase {
         Ok(entries)
     }
 
+    /// Fetch the caller's OWN private entries matching the same category /
+    /// resonance / (optional) full-text filters as list/search (Issue #400).
+    /// See the trait doc on `KnowledgeStore::owned_private_matching`.
+    pub fn owned_private_matching(
+        &self,
+        agent: &str,
+        query: Option<&str>,
+        filter: &crate::store::KnowledgeFilter,
+    ) -> Result<Vec<KnowledgeEntry>> {
+        Self::runtime().block_on(self.owned_private_matching_async(agent, query, filter))
+    }
+
+    async fn owned_private_matching_async(
+        &self,
+        agent: &str,
+        query: Option<&str>,
+        filter: &crate::store::KnowledgeFilter,
+    ) -> Result<Vec<KnowledgeEntry>> {
+        // Reuse the SAME clause builders the main list/search queries use so the
+        // hint count stays consistent with what those commands would display
+        // (kn-e8d7eff2): effective/decayed resonance via build_resonance_filter,
+        // category matching via build_category_filter.
+        let resonance_clause = Self::build_resonance_filter(filter);
+        let category_clause = Self::build_category_filter(filter);
+
+        // Visibility is FIXED to the caller's own private rows. We deliberately
+        // do NOT call build_visibility_filter here: that helper also admits
+        // public rows, but this query must count ONLY owned-private matches (the
+        // rows the public-only default hides) and must NEVER touch another
+        // agent's private entries (visibility-bypass pipe-dream kn-a5f8a209).
+        // $current_agent is a bound parameter, never interpolated.
+        let search_clause = if query.is_some() {
+            "AND (title @@ $query OR body @@ $query OR summary @@ $query)"
+        } else {
+            ""
+        };
+
+        let sql = format!(
+            "SELECT {}
+            FROM knowledge
+            WHERE visibility = 'private' AND owner = $current_agent {} {} {}
+            ORDER BY id",
+            Self::knowledge_select_fields(),
+            search_clause,
+            resonance_clause,
+            category_clause
+        );
+
+        let mut response = with_db!(self, db, {
+            let mut q = db.query(&sql).bind(("current_agent", agent.to_string()));
+            if let Some(query_str) = query {
+                q = q.bind(("query", query_str.to_string()));
+            }
+            q.await
+                .context("Failed to query owned private matches (Issue #400 hint)")
+        })?;
+
+        let results: Vec<serde_json::Value> = response.take(0)?;
+        let mut entries = Vec::new();
+        for obj in results {
+            entries.push(self.value_to_knowledge_entry(obj).await?);
+        }
+
+        Ok(entries)
+    }
+
     // =========================================================================
     // WAKE SESSION OPERATIONS
     // =========================================================================

--- a/src/surreal_db/queries.rs
+++ b/src/surreal_db/queries.rs
@@ -1565,6 +1565,17 @@ impl SurrealDatabase {
             ""
         };
 
+        // S1 — accepted cost: this SELECTs and hydrates FULL `KnowledgeEntry`
+        // rows (body + per-row tag/applicability follow-ups in
+        // `value_to_knowledge_entry`), not a bare COUNT, and it runs on every
+        // default `list`/`search` when a calling agent is set. Full hydration is
+        // REQUIRED, not incidental: the hint count must match the main query
+        // exactly, and the caller re-applies `apply_entry_filters` (tags + field
+        // presence — e.g. has_anchors, has_wake_phrase) to these rows. Those
+        // predicates read fields a COUNT could not project, so a COUNT here would
+        // over-count relative to what the main query actually displays. The rows
+        // are the caller's own private entries only (bounded, single query), so
+        // the cost is bounded and deemed acceptable versus correctness.
         let sql = format!(
             "SELECT {}
             FROM knowledge

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -920,6 +920,157 @@ fn test_update_summary_cross_agent_visibility_blocked() {
         "Summary should be unchanged after failed cross-agent update"
     );
 }
+// =========================================================================
+// OWNED-PRIVATE MATCHING (Issue #400)
+//
+// `owned_private_matching` powers the "N private entries of yours are hidden"
+// stderr hint on list/search. It must return ONLY the caller's own private
+// rows (never public, never another agent's private) while honoring the same
+// category / effective-resonance / full-text filters the main query uses.
+// =========================================================================
+
+#[test]
+fn test_owned_private_matching_scopes_to_caller_only() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Caller's own private entry -> must be returned.
+    let mut mine = make_test_entry("kn-mine-priv", 5, 0.0);
+    mine.visibility = "private".to_string();
+    mine.owner = Some("agent-a".to_string());
+    db.upsert_knowledge(&mine).unwrap();
+
+    // Another agent's private entry -> must NEVER be returned (kn-a5f8a209).
+    let mut theirs = make_test_entry("kn-their-priv", 5, 0.0);
+    theirs.visibility = "private".to_string();
+    theirs.owner = Some("agent-b".to_string());
+    db.upsert_knowledge(&theirs).unwrap();
+
+    // A public entry -> not owned-private, must not be returned.
+    let public = make_test_entry("kn-pub", 5, 0.0);
+    db.upsert_knowledge(&public).unwrap();
+
+    let filter = crate::store::KnowledgeFilter::default();
+    let got = db.owned_private_matching("agent-a", None, &filter).unwrap();
+
+    let ids: Vec<&str> = got.iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["kn-mine-priv"],
+        "must return only the caller's OWN private entries — never public, \
+         never another agent's private rows"
+    );
+}
+
+#[test]
+fn test_owned_private_matching_empty_when_none_private() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Only public entries exist for this agent.
+    let public = make_test_entry("kn-only-pub", 5, 0.0);
+    db.upsert_knowledge(&public).unwrap();
+
+    let filter = crate::store::KnowledgeFilter::default();
+    let got = db.owned_private_matching("agent-a", None, &filter).unwrap();
+    assert!(
+        got.is_empty(),
+        "no owned-private entries -> empty result (hint will be suppressed)"
+    );
+}
+
+#[test]
+fn test_owned_private_matching_honors_category_filter() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Two owned-private entries in different categories.
+    let mut in_cat = make_test_entry("kn-priv-decision", 5, 0.0);
+    in_cat.visibility = "private".to_string();
+    in_cat.owner = Some("agent-a".to_string());
+    in_cat.category_id = "decision".to_string();
+    db.upsert_knowledge(&in_cat).unwrap();
+
+    let mut other_cat = make_test_entry("kn-priv-test", 5, 0.0);
+    other_cat.visibility = "private".to_string();
+    other_cat.owner = Some("agent-a".to_string());
+    other_cat.category_id = "test".to_string();
+    db.upsert_knowledge(&other_cat).unwrap();
+
+    let filter = crate::store::KnowledgeFilter {
+        categories: Some(vec!["decision".to_string()]),
+        ..Default::default()
+    };
+    let got = db.owned_private_matching("agent-a", None, &filter).unwrap();
+    let ids: Vec<&str> = got.iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["kn-priv-decision"],
+        "category filter must match the main query's category scoping"
+    );
+}
+
+#[test]
+fn test_owned_private_matching_honors_search_terms() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // Matching owned-private entry.
+    let mut hit = make_test_entry("kn-priv-widget", 5, 0.0);
+    hit.visibility = "private".to_string();
+    hit.owner = Some("agent-a".to_string());
+    hit.title = "unique searchable widget".to_string();
+    hit.body = Some("unique searchable widget content".to_string());
+    db.upsert_knowledge(&hit).unwrap();
+
+    // Non-matching owned-private entry (different terms).
+    let mut miss = make_test_entry("kn-priv-sprocket", 5, 0.0);
+    miss.visibility = "private".to_string();
+    miss.owner = Some("agent-a".to_string());
+    miss.title = "unrelated sprocket".to_string();
+    miss.body = Some("unrelated sprocket content".to_string());
+    db.upsert_knowledge(&miss).unwrap();
+
+    let filter = crate::store::KnowledgeFilter::default();
+    let got = db
+        .owned_private_matching("agent-a", Some("widget"), &filter)
+        .unwrap();
+    let ids: Vec<&str> = got.iter().map(|e| e.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["kn-priv-widget"],
+        "search-term (@@) filter must exclude owned-private entries that don't \
+         match the query"
+    );
+}
+
+#[test]
+fn test_owned_private_matching_honors_effective_resonance() {
+    let db = SurrealDatabase::open_in_memory().unwrap();
+
+    // An owned-private entry with LOW raw resonance and an old activation so
+    // its effective (decayed) resonance is well below the threshold. Uses the
+    // SAME effective_resonance_expr as list/search, so a min_resonance filter
+    // must exclude it — matching what the main query would display.
+    let mut faded = make_test_entry("kn-priv-faded", 2, 0.0);
+    faded.visibility = "private".to_string();
+    faded.owner = Some("agent-a".to_string());
+    faded.resonance_type = Some("ephemeral".to_string());
+    // Activated ~1 year ago: with base 0.90 on resonance<=3, effective ~= 0.
+    faded.last_activated = Some(
+        (chrono::Utc::now() - chrono::Duration::days(365)).to_rfc3339(),
+    );
+    faded.created_at = faded.last_activated.clone();
+    db.upsert_knowledge(&faded).unwrap();
+
+    let filter = crate::store::KnowledgeFilter {
+        min_resonance: Some(3),
+        ..Default::default()
+    };
+    let got = db.owned_private_matching("agent-a", None, &filter).unwrap();
+    assert!(
+        got.is_empty(),
+        "an owned-private entry whose EFFECTIVE (decayed) resonance is below \
+         min_resonance must be excluded, like list/search"
+    );
+}
+
 #[test]
 fn test_reinforce_basic() {
     // Test basic reinforcement functionality

--- a/src/surreal_db/tests.rs
+++ b/src/surreal_db/tests.rs
@@ -1053,9 +1053,7 @@ fn test_owned_private_matching_honors_effective_resonance() {
     faded.owner = Some("agent-a".to_string());
     faded.resonance_type = Some("ephemeral".to_string());
     // Activated ~1 year ago: with base 0.90 on resonance<=3, effective ~= 0.
-    faded.last_activated = Some(
-        (chrono::Utc::now() - chrono::Duration::days(365)).to_rfc3339(),
-    );
+    faded.last_activated = Some((chrono::Utc::now() - chrono::Duration::days(365)).to_rfc3339());
     faded.created_at = faded.last_activated.clone();
     db.upsert_knowledge(&faded).unwrap();
 

--- a/src/surreal_db/trait_impl.rs
+++ b/src/surreal_db/trait_impl.rs
@@ -83,6 +83,15 @@ impl KnowledgeStore for SurrealDatabase {
         self.count_by_category(category, ctx, filter)
     }
 
+    fn owned_private_matching(
+        &self,
+        agent: &str,
+        query: Option<&str>,
+        filter: &crate::store::KnowledgeFilter,
+    ) -> Result<Vec<KnowledgeEntry>> {
+        self.owned_private_matching(agent, query, filter)
+    }
+
     fn list_all(&self, ctx: &crate::store::AgentContext) -> Result<Vec<KnowledgeEntry>> {
         self.list_all(ctx)
     }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1393,6 +1393,14 @@ mod tests {
             ) -> Result<usize> {
                 unreachable!()
             }
+            fn owned_private_matching(
+                &self,
+                _agent: &str,
+                _query: Option<&str>,
+                _filter: &KnowledgeFilter,
+            ) -> Result<Vec<KnowledgeEntry>> {
+                unreachable!()
+            }
             fn list_all(&self, _ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>> {
                 unreachable!()
             }

--- a/src/wake_ritual.rs
+++ b/src/wake_ritual.rs
@@ -1399,6 +1399,10 @@ mod tests {
                 _query: Option<&str>,
                 _filter: &KnowledgeFilter,
             ) -> Result<Vec<KnowledgeEntry>> {
+                // N2: unreachable here by design — this hint query (Issue #400) is
+                // only ever invoked from the List/Search handlers, never from the
+                // wake ritual this MockStore exercises. The hint-count behavior is
+                // covered by the SurrealDatabase-backed tests in helpers.rs.
                 unreachable!()
             }
             fn list_all(&self, _ctx: &AgentContext) -> Result<Vec<KnowledgeEntry>> {

--- a/tests/hidden_private_hint_cli.rs
+++ b/tests/hidden_private_hint_cli.rs
@@ -30,10 +30,16 @@ use tempfile::TempDir;
 const MX: &str = env!("CARGO_BIN_EXE_mx");
 
 /// Run `mx` as `agent-a` against an isolated surreal root in `dir`.
+///
+/// `MX_SURREAL_MODE=embedded` is forced so an ambient `MX_SURREAL_MODE=network`
+/// in the developer's shell cannot silently redirect the binary at a shared
+/// network DB — that masking is exactly what let a bogus (non-seeded) category
+/// pass locally while CI, running embedded against the isolated root, went red.
 fn mx(dir: &TempDir, args: &[&str]) -> std::process::Output {
     let mut cmd = Command::new(MX);
     cmd.args(args)
         .env("MX_CURRENT_AGENT", "agent-a")
+        .env("MX_SURREAL_MODE", "embedded")
         .env("MX_SURREAL_ROOT", dir.path().join("surreal"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -59,16 +65,20 @@ const HINT_FLAG: &str = "--include-private";
 fn hint_reaches_stderr_only_and_never_stdout() {
     let dir = TempDir::new().unwrap();
 
-    // `discovery` is one of the default categories seeded on schema application,
-    // so no `categories add` is needed (it would fail "already exists"). Seed a
-    // single OWNED-PRIVATE entry for agent-a that the public-only default hides.
+    // `insight` is one of the categories seeded on schema application
+    // (schema/surrealdb-schema.surql: bloom, decision, gotcha, insight, pattern,
+    // reference, session, technique — validated at handlers/memory.rs). No
+    // `categories add` is needed. NOTE: do NOT use the Wonka CLAUDE.md taxonomy
+    // (discovery, recipe, method, ...) here — those are NOT mx categories and the
+    // add would exit non-zero against a genuinely isolated store. Seed a single
+    // OWNED-PRIVATE entry for agent-a that the public-only default hides.
     let add = mx(
         &dir,
         &[
             "memory",
             "add",
             "--category",
-            "discovery",
+            "insight",
             "--title",
             "unique searchable widget",
             "--content",

--- a/tests/hidden_private_hint_cli.rs
+++ b/tests/hidden_private_hint_cli.rs
@@ -1,0 +1,149 @@
+//! CLI-level integration test for the Issue #400 "hidden private entries"
+//! hint on `mx memory list` / `mx memory search`.
+//!
+//! This drives the real binary (`CARGO_BIN_EXE_mx`) against an isolated
+//! SurrealDB (`MX_SURREAL_ROOT`), so it never touches the developer's real
+//! store. Its whole purpose is the STDOUT/STDERR invariance (finding S2): the
+//! hint must reach STDERR only — never stdout, never `--json` — so a caller
+//! piping stdout into another program sees byte-identical output whether or not
+//! the hint fires.
+//!
+//! Design notes:
+//!   - Everything runs inside ONE `#[serial]` test against ONE seeded store.
+//!     Spinning up an embedded SurrealDB applies the full schema (DEFINE INDEX +
+//!     default-category seeding); doing that from several test processes at once
+//!     races SurrealDB's optimistic concurrency ("read or write conflict … can
+//!     be retried"). One store + `#[serial]` keeps the fresh-DB init off the hot
+//!     parallel path and keeps the wall-clock cost to a single init.
+//!   - The `--semantic` suppression (finding W1) is pinned deterministically at
+//!     the unit layer (`hidden_private_hint_tests::hint_absent_under_semantic_mode`
+//!     in src/helpers.rs) rather than here: the semantic path constructs a
+//!     `TractProvider`, which loads/downloads an ONNX embedding model — a
+//!     network- and model-cache-dependent side effect with no place in a
+//!     hermetic CLI test. That pure-function test proves the flag alone
+//!     suppresses the hint, which is exactly the contract W1 asked for.
+
+use serial_test::serial;
+use std::process::{Command, Stdio};
+use tempfile::TempDir;
+
+const MX: &str = env!("CARGO_BIN_EXE_mx");
+
+/// Run `mx` as `agent-a` against an isolated surreal root in `dir`.
+fn mx(dir: &TempDir, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(MX);
+    cmd.args(args)
+        .env("MX_CURRENT_AGENT", "agent-a")
+        .env("MX_SURREAL_ROOT", dir.path().join("surreal"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn mx");
+    drop(child.stdin.take());
+    child.wait_with_output().expect("failed to wait on mx")
+}
+
+fn stdout_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+fn stderr_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+const HINT_MARK: &str = "private entry of yours";
+const HINT_FLAG: &str = "--include-private";
+
+#[test]
+#[serial]
+fn hint_reaches_stderr_only_and_never_stdout() {
+    let dir = TempDir::new().unwrap();
+
+    // `discovery` is one of the default categories seeded on schema application,
+    // so no `categories add` is needed (it would fail "already exists"). Seed a
+    // single OWNED-PRIVATE entry for agent-a that the public-only default hides.
+    let add = mx(
+        &dir,
+        &[
+            "memory",
+            "add",
+            "--category",
+            "discovery",
+            "--title",
+            "unique searchable widget",
+            "--content",
+            "unique searchable widget body",
+            "--private",
+        ],
+    );
+    assert!(
+        add.status.success(),
+        "private add must succeed; stderr: {}",
+        stderr_of(&add)
+    );
+
+    // 1) Default `list`: the owned-private entry is hidden from the main output,
+    //    so the hint nudges on STDERR and must NOT appear on STDOUT.
+    let out = mx(&dir, &["memory", "list"]);
+    assert!(
+        out.status.success(),
+        "list must succeed; stderr: {}",
+        stderr_of(&out)
+    );
+    let (so, se) = (stdout_of(&out), stderr_of(&out));
+    assert!(
+        se.contains(HINT_MARK) && se.contains(HINT_FLAG),
+        "list hint must appear on STDERR; stderr was: {se:?}"
+    );
+    assert!(
+        !so.contains(HINT_MARK) && !so.contains(HINT_FLAG),
+        "list hint must NEVER touch STDOUT; stdout was: {so:?}"
+    );
+
+    // 2) Text `search` matching the entry: same invariance.
+    let out = mx(&dir, &["memory", "search", "widget"]);
+    assert!(
+        out.status.success(),
+        "search must succeed; stderr: {}",
+        stderr_of(&out)
+    );
+    let (so, se) = (stdout_of(&out), stderr_of(&out));
+    assert!(
+        se.contains(HINT_MARK) && se.contains(HINT_FLAG),
+        "search hint must appear on STDERR; stderr was: {se:?}"
+    );
+    assert!(
+        !so.contains(HINT_MARK) && !so.contains(HINT_FLAG),
+        "search hint must NEVER touch STDOUT; stdout was: {so:?}"
+    );
+
+    // 3) `list --json`: stdout must stay valid, hint-free JSON (a consumer piping
+    //    stdout must not choke on a stray note line).
+    let out = mx(&dir, &["memory", "list", "--json"]);
+    assert!(
+        out.status.success(),
+        "list --json must succeed; stderr: {}",
+        stderr_of(&out)
+    );
+    let so = stdout_of(&out);
+    assert!(
+        !so.contains(HINT_MARK) && !so.contains(HINT_FLAG),
+        "the hint must not appear in --json stdout; stdout was: {so:?}"
+    );
+    serde_json::from_str::<serde_json::Value>(so.trim())
+        .expect("list --json stdout must be valid JSON even when the hint fires on stderr");
+
+    // 4) `--include-private`: the entry is already shown, so the hint must NOT
+    //    fire on either stream (it would be redundant and misleading).
+    let out = mx(&dir, &["memory", "list", "--include-private"]);
+    assert!(out.status.success(), "list --include-private must succeed");
+    let (so, se) = (stdout_of(&out), stderr_of(&out));
+    assert!(
+        so.contains("unique searchable widget"),
+        "the private entry must be visible with --include-private; stdout: {so:?}"
+    );
+    assert!(
+        !se.contains(HINT_MARK) && !so.contains(HINT_MARK),
+        "no hint when --include-private already reveals the entry; stdout: {so:?} stderr: {se:?}"
+    );
+}


### PR DESCRIPTION
Closes #400

## Summary

Implements **option (a)** from #400, per the Savorist's decision: `list` and `search` run public-only by default and silently drop the caller's *own* private matches (an ~85% undercount versus `wake`, which includes them). Rather than change the default visibility, we now emit a **best-effort hint on stderr** when the caller's own private matches are being hidden.

- Zero change to `stdout`, `--json` output, or exit codes — the hint is **stderr only**.
- Default visibility is **unchanged** (public-only stays the default).
- Option (b) — changing the default to include private — was **explicitly rejected**.
- The hint fires only when the context is public-only *and* an agent is set. `--include-private` and `--mine` both resolve to `include_private=true` and silence the hint.

Also documents the **raw-vs-decayed `--min-resonance` divergence** in the CLI help text: `wake` filters on **raw** stored resonance, while `list`/`search` filter on **decayed effective** resonance. This is a documentation-only clarification pending #404's explicit `--resonance-basis` flag.

## Files affected

- `src/store.rs` — new trait method `owned_private_matching`.
- `src/surreal_db/queries.rs` — implementation; reuses `build_resonance_filter` / `build_category_filter` with an owner-scoped bound param (deliberately does not use `build_visibility_filter`, which would also admit public rows).
- `src/surreal_db/trait_impl.rs` — delegation.
- `src/wake_ritual.rs` — `MockStore` stub.
- `src/helpers.rs` — `hidden_private_hint` (pure, returns `Option<String>`) + `warn_hidden_private` (stderr wrapper).
- `src/handlers/memory.rs` — `List`/`Search` arms call the hint after stdout printing.
- `src/cli.rs` — `--min-resonance` help text (raw-vs-decayed note).
- `CHANGELOG.md` — new entry.

## Test results

- `cargo build` — clean
- `cargo clippy --all-targets` — clean
- `cargo test` — **1174 lib passed + integration suites / 0 failed** (16 new tests: 5 store-level, 11 hint-level; plus new integration suite `tests/hidden_private_hint_cli.rs`)
- E2E verified: hint appears on **stderr only**; `--include-private` silences it.

## Review fixes

Addressing the review before merge:

- **W1 — semantic-mode hint suppression.** The hidden-private hint is now gated off under `--semantic`: semantic ranking does not run the owner-scoped count path, so the hint could misreport. Docstrings re-scoped to text search accordingly.
- **S1 — hydration-cost comment.** Added a comment documenting the hydration cost of the count query so future readers understand why it stays best-effort.
- **S2 — stderr/stdout CLI integration test.** New integration test asserts the hint lands on **stderr** and never contaminates **stdout** (`tests/hidden_private_hint_cli.rs`).
- **N2 — MockStore unreachable comment.** Clarifying comment on the `MockStore` stub explaining why the branch is unreachable in the mock.

## Bonus fix

`src/surreal_db/connection.rs` — `apply_schema` now retries transient *"read or write conflict"* errors from concurrent embedded-SurrealDB schema init, using bounded jittered backoff. All schema statements are `IF NOT EXISTS`, so retries are idempotent and the happy path is untouched. This was a pre-existing flake surfaced by the new integration test running schema init concurrently.

## Note

The count query is **best-effort** — any error is swallowed and never affects the exit code or stdout.
